### PR TITLE
Fix tests for large inode-numbers (i >= 2^32).

### DIFF
--- a/tests/LTbasic.c
+++ b/tests/LTbasic.c
@@ -356,8 +356,8 @@ tstlsof(texec, tkmem, tproc)
 		    pem = cem;
 		    break;
 		}
-		(void) snprintf(ibuf, sizeof(ibuf) - 1, "%u",
-		    (unsigned int)cwdsb.st_ino);
+		(void) snprintf(ibuf, sizeof(ibuf) - 1, "%" PRIu64,
+		    (uint64_t)cwdsb.st_ino);
 		ibuf[sizeof(ibuf) - 1] = '\0';
 		if ((tmpdc.maj == cwddc.maj)
 		&&  (tmpdc.min == cwddc.min)
@@ -389,8 +389,8 @@ tstlsof(texec, tkmem, tproc)
 		    pem = cem;
 		    break;
 		}
-		(void) snprintf(ibuf, sizeof(ibuf) - 1, "%u",
-		    (unsigned int)kmemsb.st_ino);
+		(void) snprintf(ibuf, sizeof(ibuf) - 1, "%" PRIu64,
+		    (uint64_t)kmemsb.st_ino);
 		ibuf[sizeof(ibuf) - 1] = '\0';
 		if ((tmpdc.maj == kmemdc.maj)
 		&&  (tmpdc.min == kmemdc.min)
@@ -420,8 +420,8 @@ tstlsof(texec, tkmem, tproc)
 		    pem = cem;
 		    break;
 		}
-		(void) snprintf(ibuf, sizeof(ibuf) - 1, "%u",
-		    (unsigned int)lsofsb.st_ino);
+		(void) snprintf(ibuf, sizeof(ibuf) - 1, "%" PRIu64,
+		    (uint64_t)lsofsb.st_ino);
 		ibuf[sizeof(ibuf) - 1] = '\0';
 		if ((tmpdc.maj == lsofdc.maj)
 		&&  (tmpdc.min == lsofdc.min)

--- a/tests/LTdnlc.c
+++ b/tests/LTdnlc.c
@@ -186,7 +186,7 @@ main(argc, argv)
     }
     if ((em = ConvStatDev(&sb.st_dev, &cwddc)))
 	PrtMsgX(em, Pn, cleanup, 1);
-    (void) snprintf(ibuf, sizeof(ibuf) - 1, "%u", (unsigned int)sb.st_ino);
+    (void) snprintf(ibuf, sizeof(ibuf) - 1, "%" PRIu64, (uint64_t)sb.st_ino);
     ibuf[sizeof(ibuf) - 1] = '\0';
 /*
  * Loop ATTEMPT_CT times.

--- a/tests/LTnlink.c
+++ b/tests/LTnlink.c
@@ -209,7 +209,7 @@ print_file_error:
  */
     if ((em = ConvStatDev(&tfsb.st_dev, &tfdc)))
 	PrtMsgX(em, Pn, cleanup, 1);
-    (void) snprintf(ibuf, sizeof(ibuf) - 1, "%u", (unsigned int)tfsb.st_ino);
+    (void) snprintf(ibuf, sizeof(ibuf) - 1, "%" PRIu64, (uint64_t)tfsb.st_ino);
     ibuf[sizeof(szbuf) - 1] = '\0';
     (void) snprintf(xlnk, sizeof(xlnk) - 1, "%d", (int)tfsb.st_nlink);
     ibuf[sizeof(szbuf) - 1] = '\0';

--- a/tests/LTszoff.c
+++ b/tests/LTszoff.c
@@ -357,7 +357,7 @@ testlsof(tt, opt, xval)
  */
     if ((cem = ConvStatDev(&sb.st_dev, &stdc)))
 	PrtMsgX(buf, Pn, cleanup, 1);
-    (void) snprintf(ibuf, sizeof(ibuf) - 1, "%u", (unsigned int)sb.st_ino);
+    (void) snprintf(ibuf, sizeof(ibuf) - 1, "%" PRIu64, (uint64_t)sb.st_ino);
     ibuf[sizeof(ibuf) - 1] = '\0';
 /*
  * Complete the option vector and start lsof execution.

--- a/tests/LsofTest.h
+++ b/tests/LsofTest.h
@@ -75,6 +75,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <signal.h>
+#include <inttypes.h>
 
 #include <sys/types.h>
 


### PR DESCRIPTION
The way that test strings were formatted could lead to tests failing
when run with large inode-numbers (i >= 2^32). This is fixed by
formatting with uint64 values intead of unsigned ints.