### PR TITLE
Remove "rcsid" declarations

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: arg.c,v 1.51 2012/04/10 16:30:06 abe Exp abe $";
 #endif
 
 

--- a/dialects/aix/ddev.c
+++ b/dialects/aix/ddev.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ddev.c,v 1.14 2005/08/08 19:46:38 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dfile.c
+++ b/dialects/aix/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.13 2005/08/08 19:46:38 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dmnt.c
+++ b/dialects/aix/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.13 2005/08/08 19:46:38 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dnode.c
+++ b/dialects/aix/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.25 2008/10/21 16:14:18 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dnode1.c
+++ b/dialects/aix/dnode1.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.10 2005/08/08 19:46:38 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dnode2.c
+++ b/dialects/aix/dnode2.c
@@ -36,7 +36,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2003 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode2.c,v 1.4 2005/08/08 19:46:38 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dproc.c
+++ b/dialects/aix/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.27 2018/02/14 14:23:27 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dsock.c
+++ b/dialects/aix/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.24 2008/10/21 16:14:18 abe Exp $";
 #endif
 
 

--- a/dialects/aix/dstore.c
+++ b/dialects/aix/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.12 2004/12/30 18:40:59 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/kmem/ddev.c
+++ b/dialects/darwin/kmem/ddev.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ddev.c,v 1.5 2006/03/27 23:24:50 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/kmem/dfile.c
+++ b/dialects/darwin/kmem/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id$";
 #endif
 
 

--- a/dialects/darwin/kmem/dmnt.c
+++ b/dialects/darwin/kmem/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.4 2005/11/01 20:24:51 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/kmem/dnode.c
+++ b/dialects/darwin/kmem/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.11 2006/03/27 23:24:50 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/kmem/dnode1.c
+++ b/dialects/darwin/kmem/dnode1.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.3 2005/11/01 20:24:51 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/darwin/kmem/dproc.c
+++ b/dialects/darwin/kmem/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.8 2005/11/01 20:24:51 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/darwin/kmem/dsock.c
+++ b/dialects/darwin/kmem/dsock.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.11 2005/11/01 20:24:51 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/kmem/dstore.c
+++ b/dialects/darwin/kmem/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.5 2005/11/01 20:24:51 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/libproc/ddev.c
+++ b/dialects/darwin/libproc/ddev.c
@@ -37,7 +37,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005 Apple Computer, Inc. and Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ddev.c,v 1.2 2006/03/27 23:23:13 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/libproc/dfile.c
+++ b/dialects/darwin/libproc/dfile.c
@@ -36,7 +36,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005-2007 Apple Inc. and Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.9 2018/02/14 14:27:57 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/libproc/dmnt.c
+++ b/dialects/darwin/libproc/dmnt.c
@@ -37,7 +37,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005  Apple Computer, Inc. and Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.6 2012/04/10 16:41:04 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/libproc/dproc.c
+++ b/dialects/darwin/libproc/dproc.c
@@ -37,7 +37,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005-2007 Apple Inc. and Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.10 2018/02/14 14:27:57 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/darwin/libproc/dsock.c
+++ b/dialects/darwin/libproc/dsock.c
@@ -37,7 +37,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005 Apple Computer, Inc. and Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.7 2012/04/10 16:41:04 abe Exp $";
 #endif
 
 

--- a/dialects/darwin/libproc/dstore.c
+++ b/dialects/darwin/libproc/dstore.c
@@ -37,7 +37,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2005 Apple Computer, Inc. and Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.5 2018/02/14 14:27:57 abe Exp $";
 #endif
 
 

--- a/dialects/du/ddev.c
+++ b/dialects/du/ddev.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ddev.c,v 1.17 2005/08/12 15:35:14 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/du/dfile.c
+++ b/dialects/du/dfile.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.12 2001/08/14 12:40:12 abe Exp $";
 #endif
 
 

--- a/dialects/du/dmnt.c
+++ b/dialects/du/dmnt.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.11 2005/08/08 19:56:44 abe Exp $";
 #endif
 
 

--- a/dialects/du/dnode.c
+++ b/dialects/du/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.23 2006/03/27 20:40:59 abe Exp $";
 #endif
 
 

--- a/dialects/du/dproc.c
+++ b/dialects/du/dproc.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.23 2005/08/08 19:56:44 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/du/dsock.c
+++ b/dialects/du/dsock.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.19 2005/08/08 19:56:44 abe Exp $";
 #endif
 
 

--- a/dialects/du/dstore.c
+++ b/dialects/du/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.10 2000/08/09 20:06:50 abe Exp $";
 #endif
 
 

--- a/dialects/freebsd/dmnt.c
+++ b/dialects/freebsd/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.18 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 

--- a/dialects/freebsd/dnode.c
+++ b/dialects/freebsd/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.45 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 

--- a/dialects/freebsd/dnode1.c
+++ b/dialects/freebsd/dnode1.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.11 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 

--- a/dialects/freebsd/dnode2.c
+++ b/dialects/freebsd/dnode2.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2008 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode2.c,v 1.7 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 

--- a/dialects/freebsd/dproc.c
+++ b/dialects/freebsd/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.20 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/freebsd/dsock.c
+++ b/dialects/freebsd/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.31 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 

--- a/dialects/freebsd/dstore.c
+++ b/dialects/freebsd/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.9 2018/02/14 14:26:03 abe Exp $";
 #endif
 
 

--- a/dialects/hpux/kmem/dfile.c
+++ b/dialects/hpux/kmem/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.14 2001/08/14 13:27:16 abe Exp $";
 #endif
 
 #if	defined(HPUXKERNBITS) && HPUXKERNBITS>=64

--- a/dialects/hpux/kmem/dmnt.c
+++ b/dialects/hpux/kmem/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.8 2005/08/08 19:50:23 abe Exp $";
 #endif
 
 #if	defined(HPUXKERNBITS) && HPUXKERNBITS>=64

--- a/dialects/hpux/kmem/dnode.c
+++ b/dialects/hpux/kmem/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.21 2007/04/24 16:25:30 abe Exp $";
 #endif
 
 #if	defined(HPUXKERNBITS) && HPUXKERNBITS>=64

--- a/dialects/hpux/kmem/dnode1.c
+++ b/dialects/hpux/kmem/dnode1.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.11 2005/08/08 19:50:23 abe Exp $";
 #endif
 
 

--- a/dialects/hpux/kmem/dnode2.c
+++ b/dialects/hpux/kmem/dnode2.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode2.c,v 1.7 2005/08/08 19:50:23 abe Exp $";
 #endif
 
 #if	defined(HAS_AFS)

--- a/dialects/hpux/kmem/dproc.c
+++ b/dialects/hpux/kmem/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.18 2008/10/08 13:24:36 abe Exp $";
 #endif
 
 #if	defined(HPUXKERNBITS)

--- a/dialects/hpux/kmem/dsock.c
+++ b/dialects/hpux/kmem/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.20 2005/08/08 19:50:23 abe Exp $";
 #endif
 
 #if	defined(HPUXKERNBITS) && HPUXKERNBITS>=64

--- a/dialects/hpux/kmem/dstore.c
+++ b/dialects/hpux/kmem/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.12 2007/04/24 16:25:30 abe Exp $";
 #endif
 
 

--- a/dialects/hpux/pstat/dfile.c
+++ b/dialects/hpux/pstat/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1999 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id";
 #endif
 
 

--- a/dialects/hpux/pstat/dproc.c
+++ b/dialects/hpux/pstat/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1999 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id";
 #endif
 
 

--- a/dialects/hpux/pstat/dsock.c
+++ b/dialects/hpux/pstat/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1999 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id";
 #endif
 
 

--- a/dialects/hpux/pstat/dstore.c
+++ b/dialects/hpux/pstat/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1999 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id";
 #endif
 
 

--- a/dialects/linux/dfile.c
+++ b/dialects/linux/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.8 2012/04/10 16:39:50 abe Exp abe $";
 #endif
 
 

--- a/dialects/linux/dmnt.c
+++ b/dialects/linux/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef	lint
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.21 2018/02/14 14:26:38 abe Exp $";
 #endif
 
 

--- a/dialects/linux/dnode.c
+++ b/dialects/linux/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.27 2018/03/26 21:52:29 abe Exp $";
 #endif
 
 

--- a/dialects/linux/dproc.c
+++ b/dialects/linux/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.31 2018/03/26 21:52:29 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.43 2018/03/26 21:52:29 abe Exp $";
 #endif
 
 

--- a/dialects/linux/dstore.c
+++ b/dialects/linux/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.4 2011/09/07 19:07:45 abe Exp $";
 #endif
 
 

--- a/dialects/n+obsd/dmnt.c
+++ b/dialects/n+obsd/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.12 2005/08/08 19:53:24 abe Exp $";
 #endif
 
 

--- a/dialects/n+obsd/dnode.c
+++ b/dialects/n+obsd/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.38 2007/04/24 16:22:02 abe Exp $";
 #endif
 
 

--- a/dialects/n+obsd/dnode1.c
+++ b/dialects/n+obsd/dnode1.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.8 2005/08/08 19:53:24 abe Exp $";
 #endif
 
 

--- a/dialects/n+obsd/dproc.c
+++ b/dialects/n+obsd/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.17 2005/05/11 12:53:54 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/n+obsd/dsock.c
+++ b/dialects/n+obsd/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.25 2005/08/08 19:53:24 abe Exp $";
 #endif
 
 

--- a/dialects/n+obsd/dstore.c
+++ b/dialects/n+obsd/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.9 2004/12/30 18:42:24 abe Exp $";
 #endif
 
 

--- a/dialects/n+os/dnode.c
+++ b/dialects/n+os/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.17 2006/03/28 22:08:17 abe Exp $";
 #endif
 
 

--- a/dialects/n+os/dnode1.c
+++ b/dialects/n+os/dnode1.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.7 2005/08/08 19:54:03 abe Exp $";
 #endif
 
 

--- a/dialects/n+os/dproc.c
+++ b/dialects/n+os/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.12 2001/08/09 11:44:07 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/n+os/dsock.c
+++ b/dialects/n+os/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.17 2005/08/08 19:54:03 abe Exp $";
 #endif
 
 

--- a/dialects/n+os/dstore.c
+++ b/dialects/n+os/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.10 2001/08/09 11:44:07 abe Exp $";
 #endif
 
 

--- a/dialects/osr/dfile.c
+++ b/dialects/osr/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1995 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.11 2000/12/04 14:32:49 abe Exp abe $";
 #endif
 
 #include "lsof.h"

--- a/dialects/osr/dmnt.c
+++ b/dialects/osr/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1995 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.8 2005/08/08 19:54:32 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/osr/dnode.c
+++ b/dialects/osr/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1995 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.21 2006/03/28 22:09:23 abe Exp $";
 #endif
 
 

--- a/dialects/osr/dproc.c
+++ b/dialects/osr/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1995 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.18 2007/04/24 16:22:40 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/osr/dsock.c
+++ b/dialects/osr/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1995 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.15 2004/03/10 23:52:12 abe Exp $";
 #endif
 
 

--- a/dialects/osr/dstore.c
+++ b/dialects/osr/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1995 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.9 2002/12/03 18:23:08 abe Exp $";
 #endif
 
 

--- a/dialects/sun/ddev.c
+++ b/dialects/sun/ddev.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ddev.c,v 1.20 2005/08/08 19:55:41 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dfile.c
+++ b/dialects/sun/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.21 2009/03/25 19:22:16 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dmnt.c
+++ b/dialects/sun/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.15 2005/08/29 10:24:25 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dnode.c
+++ b/dialects/sun/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.61 2015/07/07 20:27:15 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dnode1.c
+++ b/dialects/sun/dnode1.c
@@ -33,7 +33,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.9 2005/08/08 19:55:41 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dnode2.c
+++ b/dialects/sun/dnode2.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode2.c,v 1.23 2010/01/18 19:03:54 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dproc.c
+++ b/dialects/sun/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.36 2010/01/18 19:03:54 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/sun/dsock.c
+++ b/dialects/sun/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.31 2011/08/07 22:53:42 abe Exp $";
 #endif
 
 

--- a/dialects/sun/dstore.c
+++ b/dialects/sun/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.23 2010/01/18 19:03:54 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dfile.c
+++ b/dialects/uw/dfile.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dfile.c,v 1.11 2000/08/01 15:26:38 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dmnt.c
+++ b/dialects/uw/dmnt.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dmnt.c,v 1.7 2005/08/13 16:21:41 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dnode.c
+++ b/dialects/uw/dnode.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode.c,v 1.28 2006/03/28 21:57:57 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dnode1.c
+++ b/dialects/uw/dnode1.c
@@ -35,7 +35,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode1.c,v 1.6 2005/08/13 16:21:41 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dnode2.c
+++ b/dialects/uw/dnode2.c
@@ -34,7 +34,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode2.c,v 1.7 2005/08/13 16:21:41 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dnode3.c
+++ b/dialects/uw/dnode3.c
@@ -34,7 +34,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dnode3.c,v 1.5 2005/08/13 16:21:41 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dproc.c
+++ b/dialects/uw/dproc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dproc.c,v 1.14 2002/10/08 20:18:34 abe Exp $";
 #endif
 
 #include "lsof.h"

--- a/dialects/uw/dsock.c
+++ b/dialects/uw/dsock.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dsock.c,v 1.16 2005/08/13 16:21:41 abe Exp $";
 #endif
 
 

--- a/dialects/uw/dstore.c
+++ b/dialects/uw/dstore.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1996 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dstore.c,v 1.8 2000/11/03 18:57:07 abe Exp abe $";
 #endif
 
 

--- a/lib/ckkv.c
+++ b/lib/ckkv.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1998 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ckkv.c,v 1.3 2008/10/21 16:12:36 abe Exp abe $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/cvfs.c
+++ b/lib/cvfs.c
@@ -49,7 +49,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: cvfs.c,v 1.6 2008/10/21 16:12:36 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include	"../lsof.h"

--- a/lib/dvch.c
+++ b/lib/dvch.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: dvch.c,v 1.16 2008/10/21 16:12:36 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/fino.c
+++ b/lib/fino.c
@@ -46,7 +46,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: fino.c,v 1.5 2008/10/21 16:12:36 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/isfn.c
+++ b/lib/isfn.c
@@ -61,7 +61,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: isfn.c,v 1.10 2008/10/21 16:12:36 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/lkud.c
+++ b/lib/lkud.c
@@ -46,7 +46,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: lkud.c,v 1.7 2008/10/21 16:12:36 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/pdvn.c
+++ b/lib/pdvn.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: pdvn.c,v 1.8 2008/10/21 16:12:36 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/prfp.c
+++ b/lib/prfp.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: prfp.c,v 1.15 2018/02/14 14:21:08 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/ptti.c
+++ b/lib/ptti.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: ptti.c,v 1.6 2008/10/21 16:13:23 abe Exp $";
 # endif	/* !defined(lint) */
 
 #define	TCPSTATES			/* activate tcpstates[] */

--- a/lib/rdev.c
+++ b/lib/rdev.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: rdev.c,v 1.12 2008/10/21 16:13:23 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/rmnt.c
+++ b/lib/rmnt.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: rmnt.c,v 1.12 2008/10/21 16:13:23 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/rnam.c
+++ b/lib/rnam.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: rnam.c,v 1.11 2008/10/21 16:13:23 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/rnch.c
+++ b/lib/rnch.c
@@ -37,7 +37,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: rnch.c,v 1.11 2008/10/21 16:13:23 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/lib/rnmh.c
+++ b/lib/rnmh.c
@@ -38,7 +38,6 @@
 # if	!defined(lint)
 static char copyright[] =
 "@(#) Copyright 1997 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: rnmh.c,v 1.13 2008/10/21 16:13:23 abe Exp $";
 # endif	/* !defined(lint) */
 
 #include "../lsof.h"

--- a/main.c
+++ b/main.c
@@ -34,7 +34,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: main.c,v 1.59 2018/03/26 21:50:45 abe Exp $";
 #endif
 
 

--- a/misc.c
+++ b/misc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: misc.c,v 1.29 2018/02/14 14:20:14 abe Exp $";
 #endif
 
 

--- a/node.c
+++ b/node.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: node.c,v 1.5 2000/08/01 17:08:05 abe Exp $";
 #endif
 
 

--- a/print.c
+++ b/print.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: print.c,v 1.56 2018/02/14 14:20:14 abe Exp $";
 #endif
 
 

--- a/proc.c
+++ b/proc.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: proc.c,v 1.50 2018/02/14 14:20:14 abe Exp $";
 #endif
 
 

--- a/store.c
+++ b/store.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1994 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: store.c,v 1.44 2018/02/14 14:20:14 abe Exp $";
 #endif
 
 

--- a/usage.c
+++ b/usage.c
@@ -32,7 +32,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 1998 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: usage.c,v 1.33 2018/02/14 14:20:14 abe Exp $";
 #endif
 
 

--- a/util.c
+++ b/util.c
@@ -39,7 +39,6 @@
 #ifndef lint
 static char copyright[] =
 "@(#) Copyright 2008 Purdue Research Foundation.\nAll rights reserved.\n";
-static char *rcsid = "$Id: util.c,v 1.1 2008/04/01 11:56:53 abe Exp $";
 #endif
 
 #if	defined(HAS_STRFTIME)


### PR DESCRIPTION
Compilers report them as unused variabels.

Suggested by Tomasz Kłoczko (@kloczek) in #62.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>