### PR TITLE
[linux] fix accessing an uninitialized local variable

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5005,5 +5005,8 @@ July 14, 2018
 		Enhanced -r option. With `c<N>' specifier, lsof can stop itself
 		when the number of iterations reaches at <N>.
 
+		[linux] Fixed accessing an uninitialized local variable.
+		Detected by valgrind.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/dialects/linux/dproc.c
+++ b/dialects/linux/dproc.c
@@ -1195,6 +1195,7 @@ process_id(idp, idpl, cmd, uid, pid, ppid, pgid, tid, tcmd)
 		zeromem((char *)&sb, sizeof(sb));
 		lnk = ss = 0;
 		if (!Fwarn) {
+		    ls = 0;
 		    (void) snpf(nmabuf, sizeof(nmabuf), "(readlink: %s)",
 			strerror(errno));
 		    nmabuf[sizeof(nmabuf) - 1] = '\0';


### PR DESCRIPTION
In process_id(), a local variable `ls' is passed to process_proc_node()
if `pn' is non-zero. However, there is a control-flow where `pn' is set to 1
but `ls' is not set. Valgrind detected this.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>