### PR TITLE
Don't display usage even when even a non-existing file is passed

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5035,5 +5035,9 @@ July 14, 2018
 		This feature is enabled by default.
 		To turn off printing state information, use -T option.
 
+		Don't display command usage even when a file (or directory) listed
+		in command line doesn't exist.
+		This closes the github issue #90 reported by @rowlap.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/main.c
+++ b/main.c
@@ -1245,7 +1245,7 @@ main(argc, argv)
  */
 	if (GOx1 < argc) {
 	    if (ck_file_arg(GOx1, argc, argv, Ffilesys, 0, (struct stat *)NULL))
-		usage(1, 0, 0);
+		Exit(1);
 	}
 /*
  * Do dialect-specific initialization.

--- a/tests/case-20-handle-missing-files.bash
+++ b/tests/case-20-handle-missing-files.bash
@@ -1,0 +1,16 @@
+# See https://github.com/lsof-org/lsof/issues/90
+name=$(basename $0 .bash)
+lsof=$1
+report=$2
+msg=$(${lsof} /NO-SUCH-FILE 2>&1)
+
+if [[ "${msg}" == \
+	       *': status error on /NO-SUCH-FILE: No such file or directory' ]]; then
+    exit 0
+else
+    {
+	echo "unexpected output: "
+	echo "${msg}"
+    } > $report
+    exit 1
+fi


### PR DESCRIPTION
Close #90.

The original behavior (taken from #90):

    ## file not in use
    $ lsof /bin/ls
    ...

    ## file not in use + non-existent
    $ lsof /bin/ls /bin/lsxxx
    lsof: status error on /bin/lsxxx: No such file or directory
    ...

    ## only non-existent
    $ lsof /bin/lsxxx
    lsof: status error on /bin/lsxxx: No such file or directory
    lsof 4.91
     latest revision: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/
     latest FAQ: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/FAQ
     latest man page: ftp://lsof.itap.purdue.edu/pub/tools/unix/lsof/lsof_man
     usage: [-?abhKlnNoOPRtUvVX] [+|-c c] [+|-d s] [+D D] [+|-E] [+|-e s] [+|-f[gG]]
     [-F [f]] [-g [s]] [-i [i]] [+|-L [l]] [+m [m]] [+|-M] [-o [o]] [-p s]
     [+|-r [t]] [-s [p:s]] [-S [t]] [-T [t]] [-u s] [+|-w] [-x [fl]] [--] [names]
    Use the ``-h'' option to get more help information.

Just displaying "No such file or directory" is enough for all the cases.
Displaying the usage is needed for a syntax error.
Specifying a non-existing file is not a a syntax error.

Quoted a comment in #90 submitted by @rowlap:

    When usage is displayed, the implication to the user is that an
    syntax error has been made. When calling out to lsof from other
    programs, I really would prefer that lsof stderr output doesn't
    depend on ephemeral conditions such as file existence.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>