### PR TITLE
Allow to specify max iteration count to -r option

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -4999,5 +4999,8 @@ July 14, 2018
                 [FreeBSD] update to include <sys/_lock.h> on recent -CURRENT
 		since it is no longer implicitly included via header pollution.
 
+		Enhanced -r option. With `c<N>' specifier, lsof can stop itself
+		when the number of iterations reaches at <N>.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/Lsof.8
+++ b/Lsof.8
@@ -1373,7 +1373,7 @@ Inhibiting the conversion may make
 run a little faster.
 It is also useful when port name lookup is not working properly.
 .TP \w'names'u+4
-.BI +|\-r " [t[m<fmt>]]"
+.BI +|\-r " [t[c<N>][m<fmt>]]"
 puts
 .I lsof
 in repeat mode.
@@ -1388,6 +1388,10 @@ the prefix to the option.
 If the prefix is a `\-', repeat mode is endless.
 .I Lsof
 must be terminated with an interrupt or quit signal.
+`c<N>' is for specifying the limits of repeating; if the number of
+iterations reaches at `<N>',
+.I Lsof
+stops itself.
 .IP
 If the prefix is `+', repeat mode will end the first cycle no open files
 are listed \- and of course when

--- a/lsof.h
+++ b/lsof.h
@@ -1063,6 +1063,7 @@ extern int Procsrch;
 
 extern int PrPass;
 extern int RptTm;
+extern int RptMaxCount;
 extern struct l_dev **Sdev;
 extern int SelAll;
 extern int Selflags;

--- a/main.c
+++ b/main.c
@@ -84,6 +84,7 @@ main(argc, argv)
 	struct str_lst *str, *strt;
 	int version = 0;
 	int xover = 0;
+	int pr_count = 0;
 
 #if	defined(HAS_STRFTIME)
 	char *fmt = (char *)NULL;
@@ -783,6 +784,16 @@ main(argc, argv)
 		     break;
 		while(*cp && (*cp == ' '))
 		    cp++;
+
+		if (*cp == 'c') {
+		    cp++;
+		    for (i = 0;
+			 *cp && isdigit((unsigned char)*cp);
+			 cp++)
+			i = (i * 10) + ((int)*cp - '0');
+		    RptMaxCount = i;
+		}
+
 		if (*cp != LSOF_FID_MARK) {
 		    GOx1 = GObk[0];
 		    GOx2 = GObk[1] + n;
@@ -1539,6 +1550,8 @@ main(argc, argv)
 		Hdr = Nlproc = 0;
 		CkPasswd = 1;
 	    }
+	    if (RptMaxCount && (++pr_count == RptMaxCount))
+		RptTm = 0;
 	} while (RptTm);
 /*
  * See if all requested information was displayed.  Return zero if it

--- a/store.c
+++ b/store.c
@@ -324,6 +324,8 @@ int Procsrch = 0;		/* 1 if searching for any proc file system
 int PrPass = 0;			/* print pass: 0 = compute column widths
 				 *	       1 = print */
 int RptTm = 0;			/* repeat time -- set by -r */
+int RptMaxCount = 0;		/* count of repeasts: 0 = no limit
+				 * -- set by -r */
 struct l_dev **Sdev = (struct l_dev **)NULL;
 				/* pointer to Devtp[] pointers, sorted
 				 * by device */

--- a/tests/case-20-repeat-count.bash
+++ b/tests/case-20-repeat-count.bash
@@ -1,0 +1,15 @@
+name=$(basename $0 .bash)
+lsof=$1
+report=$2
+base=$(pwd)
+
+
+if [ $(${lsof} -r 1c1 -p $$ | tee -a $report | grep -e '=======' | wc -l) != 1 ]; then
+    exit 1
+fi
+
+if [ $(${lsof} -r 1c5 -p $$ | tee -a $report | grep -e '=======' | wc -l) != 5 ]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
e.g.

	$ ./lsof -r1c3 -p 1

This command line lists files currently opend by the process having 1
as pid 3 times with 1 sec interval.

This enhancement helps us to run lsof under valgrind.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>