### PR TITLE
[linux] print the connection state of unix domain socket

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5020,5 +5020,20 @@ July 14, 2018
 		[linux] decode more netlink protocol numbers (RDMA, CRYPTO, and
 		SMC).
 
+		[linux] print the connection state of unix domain socket
+		Lsof can print the state of TCP socket like:
+
+		         nc      22247 yamato    3u  IPv4 471409      0t0        TCP localhost:38802->localhost:9999 (ESTABLISHED)
+
+		This change exnteds this feature to support unix domain sockets.
+		LISTEN, UNCONNECTED, CONNECTING, CONNECTED, DISCONNECTING,
+		and UNKNOWN can be taken as a state.
+		An example of output:
+
+		         evince    17333  yamato    1u  unix 0x0000000054183795      0t0  89141 type=STREAM (CONNECTED)
+
+		This feature is enabled by default.
+		To turn off printing state information, use -T option.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/Configure
+++ b/Configure
@@ -3014,6 +3014,18 @@ return(0); }
 	LSOF_CFGF="$LSOF_CFGF -DHASPTYEPT"
       fi	# }
     fi	# }
+
+  # Test for (unix) socket state support.
+
+    if test -f ${LSOF_INCLUDE}/linux/net.h # {
+    then
+      grep -q SS_CONNECTED ${LSOF_INCLUDE}/linux/net.h
+      if test $? -eq 0 # {
+      then
+        LSOF_CFGF="$LSOF_CFGF -DHASSOSTATE -DHASSOOPT"
+      fi	# }
+    fi	# }
+
     LSOF_DIALECT_DIR="linux"
     LSOF_CFGF="$LSOF_CFGF -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE"
     ;;

--- a/Lsof.8
+++ b/Lsof.8
@@ -1669,6 +1669,7 @@ the partial listen queue connection count for my dialect?''
 questions in the
 .I lsof
 FAQ (The \fBFAQ\fP section gives its location.)
+On Linux this option also prints the state of UNIX domain sockets.
 .TP \w'names'u+4
 .B \-t
 specifies that

--- a/dialects/linux/dlsof.h
+++ b/dialects/linux/dlsof.h
@@ -173,6 +173,16 @@ struct sfile {
 	struct sfile *next;		/* forward link */
 };
 
+# if	defined(HASEPTOPTS)
+typedef struct pxinfo {			/* hashed pipe, UNIX socket or pseudo-
+					 * terminal inode information */
+	INODETYPE ino;			/* file's inode */
+	struct lfile *lf;		/* connected peer file */
+	int lpx;			/* connected process index */
+	struct pxinfo *next;		/* next entry for hashed inode */
+} pxinfo_t;
+# endif	/* defined(HASEPTOPTS) */
+
 extern int HasNFS;
 extern dev_t MqueueDev;
 extern int OffType;

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -197,7 +197,6 @@ struct tcp_udp6 {			/* IPv6 TCP and UDP socket
 };
 #endif	/* defined(HASIPv6) */
 
-# if	defined(HASEPTOPTS)
 typedef struct uxsin {			/* UNIX socket information */
 	INODETYPE inode;		/* node number */
 	char *pcb;			/* protocol control block */
@@ -218,7 +217,6 @@ typedef struct uxsin {			/* UNIX socket information */
 
 	struct uxsin *next;
 } uxsin_t;
-# endif	/* defined(HASEPTOPTS) */
 
 /*
  * Local static values

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -197,6 +197,28 @@ struct tcp_udp6 {			/* IPv6 TCP and UDP socket
 };
 #endif	/* defined(HASIPv6) */
 
+# if	defined(HASEPTOPTS)
+typedef struct uxsin {			/* UNIX socket information */
+	INODETYPE inode;		/* node number */
+	char *pcb;			/* protocol control block */
+	char *path;			/* file path */
+	unsigned char sb_def;		/* stat(2) buffer definitions */
+	dev_t sb_dev;			/* stat(2) buffer device */
+	INODETYPE sb_ino;		/* stat(2) buffer node number */
+	dev_t sb_rdev;			/* stat(2) raw device number */
+	uint32_t ty;			/* socket type */
+
+#  if	defined(HASEPTOPTS) && defined(HASUXSOCKEPT)
+	struct uxsin *icons;		/* incoming socket conections */
+	unsigned int icstat;		/* incoming connection status
+					 * 0 == none */
+	pxinfo_t *pxinfo;		/* inode information */
+	struct uxsin *peer;	        /* connected peer(s) info */
+#  endif	/* defined(HASEPTOPTS) && defined(HASUXSOCKEPT) */
+
+	struct uxsin *next;
+} uxsin_t;
+# endif	/* defined(HASEPTOPTS) */
 
 /*
  * Local static values

--- a/dialects/linux/tests/case-10-ux-socket-state.bash
+++ b/dialects/linux/tests/case-10-ux-socket-state.bash
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+name=$(basename $0 .bash)
+lsof=$1
+report=$2
+
+ux=/tmp/$name-$$.sock
+nc -l -U $ux > /dev/null < /dev/zero &
+server=$!
+
+killBoth()
+{
+    kill -9 $1
+    sleep 1
+    kill -9 $2
+} 2> /dev/null > /dev/null
+
+fserver=/tmp/${name}-server-$$-before
+$lsof -n -Ts -P -U -a -p $server > $fserver
+# nc        22512 yamato    3u  unix 0x000000008f6993b8      0t0     470697 /tmp/a type=STREAM (LISTEN)
+if ! cat $fserver | grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM (LISTEN)"; then
+    echo "failed in server side (before connecting)" >> $report
+    cat $fserver >> $report
+    kill -9 $server
+    rm $ux
+    exit 1
+fi
+
+nc -U $ux < /dev/zero  > /dev/null &
+client=$!
+sleep 1
+fserver=/tmp/${name}-server-$$-after
+$lsof -n -Ts -P -U -a -p $server > $fserver
+# nc      22512 yamato    4u  unix 0x00000000deffde05      0t0 472699 /tmp/a type=STREAM (CONNECTED)
+if ! cat $fserver | grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM (CONNECTED)"; then
+    echo "failed in server side (after connecting)" >> $report
+    cat $fserver >> $report
+    killBoth $client $server
+    rm $ux
+    exit 1
+fi
+
+fclient=/tmp/${name}-client-$$
+$lsof -n -Ts -P -U -a -p $client -FT | grep ^TST > $fclient
+# TST=CONNECTED
+if ! cat $fclient | grep -q "^TST=CONNECTED"; then
+    echo "failed in client side" >> $report
+    cat $fclient >> $report
+    killBoth $client $server
+    rm $ux
+    exit 1
+fi
+
+killBoth $client $server
+rm $ux
+
+exit 0

--- a/lsof.h
+++ b/lsof.h
@@ -628,37 +628,6 @@ struct pff_tab {			/* print file flags table structure */
 };
 # endif	/* defined(HASFSTRUCT) */
 
-# if	defined(HASEPTOPTS)
-typedef struct pxinfo {			/* hashed pipe, UNIX socket or pseudo-
-					 * terminal inode information */
-	INODETYPE ino;			/* file's inode */
-	struct lfile *lf;		/* connected peer file */
-	int lpx;			/* connected process index */
-	struct pxinfo *next;		/* next entry for hashed inode */
-} pxinfo_t;
-
-typedef struct uxsin {			/* UNIX socket information */
-	INODETYPE inode;		/* node number */
-	char *pcb;			/* protocol control block */
-	char *path;			/* file path */
-	unsigned char sb_def;		/* stat(2) buffer definitions */
-	dev_t sb_dev;			/* stat(2) buffer device */
-	INODETYPE sb_ino;		/* stat(2) buffer node number */
-	dev_t sb_rdev;			/* stat(2) raw device number */
-	uint32_t ty;			/* socket type */
-
-#  if	defined(HASEPTOPTS) && defined(HASUXSOCKEPT)
-	struct uxsin *icons;		/* incoming socket conections */
-	unsigned int icstat;		/* incoming connection status
-					 * 0 == none */
-	pxinfo_t *pxinfo;		/* inode information */
-	struct uxsin *peer;	        /* connected peer(s) info */
-#  endif	/* defined(HASEPTOPTS) && defined(HASUXSOCKEPT) */
-
-	struct uxsin *next;
-} uxsin_t;
-# endif	/* defined(HASEPTOPTS) */
-
 
 struct seluid {
 	uid_t uid;			/* User ID */


### PR DESCRIPTION
    Lsof can print the state of TCP socket like:
    
         nc      22247 yamato    3u  IPv4 471409      0t0        TCP localhost:38802->localhost:9999 (ESTABLISHED)
    
    This change exnteds this feature to support unix domain sockets.
    LISTEN, UNCONNECTED, CONNECTING, CONNECTED, DISCONNECTING,
    and UNKNOWN can be taken as a state.
    
    An example of output:
    
       evince    17333  yamato    1u  unix 0x0000000054183795      0t0  89141 type=STREAM (CONNECTED)
    
    This feature is enabled by default.
    To turn off printing state information, use -T option.
    
    Close #76.
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
