### PR TITLE
Use the old repo name in URLs for CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-[![Cirrus CI FreeBSD 11 Build Status](https://api.cirrus-ci.com/github/lsof-org/lsof.svg?task=freebsd11&branch=master)](https://cirrus-ci.com/github/lsof-org/lsof)
-[![Cirrus CI FreeBSD 12 Build Status](https://api.cirrus-ci.com/github/lsof-org/lsof.svg?task=freebsd12&branch=master)](https://cirrus-ci.com/github/lsof-org/lsof)
-[![Travis CI Linux Build Status](https://travis-ci.org/lsof-org/lsof.svg?branch=master)](https://travis-ci.org/lsof-org/lsof)
-[![Coveralls Linux Coverage Status on Travis CI](https://coveralls.io/repos/github/lsof-org/lsof/badge.svg?branch=master)](https://coveralls.io/github/lsof-org/lsof?branch=master)
+<!-- Use "lsof-legacy" here because of historical reason  -->
+[![Cirrus CI FreeBSD 11 Build Status](https://api.cirrus-ci.com/github/lsof-org/lsof-legacy.svg?task=freebsd11&branch=master)](https://cirrus-ci.com/github/lsof-org/lsof-legacy)
+[![Cirrus CI FreeBSD 12 Build Status](https://api.cirrus-ci.com/github/lsof-org/lsof-legacy.svg?task=freebsd12&branch=master)](https://cirrus-ci.com/github/lsof-org/lsof-legacy)
+[![Travis CI Linux Build Status](https://travis-ci.org/lsof-org/lsof-legacy.svg?branch=master)](https://travis-ci.org/lsof-org/lsof-legacy)
+[![Coveralls Linux Coverage Status on Travis CI](https://coveralls.io/repos/github/lsof-org/lsof-legacy/badge.svg?branch=master)](https://coveralls.io/github/lsof-org/lsof-legacy?branch=master)
 
 # lsof
 lsof-org at GitHub team takes over the maintainership of lsof


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>