### PR TITLE
docs: update URLs and contact addresses in man page

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -4999,5 +4999,5 @@ July 14, 2018
                 [FreeBSD] update to include <sys/_lock.h> on recent -CURRENT
 		since it is no longer implicitly included via header pollution.
 
-Masatake YAMATO <yamato@redhat.com>, a member of lsof-org
+Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/Lsof.8
+++ b/Lsof.8
@@ -4429,13 +4429,9 @@ file of the
 .I lsof
 distribution.
 .PP
-That file is also available via anonymous ftp from
-.I lsof.itap.purdue.edu
-at
-.IR pub/tools/unix/lsof FAQ .
-The URL is:
+That latest version of the file is found at:
 .IP
-ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
+https://github.com/lsof-org/lsof/blob/master/00FAQ
 .SH FILES
 .TP \w'.lsof_hostname'u+4
 .I /dev/kmem
@@ -4457,6 +4453,7 @@ is the first component of the host's name returned by
 .SH AUTHORS
 .I Lsof
 was written by Victor A.\&Abell <abe@purdue.edu> of Purdue University.
+Since version 4.93.0, lsof-org at GitHUB team maintains.
 Many others have contributed to
 .IR lsof .
 They're listed in the
@@ -4467,56 +4464,9 @@ distribution.
 .SH DISTRIBUTION
 The latest distribution of
 .I lsof
-is available via anonymous ftp from the host
-.IR lsof.itap.purdue.edu .
-You'll find the
-.I lsof
-distribution in the
-.I pub/tools/unix/lsof
-directory.
-.PP
-You can also use this URL:
+is available at
 .IP
-ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof
-.PP
-.I Lsof
-is also mirrored elsewhere.
-When you access
-.I lsof.itap.purdue.edu
-and change to its
-.I pub/tools/unix/lsof
-directory, you'll be given a list of some mirror sites.
-The
-.I pub/tools/unix/lsof
-directory also contains a more complete list in its
-.I mirrors
-file.
-Use mirrors with caution \- not all mirrors always have the latest
-.I lsof
-revision.
-.PP
-Some pre\-compiled
-.I Lsof
-executables are available on
-.IR lsof.itap.purdue.edu ,
-but their use is discouraged \- it's better that you build
-your own from the sources.
-If you feel you must use a pre\-compiled executable, please
-read the cautions that appear in the README files of the
-.I pub/tools/unix/lsof/binaries
-subdirectories and in the 00* files of the distribution.
-.PP
-More information on the
-.I lsof
-distribution can be found in its
-.I README.lsof_<version>
-file.
-If you intend to get the
-.I lsof
-distribution and build it, please read
-.I README.lsof_<version>
-and the other 00* files of the distribution before sending questions
-to the author.
+https://github.com/lsof-org/lsof/releases
 .SH SEE ALSO
 .PP
 Not all the following manual pages may exist in every UNIX

--- a/Lsof.8
+++ b/Lsof.8
@@ -4453,7 +4453,7 @@ is the first component of the host's name returned by
 .SH AUTHORS
 .I Lsof
 was written by Victor A.\&Abell <abe@purdue.edu> of Purdue University.
-Since version 4.93.0, lsof-org at GitHUB team maintains.
+Since version 4.93.0, the lsof-org team at GitHub maintains lsof.
 Many others have contributed to
 .IR lsof .
 They're listed in the

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coveralls Linux Coverage Status on Travis CI](https://coveralls.io/repos/github/lsof-org/lsof/badge.svg?branch=master)](https://coveralls.io/github/lsof-org/lsof?branch=master)
 
 # lsof
-lsof-org at GitHub team takes over the maintainership of lsof
+The lsof-org team at GitHub takes over the maintainership of lsof
 originally maintained by Vic Abell. This repository is for maintaining
 the final source tree of lsof inherited from Vic. "legacy" branch
 keeps the original source tree. We will not introduce any changes to
@@ -42,4 +42,4 @@ GNU/Linux. We will merge the fruits of "lsof-linux" repository to this
 repository incrementally. If you are using GNU/Linux, you may want to
 use the code in "lsof-linux" repository.
 
-lsof-org at GitHub team
+The lsof-org team at GitHub


### PR DESCRIPTION
We have to update the URLs and contact addresses in our documents so we can receive bug ports.
This is the first step.