### PR TITLE
test cases: include <sys/sysmaros.h> to compile tests/LTlib.c on newer GNU/Linux distributions

### DIFF
--- a/tests/LTlib.c
+++ b/tests/LTlib.c
@@ -188,6 +188,14 @@ static char copyright[] =
 #include <sys/mkdev.h>
 #endif	/* defined(LT_DIAL_uw) */
 
+#if	defined(LT_DIAL_linux)
+/*
+ * Linux-specific items
+ */
+
+#include <sys/sysmacros.h>
+#endif	/* defined(LT_DIAL_linux) */
+
 
 /*
  * Global variables


### PR DESCRIPTION
"major" is defined in sys/sysmacros.h of glibc.
sys/types.h included sys/sysmacros.h.
However, newer glibc shipped as part of Fedora29 removed the directive
for including sys/sysmacros.h from sys/types.h. As the result, we cannot
compile tests/LTlib.c on Feodra29 because of no major definition.

As instructed in sys/types.h, we will include sys/sysmacros.h directly
in this change.

The original issue is reported by @barsnick at #40.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>