### PR TITLE
Support POSIX message queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ LTunix
 #
 # Dialect specific test related files
 #
+dialects/linux/tests/mq_open
 dialects/linux/tests/open_with_flags
 dialects/linux/tests/pipe
 dialects/linux/tests/pty

--- a/00DIST
+++ b/00DIST
@@ -4982,5 +4982,11 @@ July 14, 2018
 		information with +|-E option. The option handles
 		INET sockets using IPC.
 
+		[linux] Added support for POSIX MQ of Linux
+		implementation.  A POSIX message queue (MQ) is
+		represented in a fd on Linux.  lsof reported it as a
+		regular file. lsof with this change reports it as a
+		file with PSXMQ type if mqueue file system is mounted.
+
 Masatake YAMATO <yamato@redhat.com>, a member of lsof-org
 May 8, 2019

--- a/Lsof.8
+++ b/Lsof.8
@@ -2722,6 +2722,8 @@ or ``PSTA'' for a
 .I /proc
 status file;
 .IP
+or ``PSXMQ'' for a POSIX message queue file;
+.IP
 or ``PSXSEM'' for a POSIX semaphore file;
 .IP
 or ``PSXSHM'' for a POSIX shared memory file;

--- a/dialects/linux/dlsof.h
+++ b/dialects/linux/dlsof.h
@@ -174,6 +174,7 @@ struct sfile {
 };
 
 extern int HasNFS;
+extern dev_t MqueueDev;
 extern int OffType;
 
 #endif	/* LINUX_LSOF_H	*/

--- a/dialects/linux/dmnt.c
+++ b/dialects/linux/dmnt.c
@@ -429,6 +429,7 @@ readmnt()
 	struct mounts *mp;
 	FILE *ms;
 	int nfs;
+	int mqueue;
 	struct stat sb;
 	static char *vbuf = (char *)NULL;
 	static size_t vsz = (size_t)0;
@@ -524,6 +525,12 @@ readmnt()
 	    if (*dn != '/')
 		continue;
 	    dnl = strlen(dn);
+
+	/*
+	 * Test Mqueue directory
+	 */
+	    mqueue = strcmp(fp[2], "mqueue");
+
 	/*
 	 * Test for duplicate and NFS directories.
 	 */
@@ -635,8 +642,12 @@ readmnt()
 		mp->ty = N_NFS;
 		if (HasNFS < 2)
 		    HasNFS = 2;
-	    } else
+	    } else if (!mqueue) {
+		mp->ty = N_MQUEUE;
+		MqueueDev = mp->dev;
+	    } else {
 		mp->ty = N_REGLR;
+	    }
 
 #if	defined(HASMNTSUP)
 	/*

--- a/dialects/linux/dnode.c
+++ b/dialects/linux/dnode.c
@@ -826,7 +826,10 @@ process_proc_node(p, pbr, s, ss, l, ls)
 		tn = "FIFO";
 		break;
 	    case S_IFREG:
-		tn = "REG";
+		if (Lf->dev == MqueueDev)
+		    tn = "PSXMQ";
+		else
+		    tn = "REG";
 		break;
 	    case S_IFLNK:
 		tn = "LINK";

--- a/dialects/linux/dstore.c
+++ b/dialects/linux/dstore.c
@@ -46,6 +46,8 @@ int HasNFS = 0;				/* NFS mount point status:
 					 *          and its device number is
 					 *          known
 					 */
+dev_t MqueueDev = -1;			/* The number for the device behind
+					 * mqueue mount point */
 int OffType = 0;			/* offset type:
 					 *     0 == unknown
 					 *     1 == lstat's st_size

--- a/dialects/linux/tests/Makefile
+++ b/dialects/linux/tests/Makefile
@@ -1,4 +1,5 @@
 HELPERS = \
+	mq_open \
 	pipe \
 	pty \
 	\
@@ -13,3 +14,12 @@ CFLAGS  = -g -Wall -std=c99
 all: $(HELPERS)
 clean:
 	rm -f $(HELPERS) *.o
+
+# See
+# https://stackoverflow.com/questions/19964206/weird-posix-message-queue-linking-issue-sometimes-it-doesnt-link-correctly
+#
+# We cannot use LDFLAGS here.
+# -lrt must be at the end of the command line.
+#
+mq_open: mq_open.o
+	$(CC) $(CFLAGS) -o $@ $< -lrt

--- a/dialects/linux/tests/case-10-mqueue.bash
+++ b/dialects/linux/tests/case-10-mqueue.bash
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+name=$(basename $0 .sh)
+lsof=$1
+report=$2
+tdir=$3
+
+MQUEUE_MNTPOINT=/tmp/$$
+
+TARGET=$tdir/mq_open
+if ! [ -x $TARGET ]; then
+    echo "target executable ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+if grep -q mqueue /proc/mounts; then
+    :
+elif ! [ $(id -u) = 0 ]; then
+    echo "root privileged is needed to run $(basename $0. sh)" >> $report
+    exit 2
+else
+    mkdir -p ${MQUEUE_MNTPOINT}
+    if ! mount -t mqueue none ${MQUEUE_MNTPOINT}; then
+	echo "failed to mount mqeueu file system"
+	exit 2
+    fi
+fi
+
+umount_mqueue()
+{
+    if [ -d ${MQUEUE_MNTPOINT} ]; then
+	umount ${MQUEUE_MNTPOINT}
+	rmdir ${MQUEUE_MNTPOINT}
+    fi
+}
+
+cleanup()
+{
+    local status=$1
+    local pid=$2
+
+    umount_mqueue
+    while kill -0 $pid 2> /dev/null; do
+	kill -CONT $pid
+	sleep 1
+    done
+    exit $status
+}
+
+$TARGET | {
+    if read label0 pid sep label1 fd; then
+	if line=`$lsof -p $pid -a -d $fd -Ft`; then
+	    if echo "$line" | grep -q PSXMQ; then
+		cleanup 0 $pid
+	    else
+		echo "unexpected output: $line" >> $report
+		cleanup 1 $pid
+	    fi
+	else
+	    echo "lsof rejects following command line: $lsof -p $pid -a -d $fd" >> $report
+	    cleanup 1 $pid
+	fi
+    else
+	echo "$TARGET prints an unexpected line: $label0 $pid $sep $label1 $fd" >> $report
+	umount_mqueue
+	case "$pid" in
+	    [0-9]*)
+		kill $pid
+		;;
+	esac
+	exit 1
+    fi
+}

--- a/dialects/linux/tests/mq_open.c
+++ b/dialects/linux/tests/mq_open.c
@@ -1,0 +1,31 @@
+#include <fcntl.h>           /* For O_* constants */
+#include <sys/stat.h>        /* For mode constants */
+#include <mqueue.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <signal.h>
+
+#define NAME "/xxx"
+
+static void
+do_nothing(int n)
+{
+  signal(SIGCONT, do_nothing);
+}
+
+int
+main(void)
+{
+  mqd_t t = mq_open(NAME, O_CREAT|O_RDWR, S_IRUSR|S_IWUSR, NULL);;
+  if ((mqd_t)t == -1)
+    {
+      perror("open[" NAME "]");
+      return 1;
+    }
+
+  printf("pid: %d / fd: %d\n", getpid(), t);
+  fflush(stdout);
+  signal(SIGCONT, do_nothing);
+  pause();
+  return 0;
+}

--- a/lsof.h
+++ b/lsof.h
@@ -389,6 +389,7 @@ static struct utmp dummy_utmp;		/* to get login name length */
 #define	N_VXFS		52		/* Veritas file system node */
 #define	N_XFS		53		/* XFS node */
 #define	N_ZFS		54		/* ZFS node */
+#define	N_MQUEUE	55		/* Posix mqueue node on Linux */
 
 # if	!defined(OFFDECDIG)
 #define	OFFDECDIG	8		/* maximum number of digits in the


### PR DESCRIPTION
A file descriptor is used for implementing a POSIX message queue on
Linux. lsof reports the file descriptor as a REGular file.

This change introduce "PSXMQ" as a new file type for the
file descriptor.

Currently implementation requires mqueue file system must be
mounted to resolve the file type. It is mounted at /dev/mqueue
by default on Fedora. It seems that the file system is not mounted
by default on Ubuntu.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>