### PR TITLE
[linux] Allow reproducible builds

### DIFF
--- a/00CREDITS
+++ b/00CREDITS
@@ -337,7 +337,9 @@ provided test systems where I was able to do development work.
 	Andrew Merril
 	Richard van Meurs
 	Jim Mewes
+	Ivan Melnikov
 	Conrad Meyer
+	Hendrik Meyer
 	Gary Millen
 	Timothy Miller
 	Davin Milun
@@ -538,8 +540,7 @@ provided test systems where I was able to do development work.
 	Donald Zoch
 	Malcom Zung
 	Waldemar Zurowski
-	@eranik (github account)
-	Ivan Melnikov and
+	@eranik (github account) and
 	@jolmg  (github account)
 
 If I have omitted a contributor's name, the fault is wholly mine,

--- a/00DIST
+++ b/00DIST
@@ -5039,5 +5039,13 @@ July 14, 2018
 		in command line doesn't exist.
 		This closes the github issue #90 reported by @rowlap.
 
+		[linux] Allow reproducible builds
+		In a reproducible build all varied information is removed.  This
+		change does so, by checking if the standard SOURCE_DATE_EPOCH
+		variable is set.  If it is, we are attempting a reproducible build
+		and will strip varying information.
+		About the standard, see https://reproducible-builds.org/specs/source-date-epoch/
+		Provided in github pull request #93 by @T4cC0re.
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/00DIST
+++ b/00DIST
@@ -5039,7 +5039,7 @@ July 14, 2018
 		in command line doesn't exist.
 		This closes the github issue #90 reported by @rowlap.
 
-		[linux] Allow reproducible builds
+		[linux] allow reproducible builds
 		In a reproducible build all varied information is removed.  This
 		change does so, by checking if the standard SOURCE_DATE_EPOCH
 		variable is set.  If it is, we are attempting a reproducible build

--- a/dialects/linux/Makefile
+++ b/dialects/linux/Makefile
@@ -40,6 +40,17 @@ SHELL=	/bin/sh
 
 SOURCE=	Makefile ${OTHER} ${MAN} ${HDR} ${SRC}
 
+ifneq ($(SOURCE_DATE_EPOCH),)
+	LSOF_HOST=   none
+	LSOF_LOGNAME=        none
+	LSOF_SYSINFO=        none
+	LSOF_USER=   none
+	BUILD_DATE=     $(shell date --utc --date=@$(SOURCE_DATE_EPOCH))
+	export LSOF_HOST LSOF_LOGNAME LSOF_SYSINFO LSOF_USER
+else
+	BUILD_DATE=     $(shell date)
+endif
+
 all: ${PROG}
 
 ${PROG}: ${P} ${LIB} ${OBJ}
@@ -78,7 +89,7 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
+	@echo '#define	LSOF_CCDATE	"$(BUILD_DATE)"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \


### PR DESCRIPTION
In a reproducible build all varied information is removed.
This patch does so, by checking if the standard [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) variable is set.
If it is, we are attempting a reproducible build and will strip varying information.