### PR TITLE
support FreeBSD-current

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,17 +1,18 @@
-# freebsd13_task:
+#freebsd13_task:
 #   freebsd_instance:
-#     image: freebsd-13-0-current-amd64-v20190503
+#     image: freebsd-13-0-current-amd64-v20190517
 #   timeout_in: 120m
-#   install_script: pkg install -y gcc git bash
+#   install_script: pkg install -y git bash
 #   script:
-#     - ./Configure freebsd
+#     - ./Configure -n freebsd
 #     - make
+#     - bash ./check.bash freebsd
 
 freebsd12_task:
   freebsd_instance:
     image: freebsd-12-0-release-amd64
   timeout_in: 120m
-  install_script: pkg install -y gcc git bash
+  install_script: pkg install -y git bash
   script:
     - ./Configure -n freebsd
     - make
@@ -21,7 +22,7 @@ freebsd11_task:
   freebsd_instance:
     image: freebsd-11-2-release-amd64
   timeout_in: 120m
-  install_script: pkg install -y gcc git bash
+  install_script: pkg install -y git bash
   script:
     - ./Configure -n freebsd
     - make

--- a/00DIST
+++ b/00DIST
@@ -4995,6 +4995,9 @@ July 14, 2018
 		[linux] Added Linux display of INET6 socket endpoint
 		information with +|-E option. The option handles
 		INET6 sockets using IPC.
+      
+                [FreeBSD] update to include <sys/_lock.h> on recent -CURRENT
+		since it is no longer implicitly included via header pollution.
 
 Masatake YAMATO <yamato@redhat.com>, a member of lsof-org
 May 8, 2019

--- a/00DIST
+++ b/00DIST
@@ -138,7 +138,7 @@ version 3, itself a major revision of version 2.  Version 4 has
 been tested on:
 
 	Apple Darwin 9 and Mac OS X 10.[567]
-	FreeBSD 10.3, 11.0 and 12.0 for AMD64-based systems
+	FreeBSD 10.3, 11.0, 12.0 and 13.0 for AMD64-based systems
 	Solaris 9
 
 (The pub/tools/unix/lsof/contrib directory on lsof.itap.purdue.edu

--- a/Configure
+++ b/Configure
@@ -1639,7 +1639,7 @@ kernel generation process.
     # Clear LSOF_UNSUP message for supported versions of FreeBSD.
     
     case $LSOF_VERS in  # {
-    4090|8020|8030|8040|9000|10000|11000|12000)
+    4090|8020|8030|8040|9000|10000|11000|12000|13000)
       LSOF_UNSUP=""
       ;;
     esac	# }

--- a/dialects/freebsd/dlsof.h
+++ b/dialects/freebsd/dlsof.h
@@ -45,6 +45,12 @@
 #include <signal.h>
 #include <unistd.h>
 
+#if    FREEBSDV>=13000
+/* This header is a huge mess.  Please don't support EOL FreeBSD releases. */
+#define        _KERNEL 1
+#include <sys/_lock.h>
+#undef _KERNEL
+#endif         /* FREEBSDV>=13000 */
 # if	FREEBSDV>=4000
 #  if	FREEBSDV>=5000
 #   if	FREEBSDV<6020


### PR DESCRIPTION
FreeBSD -CURRENT (HEAD) needs to include <sys/_lock.h>.

