### PR TITLE
Add the way to include (or exclude) all numbered file descriptors to …

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5055,5 +5055,18 @@ July 14, 2018
 		
 		[freebsd] update for r363214
 		- no user visible changes
+
+		Added the way to include (or exclude) all numbered file descriptors
+		in -d option. "fd" is a pseudo file descriptor name for the purpose.
+		See the following output on Linux; lsof doesn't print cwd, rtd, txt,
+		and mem files.
+
+		  # ./lsof -p $$ -a -d fd
+		  COMMAND    PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
+		  bash    866421 root    0u   CHR  136,1      0t0    4 /dev/pts/1
+		  bash    866421 root    1u   CHR  136,1      0t0    4 /dev/pts/1
+		  bash    866421 root    2u   CHR  136,1      0t0    4 /dev/pts/1
+		  bash    866421 root  255u   CHR  136,1      0t0    4 /dev/pts/1
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 May 8, 2019

--- a/Lsof.8
+++ b/Lsof.8
@@ -427,6 +427,10 @@ reports them as errors and exits with a non\-zero return code.
 See the description of File Descriptor (FD) output values in the
 .B OUTPUT
 section for more information on file descriptor names.
+.IP
+\fBfd\fP is a pseudo file descriptor name for specifying
+the whole range of possible file descriptor numbers.
+\fBfd\fP does not appear in FD column of output.
 .TP \w'names'u+4
 .BI +D " D"
 causes

--- a/arg.c
+++ b/arg.c
@@ -958,6 +958,12 @@ enter_fd_lst(nm, lo, hi, excl)
  */
 	f->hi = hi;
 	f->lo = lo;
+	if (f->nm && strcmp(f->nm, "fd") == 0) {
+	    (void) free((FREE_P *)f->nm);
+	    f->nm = NULL;
+	    f->hi = INT_MAX;
+	    f->lo = 0;
+	}
 	f->next = Fdl;
 	Fdl = f;
 	FdlTy = excl;

--- a/proc.c
+++ b/proc.c
@@ -388,8 +388,7 @@ ck_fd_status(nm, num)
 			return(1);
 		    continue;
 		}
-		if ((num >= fp->lo && num <= fp->hi)
-		    || (fp->nm && strcmp(fp->nm, "fd") == 0))
+		if (num >= fp->lo && num <= fp->hi)
 		    return(1);
 	    }
 	    return(0);
@@ -403,8 +402,7 @@ ck_fd_status(nm, num)
 		    return(2);
 		continue;
 	    }
-	    if ((num >= fp->lo && num <= fp->hi)
-		|| (fp->nm && strcmp(fp->nm, "fd") == 0))
+	    if (num >= fp->lo && num <= fp->hi)
 		return(2);
 	}
 	return(0);

--- a/proc.c
+++ b/proc.c
@@ -388,7 +388,8 @@ ck_fd_status(nm, num)
 			return(1);
 		    continue;
 		}
-		if (num >= fp->lo && num <= fp->hi)
+		if ((num >= fp->lo && num <= fp->hi)
+		    || (fp->nm && strcmp(fp->nm, "fd") == 0))
 		    return(1);
 	    }
 	    return(0);
@@ -402,7 +403,8 @@ ck_fd_status(nm, num)
 		    return(2);
 		continue;
 	    }
-	    if (num >= fp->lo && num <= fp->hi)
+	    if ((num >= fp->lo && num <= fp->hi)
+		|| (fp->nm && strcmp(fp->nm, "fd") == 0))
 		return(2);
 	}
 	return(0);

--- a/tests/case-20-fd-only-inclusion.bash
+++ b/tests/case-20-fd-only-inclusion.bash
@@ -1,0 +1,36 @@
+name=$(basename $0 .bash)
+lsof=$1
+report=$2
+
+echo "inclusion test" >> $report
+while read line; do
+    if [[ $line =~ ^f[^0-9].* ]]; then
+	echo "Unexpectedly, a named file descriptor is included: "
+	echo "${line}"
+	echo
+	echo "## whole output for debugging (-d fd -F fd): "
+	${lsof} -p $$ -a -d fd -F fd
+	echo "## whole output for debugging (-d fd): "
+	${lsof} -p $$ -a -d fd
+	echo "## whole output for debugging (no -d): "
+	${lsof} -p $$
+	exit 1
+    fi
+done < <(${lsof} -p $$ -a -d fd -F fd) >> $report
+
+echo "exclusion test" >> $report
+while read line; do
+    if [[ $line =~ ^f[0-9]+ ]]; then
+	echo "Unexpectedly, a numbered file descriptor is included: "
+	echo "${line}"
+	echo "## whole output for debugging (-d fd -F fd): "
+	${lsof} -p $$ -a -d '^fd' -F fd
+	echo "## whole output for debugging (-d ^fd): "
+	${lsof} -p $$ -a -d '^fd'
+	echo "## whole output for debugging (no -d): "
+	${lsof} -p $$
+	exit 1
+    fi
+done < <(${lsof} -p $$ -a -d "^fd" -F fd) >> $report
+
+exit 0


### PR DESCRIPTION
…-d option

"fd" is a pseudo file descriptor name for the purpose.
See the following output on Linux; lsof doesn't print cwd, rtd, txt, and mem files.

	  # ./lsof -p $$ -a -d fd
	  COMMAND    PID USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
	  bash    866421 root    0u   CHR  136,1      0t0    4 /dev/pts/1
	  bash    866421 root    1u   CHR  136,1      0t0    4 /dev/pts/1
	  bash    866421 root    2u   CHR  136,1      0t0    4 /dev/pts/1
	  bash    866421 root  255u   CHR  136,1      0t0    4 /dev/pts/1

Signed-off-by: Masatake YAMATO <yamato@redhat.com>