### PR TITLE
 [linux] fix a crash when printing the endpoint for unaccepted unix socket with +E option

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5008,5 +5008,9 @@ July 14, 2018
 		[linux] Fixed accessing an uninitialized local variable.
 		Detected by valgrind.
 
+		[linux] fix a crash when printing the endpoint for unaccepted
+		unix socket with +E option.
+		This closes the github issue #74 reported by @jolmg.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -1299,15 +1299,15 @@ process_uxsinfo(f)
 			if (tp->icons) {
 			    if (tp->icstat) {
 				p = tp->icons;
-				while (p != tp) {
-				    if (p && p->inode)
+				while (p && p != tp) {
+				    if (p->inode)
 					prt_uxs(p, 1);
 				    p = p->icons;
 				}
 			    } else {
-				for (p = tp->icons; !p->icstat; p = p->icons)
+				for (p = tp->icons; p && !p->icstat; p = p->icons)
 				    ; /* DO NOTHING */
-				if (p->icstat && p->inode)
+				if (p && p->inode)
 				    prt_uxs (p, 1);
 			    }
 			}
@@ -1331,15 +1331,15 @@ process_uxsinfo(f)
 			if (tp->icons) {
 			    if (tp->icstat) {
 				p = tp->icons;
-				while (p != tp) {
-				    if (p  && p->inode)
+				while (p && p != tp) {
+				    if (p->inode)
 					prt_uxs(p, 0);
 				    p = p->icons;
 				}
 			    } else {
-				for (p = tp->icons; !p->icstat; p = p->icons)
+				for (p = tp->icons; p && !p->icstat; p = p->icons)
 				    ; /* DO NOTHING */
-				if (p->icstat && p->inode)
+				if (p && p->inode)
 				    prt_uxs(p, 0);
 			    }
 			}

--- a/dialects/linux/tests/Makefile
+++ b/dialects/linux/tests/Makefile
@@ -4,6 +4,7 @@ HELPERS = \
 	mq_open \
 	pipe \
 	pty \
+	ux \
 	\
 	open_with_flags \
 	\

--- a/dialects/linux/tests/case-20-ux-socket-endpoint-unaccepted.bash
+++ b/dialects/linux/tests/case-20-ux-socket-endpoint-unaccepted.bash
@@ -1,0 +1,84 @@
+#!/bin/sh
+
+name=$(basename $0 .sh)
+lsof=$1
+report=$2
+tdir=$3
+
+TARGET=$tdir/ux
+
+$TARGET | {
+    #
+    # An example of expect output:
+    #
+    # pid=1451661
+    # connect=4
+    # connect2=5
+    # ppid=1451659
+    # listen=3
+    # accept=5
+    # path=/tmp/lsof-test-ux-1451659.s
+    # end
+    echo "target output:" >> $report
+    while read k v; do
+	if [[ $k = end ]]; then
+	    break;
+	fi
+	echo "$k=$v" >> $report
+	eval "$k=$v"
+    done
+    #
+    # An exapmle of lsof output:
+    #
+    # COMMAND     PID USER   FD   TYPE             DEVICE SIZE/OFF     NODE NAME
+    # ux      1445917  jet    3u  unix 0x000000002d21092b      0t0 75849115 /tmp/lsof-test-ux-1445917.s type=STREAM ->INO=75843930 1445919,ux,5u
+    listen_sock_pat="^ux \+${ppid} \+.* \+${listen}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+${path} \+type=STREAM ->INO=[0-9]\+ \+${pid},ux,${connect2}u"'$'
+    # ux      1445917  jet    5u  unix 0x00000000335230a5      0t0 75849117 /tmp/lsof-test-ux-1445917.s type=STREAM ->INO=75843929 1445919,ux,4u
+    accepted_sock_pat="^ux \+${ppid} \+.* \+${accept}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+${path} \+type=STREAM ->INO=[0-9]\+ \+${pid},ux,${connect}u"'$'
+    # ux      1445919  jet    4u  unix 0x00000000627d8ccc      0t0 75843929 type=STREAM ->INO=75849117 1445917,ux,5u
+    client_sock_pat="^ux \+${pid} \+.* \+${connect}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+type=STREAM ->INO=[0-9]\+ \+${ppid},ux,${accept}u"'$'
+    # ux      1445919  jet    5u  unix 0x00000000cc000ead      0t0 75843930 type=STREAM
+    client2_sock_pat="^ux \+${pid} \+.* \+${connect2}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+type=STREAM"'$'
+    # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    # The last line reflects what unix-diagnose netlink socket reports. The counter part just queued in the listen socket,
+    # and is not accepted yet.
+    #
+    out=/tmp/${name}-$$
+    if $lsof +E $path > $out; then
+	kill -CONT $ppid
+	if [[ $(wc -l < $out) != $(( 1 + 4 )) ]]; then
+	    echo "Too many file descriptors are found (the expection is 4 but got $(wc -l < $out)):" >> $report
+	    cat $out >> $report
+	    rm $out
+	    exit 1
+	elif ! grep -q "$listen_sock_pat" < $out; then
+	    echo "don't match the pattern for listen socket" >> $report
+	    echo "expected pattern: $listen_sock_pat" >> $report
+	    cat $out >> $report
+	    rm $out
+	    exit 1
+	elif ! grep -q "$accepted_sock_pat" < $out; then
+	    echo "don't match the pattern for accepted socket" >> $report
+	    echo "expected pattern: $accepted_sock_pat" >> $report
+	    cat $out >> $report
+	    rm $out
+	    exit 1
+	elif ! grep -q "$client_sock_pat" < $out; then
+	    echo "don't match the pattern for the 1st client socket" >> $report
+	    echo "expected pattern: $client_sock_pat" >> $report
+	    cat $out >> $report
+	    rm $out
+	    exit 1
+	elif ! grep -q "$client2_sock_pat" < $out; then
+	    echo "don't match the pattern for the 2nd client socket" >> $report
+	    echo "expected pattern: $client2_sock_pat" >> $report
+	    cat $out >> $report
+	    rm $out
+	    exit 1
+	fi
+    else
+	echo "failed to run lsof: $?" >> $report
+	exit 1
+    fi
+}
+exit 0

--- a/dialects/linux/tests/ux.c
+++ b/dialects/linux/tests/ux.c
@@ -1,0 +1,154 @@
+#define _POSIX_SOURCE
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <signal.h>
+
+#define TEMPLATE "/tmp/lsof-test-ux-%ld.s"
+
+static void
+do_nothing(int n)
+{
+}
+
+int
+main(void)
+{
+  int rendezvous[2];
+  if (pipe(rendezvous) < 0)
+    {
+      perror("pipe");
+      return 1;
+    }
+
+  pid_t pid = fork();
+  if (pid > 0)
+    {
+      close (rendezvous[0]);
+      /* parent: server */
+      int server = socket(AF_UNIX, SOCK_STREAM, 0);
+      if (server < 0)
+	{
+	  perror("socket (server)");
+	  return 1;
+	}
+      struct sockaddr_un un = {
+			       .sun_family = AF_UNIX,
+      };
+      snprintf (un.sun_path, 108, TEMPLATE, (long int)getpid());
+      unlink (un.sun_path);
+
+      if (bind (server, (void *)&un, sizeof (un)) < 0)
+	{
+	  perror("bind (server)");
+	  return 1;
+	}
+      if (listen(server, 0) < 0)
+	{
+	  perror("listen (server)");
+	  return 1;
+	}
+
+      char b = 1;
+      if (write(rendezvous[1], &b, 1) < 0)
+	{
+	  perror("write rendezvous pipe (server)");
+	  return 1;
+	}
+      b++;
+
+      int client;
+      if ((client = accept(server, NULL, 0)) < 0)
+	{
+	  perror("listen (server)");
+	  return 1;
+	}
+
+      char buf[1024];
+      if (read(client, buf, 1024) < 0)
+	{
+	  perror("read (server)");
+	  return 1;
+	}
+
+      fputs(buf, stdout);
+      printf("ppid %ld\nlisten %d\naccept %d\npath %s\n",
+	     (long int)getpid(), server, client, un.sun_path);
+      fputs("end\n", stdout);
+      fflush(stdout);
+      signal(SIGCONT, do_nothing);
+      pause ();
+
+      unlink (un.sun_path);
+      write(rendezvous[1], &b, 1);
+      b++;
+
+      return 0;
+    }
+  else if (pid == 0)
+    {
+      char b;
+      /* child: client */
+      close(rendezvous[1]);
+      if (read(rendezvous[0], &b, 1) < 0)
+	{
+	  perror("read rendezvous pipe (client)");
+	  /* TODO: kill the parent process. */
+	  return 1;
+	}
+
+      int server = socket(AF_UNIX, SOCK_STREAM, 0);
+      if (server < 0)
+	{
+	  perror("socket (client)");
+	  return 1;
+	}
+
+      struct sockaddr_un un = {
+			       .sun_family = AF_UNIX,
+      };
+      snprintf (un.sun_path, 108, TEMPLATE, (long int)getppid());
+      if (connect(server, (void *)&un, sizeof(un)) < 0)
+	{
+	  perror("connect (client)");
+	  return 1;
+	}
+
+      FILE *serverf = fdopen(server, "w");
+      if (!serverf)
+	{
+	  perror("fdopen (client)");
+	  return 1;
+	}
+
+      int server2 = socket(AF_UNIX, SOCK_STREAM, 0);
+      if (server2 < 0)
+	{
+	  perror("socket (client)");
+	  return 1;
+	}
+      if (connect(server2, (void *)&un, sizeof(un)) < 0)
+	{
+	  perror("connect (client (server2))");
+	  return 1;
+	}
+
+      fprintf(serverf, "pid %ld\nconnect %d\nconnect2 %d\n", (long int)getpid(), server, server2);
+      putc('\0', serverf);
+      fflush(serverf);
+
+      if (read(rendezvous[0], &b, 1) < 0)
+	{
+	  perror("read rendezvous pipe (client)");
+	  return 1;
+	}
+      return 0;
+    }
+
+  perror("fork");
+  return 1;
+}


### PR DESCRIPTION
Close #74 reported by @jolmg.

When printing the end point of the unix domain socket whose counter part is not
accepted yet by server side, lsof with +E option crashed with NULL pointer
dereference.