### PR TITLE
Add missing header to FreeBSD dlsof.h

### DIFF
--- a/dialects/freebsd/dlsof.h
+++ b/dialects/freebsd/dlsof.h
@@ -38,6 +38,7 @@
 #if	!defined(FREEBSD_LSOF_H)
 #define	FREEBSD_LSOF_H	1
 
+#include <stddef.h>
 #include <stdlib.h>
 #include <dirent.h>
 #include <nlist.h>


### PR DESCRIPTION
Without this header the build fails on latest 12-STABLE and possibly 13-CURRENT.