### PR TITLE
[linux] decode the name of DCCP socket type

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5015,5 +5015,7 @@ July 14, 2018
 		[linux] abort execution when failing in memory allocation for
 		socket private data.
 
+		[linux] decode the name of DCCP socket type.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -5117,6 +5117,12 @@ sockty2str(ty, rf)
 	    break;
 #endif	/* defined(SOCK_SEQPACKET) */
 
+#if	defined(SOCK_DCCP)
+	case SOCK_DCCP:
+	    sr = "DCCP";
+	    break;
+#endif	/* defined(SOCK_DCCP) */
+
 #if	defined(SOCK_PACKET)
 	case SOCK_PACKET:
 	    sr = "PACKET";


### PR DESCRIPTION
Signed-off-by: Masatake YAMATO <yamato@redhat.com>