### PR TITLE
.gitignore: Ignore top-level Makefile only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,7 @@ dkms.conf
 *.gcda
 *.gcno
 *~
-Makefile
+/Makefile
 TAGS
 lsof
 tags


### PR DESCRIPTION
Without '/', all the Makefiles are ignored, including
dialect-specific ones (unless they are already added),
which can be hard-to-pin source of confusion.