### PR TITLE
make test framework pass shellcheck

### DIFF
--- a/dialects/darwin/tests/case-00-darwin-hello.bash
+++ b/dialects/darwin/tests/case-00-darwin-hello.bash
@@ -1,1 +1,2 @@
+#!/intentionally/invalid/path/to/bash
 exit 0

--- a/dialects/freebsd/tests/case-00-freebsd-hello.bash
+++ b/dialects/freebsd/tests/case-00-freebsd-hello.bash
@@ -1,1 +1,2 @@
+#!/intentionally/invalid/path/to/bash
 exit 0

--- a/dialects/linux/tests/case-00-linux-hello.bash
+++ b/dialects/linux/tests/case-00-linux-hello.bash
@@ -1,10 +1,11 @@
+#!/intentionally/invalid/path/to/bash
 report=$2
 tdir=$3
 
-{
-    # This make invocaiton is needed to
-    # run test cases locally, not CI environment.
-    make -C $tdir || exit 1
-} > $report
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+# This make invocaiton is needed to
+# run test cases locally, not CI environment.
+make -C "$tdir" || exit 1
 
 exit 0

--- a/dialects/linux/tests/case-10-ux-socket-state.bash
+++ b/dialects/linux/tests/case-10-ux-socket-state.bash
@@ -1,74 +1,78 @@
-#!/bin/bash
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .bash)
+name=$( basename "$0" .bash )
 lsof=$1
 report=$2
 
-ux=/tmp/$name-$$.sock
-nc -l -U $ux > /dev/null < /dev/zero &
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+# shellcheck disable=SC1037
+tmp=/tmp/$name-$$-
+__cleanup() { rm -f -- "$tmp"* ; }
+trap __cleanup EXIT
+
+ux="$tmp"sock
+nc -l -U "$ux" > /dev/null < /dev/zero &
 server=$!
 
 killBoth()
 {
-    kill -9 $1
-    sleep 1
-    kill -9 $2
+    kill -9 "$1"
+    wait "$1"
+    kill -9 "$2"
+    wait "$2"
 } 2> /dev/null > /dev/null
 
 waitForSyscall()
 {
     local pid=$1
     local pat=$2
-    local niterations=$3
+    local niterations=$3    # TODO "seq 0 $niterations" seems broken, but we've replicated it anyway
     local i
 
-    for i in $(seq 0 $niterations); do
+    for (( i=0 ; i<=niterations; ++i)); do
 	sleep 1
-	if grep -q "$pat" /proc/$pid/stack; then
+	if grep -q "$pat" "/proc/$pid/stack" ; then
 	    break
 	fi
     done
 }
 
-waitForSyscall $server 'select\|poll' 10
+waitForSyscall "$server" 'select\|poll' 10
 
-fserver=/tmp/${name}-server-$$-before
-$lsof -n -Ts -P -U -a -p $server > $fserver
+fserver="$tmp"server-before
+"$lsof" -n -Ts -P -U -a -p "$server" > "$fserver"
 # nc        22512 yamato    3u  unix 0x000000008f6993b8      0t0     470697 /tmp/a type=STREAM (LISTEN)
-if ! cat $fserver | grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM (LISTEN)"; then
-    echo "failed in server side (before connecting)" >> $report
-    cat $fserver >> $report
-    kill -9 $server
-    rm $ux
+if ! grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM (LISTEN)" < "$fserver" ; then
+    echo "failed in server side (before connecting)"
+    cat "$fserver"
+    kill -9 "$server"
     exit 1
 fi
 
-nc -U $ux < /dev/zero  > /dev/null &
+nc -U "$ux" < /dev/zero > /dev/null &
 client=$!
 sleep 1
-fserver=/tmp/${name}-server-$$-after
-$lsof -n -Ts -P -U -a -p $server > $fserver
+fserver="$tmp"server-after
+"$lsof" -n -Ts -P -U -a -p "$server" > "$fserver"
 # nc      22512 yamato    4u  unix 0x00000000deffde05      0t0 472699 /tmp/a type=STREAM (CONNECTED)
-if ! cat $fserver | grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM (CONNECTED)"; then
-    echo "failed in server side (after connecting)" >> $report
-    cat $fserver >> $report
-    killBoth $client $server
-    rm $ux
+if ! grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM (CONNECTED)" < "$fserver" ; then
+    echo "failed in server side (after connecting)"
+    cat "$fserver"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-fclient=/tmp/${name}-client-$$
-$lsof -n -Ts -P -U -a -p $client -FT | grep ^TST > $fclient
+fclient="$tmp"client
+"$lsof" -n -Ts -P -U -a -p "$client" -FT | grep ^TST > "$fclient"
 # TST=CONNECTED
-if ! cat $fclient | grep -q "^TST=CONNECTED"; then
-    echo "failed in client side" >> $report
-    cat $fclient >> $report
-    killBoth $client $server
-    rm $ux
+if ! grep -q "^TST=CONNECTED" < "$fclient" ; then
+    echo "failed in client side"
+    cat "$fclient"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-killBoth $client $server
-rm $ux
+killBoth "$client" "$server"
 
 exit 0

--- a/dialects/linux/tests/case-20-eventfd-endpoint.bash
+++ b/dialects/linux/tests/case-20-eventfd-endpoint.bash
@@ -1,83 +1,83 @@
-name=$(basename $0 .bash)
+#!/intentionally/invalid/path/to/bash
+
+# name=$( basename "$0" .bash ) <= IGNORED
 lsof=$1
 report=$2
 tdir=$3
 
-uname -r >> $report
-uname -r | sed -ne 's/^\([0-9]\+\)\.\([0-9]\+\)\.\([0-9]\+\).*/\1 \2/p' | {
-    read major minor
-    if [ "$major" -lt 5 ]; then
-	echo "eventfd endpoint features doesn't work on Linux $major"
-	exit 2
-    fi
-    if [ "$major" -eq 5 -a "$minor" -lt 2 ]; then
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+uname -r | {
+    if  IFS=. read -r major minor _ &&
+        (( major * 1000 + minor < 5002 ))
+    then
 	echo "event endpoint features doesn't work on Linux $major.$minor"
 	exit 2
     fi
-} >> $report
-s=$?
-if ! [ $s = 0 ]; then
-    exit $s
-fi
+}
 
-TARGET=$tdir/eventfd
-if ! [ -x $TARGET ]; then
-    echo "target executable ( $TARGET ) is not found" >> $report
+target=$tdir/eventfd
+if [[ ! -x $target ]]; then
+    echo "target executable ($target) is not found"
     exit 1
 fi
 
-{ $TARGET & } | {
-    read parent child fd
+{ "$target" & } | {
+    if ! read -r parent child fd ; then
+        echo "no output from target ($target)"
+        exit 1
+    fi
+
     if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fd" ]; then
-	echo "unexpected output form target ( $TARGET )" >> $report
+	echo "unexpected output from target ($target)"
 	exit 1
     fi
     {
-	echo parent: $parent
-	echo child: $child
-	echo fd: $fd
-	echo cmdline: "$lsof +E -p "$parent""
+	echo "parent: $parent"
+	echo "child: $child"
+	echo "fd: $fd"
+	echo "cmdline: '$lsof' +E -p '$parent'"
 	echo
 	echo PARENT
 	echo
-	$lsof +E -p "$parent"
+	"$lsof" +E -p "$parent"
 	echo
 	echo CHILD
 	echo
-	$lsof +E -p "$child"
-    } >> $report
+	"$lsof" +E -p "$child"
+    }
     {
 	{
 	    echo From the parent side
 	    # eventfd 23685 yamato    3u  a_inode   0,13        0    11217 [eventfd:29] 23686,eventfd,3u
-	    echo expected pattern: "eventfd *${parent} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${child},eventfd,${fd}u"
-	    $lsof +E -p "$parent" |
-		grep -q "eventfd *${parent} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${child},eventfd,${fd}u"
+	    echo expected pattern: "eventfd *$parent .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$child,eventfd,${fd}u"
+	    "$lsof" +E -p "$parent" |
+		grep -q "eventfd *$parent .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$child,eventfd,${fd}u"
 	} && {
 	    echo From the parent side
 	    # eventfd 23686 yamato    3u  a_inode   0,13        0    11217 [eventfd:29] 23685,eventfd,3u
-	    echo expected pattern: "eventfd *${child} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${parent},eventfd,${fd}u"
-	    $lsof +E -p "$parent" |
-		grep -q "eventfd *${child} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${parent},eventfd,${fd}u"
+	    echo expected pattern: "eventfd *$child .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$parent,eventfd,${fd}u"
+	    "$lsof" +E -p "$parent" |
+		grep -q "eventfd *$child .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$parent,eventfd,${fd}u"
 
 	} && {
 	    echo From the child side
 	    # eventfd 23685 yamato    3u  a_inode   0,13        0    11217 [eventfd:29] 23686,eventfd,3u
-	    echo expected pattern: "eventfd *${parent} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${child},eventfd,${fd}u"
-	    $lsof +E -p "$parent" |
-		grep -q  "eventfd *${parent} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${child},eventfd,${fd}u"
+	    echo expected pattern: "eventfd *$parent .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$child,eventfd,${fd}u"
+	    "$lsof" +E -p "$parent" |
+		grep -q  "eventfd *$parent .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$child,eventfd,${fd}u"
 	} && {
 	    echo From the child side
 	    # eventfd 23686 yamato    3u  a_inode   0,13        0    11217 [eventfd:29] 23685,eventfd,3u
-	    echo expected pattern: "eventfd *${child} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${parent},eventfd,${fd}u"
-	    $lsof +E -p "$parent" |
-		grep -q  "eventfd *${child} .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *${parent},eventfd,${fd}u"
+	    echo expected pattern: "eventfd *$child .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$parent,eventfd,${fd}u"
+	    "$lsof" +E -p "$parent" |
+		grep -q  "eventfd *$child .* ${fd}u *a_inode .* \[eventfd:[0-9]*\] *$parent,eventfd,${fd}u"
 
 	} && {
 	    kill "$child"
 	    exit 0
 	}
-    } >> $report
+    }
     kill "$child"
     exit 1
 }

--- a/dialects/linux/tests/case-20-inet-socket-endpoint.bash
+++ b/dialects/linux/tests/case-20-inet-socket-endpoint.bash
@@ -1,8 +1,10 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .bash)
+name=$( basename "$0" .bash )
 lsof=$1
 report=$2
+
+[[ -n $report && $report != - ]] && exec >> "$report"
 
 nc -l -4 127.0.0.1 10000 > /dev/null < /dev/zero &
 server=$!
@@ -14,29 +16,30 @@ sleep 1
 
 killBoth()
 {
-    kill -9 $1
-    sleep 1
-    kill -9 $2
+    kill -9 "$1"
+    wait "$1"
+    kill -9 "$2"
+    wait "$2"
 } 2> /dev/null > /dev/null
 
-fclient=/tmp/${name}-client-$$
-$lsof -n -E -P -p $client > $fclient
-if ! cat $fclient | grep -q "TCP 127.0.0.2:9999->127.0.0.1:10000 $server,nc,[0-9]\+u (ESTABLISHED)"; then
-    echo "failed in client side" >> $report
-    cat $fclient >> $report
-    killBoth $client $server
+fclient=/tmp/$name-client-$$
+"$lsof" -n -E -P -p "$client" > "$fclient"
+if ! grep -q "TCP 127.0.0.2:9999->127.0.0.1:10000 $server,nc,[0-9]\+u (ESTABLISHED)" < "$fclient" ; then
+    echo "failed in client side"
+    cat "$fclient"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-fserver=/tmp/${name}-server-$$
-$lsof -n -E -P -p $server > $fserver
-if ! cat $fserver | grep -q "TCP 127.0.0.1:10000->127.0.0.2:9999\+ $client,nc,[0-9]\+u (ESTABLISHED)"; then
-    echo "failed in server side" >> $report
-    cat $fserver >> $report
-    killBoth $client $server
+fserver=/tmp/$name-server-$$
+"$lsof" -n -E -P -p "$server" > "$fserver"
+if ! grep -q "TCP 127.0.0.1:10000->127.0.0.2:9999\+ $client,nc,[0-9]\+u (ESTABLISHED)" < "$fserver" ; then
+    echo "failed in server side"
+    cat "$fserver"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-killBoth $client $server
+killBoth "$client" "$server"
 
 exit 0

--- a/dialects/linux/tests/case-20-inet6-socket-endpoint.bash
+++ b/dialects/linux/tests/case-20-inet6-socket-endpoint.bash
@@ -1,18 +1,20 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .bash)
+name=$( basename "$0" .bash )
 lsof=$1
 report=$2
 
-nc -l -6 ::1 10000 > /dev/null < /dev/zero 2>> $report &
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+nc -l -6 ::1 10000 2>&1 > /dev/null < /dev/zero &
 server=$!
 sleep 1
-nc -6 -s ::1 -p 9999 ::1 10000 < /dev/zero  > /dev/null 2>> $report &
+nc -6 -s ::1 -p 9999 ::1 10000 < /dev/zero 2>&1 > /dev/null &
 client=$!
 sleep 1
 
-if ! kill -0 $server 2>/dev/null; then
-    echo "Maybe ipv6 stack is not available on this system" >> $report
+if ! kill -0 "$server" 2>/dev/null; then
+    echo "Maybe ipv6 stack is not available on this system"
     exit 2
 fi
 
@@ -20,29 +22,30 @@ sleep 1
 
 killBoth()
 {
-    kill -9 $1
-    sleep 1
-    kill -9 $2
+    kill -9 "$1"
+    wait "$1"
+    kill -9 "$2"
+    wait "$2"
 } 2> /dev/null > /dev/null
 
-fclient=/tmp/${name}-client-$$
-$lsof -n -E -P -p $client > $fclient
-if ! cat $fclient | grep -q "TCP \[::1\]:9999->\[::1\]:10000 $server,nc,[0-9]\+u (ESTABLISHED)"; then
-    echo "failed in client side" >> $report
-    cat $fclient >> $report
-    killBoth $client $server
+fclient=/tmp/$name-client-$$
+"$lsof" -n -E -P -p "$client" > "$fclient"
+if ! grep -q "TCP \[::1\]:9999->\[::1\]:10000 $server,nc,[0-9]\+u (ESTABLISHED)" < "$fclient" ; then
+    echo "failed in client side"
+    cat "$fclient"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-fserver=/tmp/${name}-server-$$
-$lsof -n -E -P -p $server > $fserver
-if ! cat $fserver | grep -q "TCP \[::1\]:10000->\[::1\]:9999\+ $client,nc,[0-9]\+u (ESTABLISHED)"; then
-    echo "failed in server side" >> $report
-    cat $fserver >> $report
-    killBoth $client $server
+fserver=/tmp/$name-server-$$
+"$lsof" -n -E -P -p "$server" > "$fserver"
+if ! grep -q "TCP \[::1\]:10000->\[::1\]:9999\+ $client,nc,[0-9]\+u (ESTABLISHED)" < "$fserver" ; then
+    echo "failed in server side"
+    cat "$fserver"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-killBoth $client $server
+killBoth "$client" "$server"
 
 exit 0

--- a/dialects/linux/tests/case-20-mqueue-endpoint.bash
+++ b/dialects/linux/tests/case-20-mqueue-endpoint.bash
@@ -1,26 +1,28 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .bash)
+name=$( basename "$0" .bash )
 lsof=$1
 report=$2
 tdir=$3
 
+[[ -n $report && $report != - ]] && exec >> "$report"
+
 MQUEUE_MNTPOINT=/tmp/$$
 
-TARGET=$tdir/mq_fork
-if ! [ -x $TARGET ]; then
-    echo "target executable ( $TARGET ) is not found" >> $report
+target=$tdir/mq_fork
+if [[ ! -x $target ]] ; then
+    echo "target executable ($target) is not found"
     exit 1
 fi
 
 if grep -q mqueue /proc/mounts; then
     :
-elif ! [ $(id -u) = 0 ]; then
-    echo "root privileged is needed to run $(basename $0. sh)" >> $report
+elif (( UID != 0 )); then
+    echo "root privileged is needed to run $0"
     exit 2
 else
-    mkdir -p ${MQUEUE_MNTPOINT}
-    if ! mount -t mqueue none ${MQUEUE_MNTPOINT}; then
+    mkdir -p $MQUEUE_MNTPOINT
+    if ! mount -t mqueue none $MQUEUE_MNTPOINT; then
 	echo "failed to mount mqeueu file system"
 	exit 2
     fi
@@ -28,66 +30,65 @@ fi
 
 umount_mqueue()
 {
-    if [ -d ${MQUEUE_MNTPOINT} ]; then
-	umount ${MQUEUE_MNTPOINT}
-	rmdir ${MQUEUE_MNTPOINT}
+    if [ -d $MQUEUE_MNTPOINT ]; then
+	umount $MQUEUE_MNTPOINT
+	rmdir $MQUEUE_MNTPOINT
     fi
 }
 
 mqname=/lsof-$name-$$
-{ $TARGET $mqname & } | {
+{ "$target" "$mqname" & } | {
     read parent child fd
     if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fd" ]; then
-	echo "unexpected output form target ( $TARGET )" >> $report
+	echo "unexpected output form target ( $TARGET )"
 	umount_mqueue
 	exit 1
     fi
+
+    echo mqname: "$mqname"
+    echo parent: "$parent"
+    echo child:  "$child"
+    echo fd:    "$fd"
+    echo cmdline: "$lsof" +E -p "$parent"
+    echo
+    echo PARENT
+    echo
+    "$lsof" +E -p "$parent"
+    echo
+    echo CHILD
+    echo
+    "$lsof" +E -p "$child"
+
     {
-	echo mqname: $mqname
-	echo parent: $parent
-	echo child:  $child
-	echo fd:    $fd
-	echo cmdline: "$lsof +E -p "$parent""
-	echo
-	echo PARENT
-	echo
-	$lsof +E -p "$parent"
-	echo
-	echo CHILD
-	echo
-	$lsof +E -p "$child"
-    } >> $report
-    {
-	{
-	    echo From the parent side
-	    # mq_fork 18020 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18021,mq_fork,3u
-	    echo expected pattern: "mq_fork *$parent .* ${fd}u *PSXMQ .* $mqname $child,mq_fork,${fd}u"
-	    $lsof +E -p "$parent" |
-		grep -q "mq_fork *${parent} .* ${fd}u *PSXMQ .* ${mqname} ${child},mq_fork,${fd}u"
-	} && {
-	    echo From the parent side
-	    # mq_fork 18021 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18020,mq_fork,3u
-	    echo expected pattern: "mq_fork *$child .* ${fd}u *PSXMQ .* $mqname $parent,mq_fork,${fd}u"
-	    $lsof +E -p "$parent" |
-		grep -q "mq_fork *${child} .* ${fd}u *PSXMQ .* ${mqname} ${parent},mq_fork,${fd}u"
-	} && {
-	    echo From the child side
-	    # mq_fork 18021 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18020,mq_fork,3u
-	    echo expected pattern: "mq_fork *$child .* ${fd}u *PSXMQ .* $mqname $parent,mq_fork,${fd}u"
-	    $lsof +E -p "$child" |
-		grep -q "mq_fork *${child} .* ${fd}u *PSXMQ .* ${mqname} ${parent},mq_fork,${fd}u"
-	} && {
-	    echo From the child side
-	    # mq_fork 18020 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18021,mq_fork,3u
-	    echo expected pattern: "mq_fork *$parent .* ${fd}u *PSXMQ .* $mqname $child,mq_fork,${fd}u"
-	    $lsof +E -p "$child" |
-		grep -q "mq_fork *${parent} .* ${fd}u *PSXMQ .* ${mqname} ${child},mq_fork,${fd}u"
-	} && {
-	    kill "$child"
-	    umount_mqueue
-	    exit 0
-	}
-    } >> $report
+        echo From the parent side
+        # mq_fork 18020 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18021,mq_fork,3u
+        echo expected pattern: "mq_fork *$parent .* $fd""u *PSXMQ .* $mqname $child,mq_fork,$fd""u"
+        "$lsof" +E -p "$parent" |
+            grep -q "mq_fork *$parent .* $fd""u *PSXMQ .* $mqname $child,mq_fork,$fd""u"
+    } && {
+        echo From the parent side
+        # mq_fork 18021 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18020,mq_fork,3u
+        echo expected pattern: "mq_fork *$child .* $fd""u *PSXMQ .* $mqname $parent,mq_fork,$fd""u"
+        "$lsof" +E -p "$parent" |
+            grep -q "mq_fork *$child .* $fd""u *PSXMQ .* $mqname $parent,mq_fork,$fd""u"
+    } && {
+        echo From the child side
+        # mq_fork 18021 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18020,mq_fork,3u
+        echo expected pattern: "mq_fork *$child .* $fd""u *PSXMQ .* $mqname $parent,mq_fork,$fd""u"
+        "$lsof" +E -p "$child" |
+            grep -q "mq_fork *$child .* $fd""u *PSXMQ .* $mqname $parent,mq_fork,$fd""u"
+    } && {
+        echo From the child side
+        # mq_fork 18020 yamato    3u  PSXMQ   0,18       80     622461 /xxx 18021,mq_fork,3u
+        echo expected pattern: "mq_fork *$parent .* $fd""u *PSXMQ .* $mqname $child,mq_fork,$fd""u"
+        "$lsof" +E -p "$child" |
+            grep -q "mq_fork *$parent .* $fd""u *PSXMQ .* $mqname $child,mq_fork,$fd""u"
+    } && {
+        kill "$child"
+        umount_mqueue
+        exit 0
+    }
+
     kill "$child"
     umount_mqueue
     exit 1

--- a/dialects/linux/tests/case-20-open-flags-cx.bash
+++ b/dialects/linux/tests/case-20-open-flags-cx.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/intentionally/invalid/path/to/bash
 
 pat=".*DIR[ \t]\+.*CX.*[ \t]\+.*/tmp$"
-source $3/util-open-flags.bash "$@" "$pat" /tmp cx
+source "$3"/util-open-flags.bash "$@" "$pat" /tmp cx

--- a/dialects/linux/tests/case-20-open-flags-path.bash
+++ b/dialects/linux/tests/case-20-open-flags-path.bash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
 pat=".*DIR[ \t]\+.*PATH.*[ \t]\+.*/tmp$"
-source $3/util-open-flags.bash "$@" "$pat" /tmp path
+source "$3"/util-open-flags.bash "$@" "$pat" /tmp path

--- a/dialects/linux/tests/case-20-open-flags-tmpf.bash
+++ b/dialects/linux/tests/case-20-open-flags-tmpf.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/intentionally/invalid/path/to/bash
 
 pat=".*REG[ \t]\+.*TMPF.*/tmp/.*$"
-source $3/util-open-flags.bash "$@" "$pat" /tmp tmpf rdwr
+source "$3"/util-open-flags.bash "$@" "$pat" /tmp tmpf rdwr

--- a/dialects/linux/tests/case-20-pipe-endpoint.bash
+++ b/dialects/linux/tests/case-20-pipe-endpoint.bash
@@ -1,43 +1,44 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .bash)
+#name=$( basename "$0" .bash )  <= IGNORED
 lsof=$1
 report=$2
 tdir=$3
 
-TARGET=$tdir/pipe
-if ! [ -x $TARGET ]; then
-    echo "target executable ( $TARGET ) is not found" >> $report
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+target=$tdir/pipe
+if [[ ! -x $target ]] ; then
+    echo "target executable ($target) is not found"
     exit 1
 fi
 
-{ ./$TARGET & } | {
+{ "$target" & } | {
     read parent child fdr fdw;
     if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fdr" ] || [ -z "$fdw" ]; then
-	echo "unexpected output form target ( $TARGET )" >> $report
+	echo "unexpected output form target ($target)"
 	exit 1
     fi
-    echo parent: $parent >> $report
-    echo child:  $child >> $report
-    echo fdr:    $fdr >> $report
-    echo fdw:    $fdw >> $report
-    echo cmdline: "$lsof +E -p "$parent"" >> $report
-    $lsof +E -p "$parent" >> $report
+    echo parent: "$parent"
+    echo child:  "$child"
+    echo fdr:    "$fdr"
+    echo fdw:    "$fdw"
+    echo cmdline: "$lsof" +E -p "$parent"
+    "$lsof" +E -p "$parent"
 
     {
-	{
-	    echo expected pattern: ".* $parent .* ${fdr}r *FIFO .* pipe ${child},p[-a-z]*,${fdw}w"
-	    $lsof +E -p "$parent" |
-		grep -q ".* $parent .* ${fdr}r *FIFO .* pipe ${child},p[-a-z]*,${fdw}w"
-	} && {
-	    echo expected parent: ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r"
-	    $lsof +E -p "$parent" |
-		grep -q ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r"
-	} && {
-	    kill "$child"
-	    exit 0
-	}
-    } >> $report
+        echo expected pattern: ".* $parent .* ${fdr}r *FIFO .* pipe $child,p[-a-z]*,${fdw}w"
+        "$lsof" +E -p "$parent" |
+            grep -q ".* $parent .* ${fdr}r *FIFO .* pipe $child,p[-a-z]*,${fdw}w"
+    } && {
+        echo expected parent: ".* $child .* ${fdw}w *FIFO .* pipe $parent,p[-a-z]*,${fdr}r"
+        "$lsof" +E -p "$parent" |
+            grep -q ".* $child .* ${fdw}w *FIFO .* pipe $parent,p[-a-z]*,${fdr}r"
+    } && {
+        kill "$child"
+        exit 0
+    }
+
     kill "$child"
     exit 1
 }

--- a/dialects/linux/tests/case-20-pipe-no-close-endpoint.bash
+++ b/dialects/linux/tests/case-20-pipe-no-close-endpoint.bash
@@ -1,55 +1,56 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .bash)
+# name=$( basename "$0" .bash ) <= IGNORED
 lsof=$1
 report=$2
 tdir=$3
 
-TARGET=$tdir/pipe
-if ! [ -x $TARGET ]; then
-    echo "target executable ( $TARGET ) is not found" >> $report
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+target=$tdir/pipe
+if [[ ! -x $target ]] ; then
+    echo "target executable ($target) is not found"
     exit 1
 fi
 
-{ ./$TARGET no-close & } | {
+{ "$target" no-close & } | {
     read parent child fdr fdw;
     if [ -z "$parent" ] || [ -z "$child" ] || [ -z "$fdr" ] || [ -z "$fdw" ]; then
-	echo "unexpected output form target ( $TARGET )" >> $report
+	echo "unexpected output form target ($target)"
 	exit 1
     fi
-    echo parent: $parent >> $report
-    echo child:  $child >> $report
-    echo fdr:    $fdr >> $report
-    echo fdw:    $fdw >> $report
-    echo cmdline: "$lsof +E -p "$parent"" >> $report
-    $lsof +E -p "$parent" >> $report
+    echo parent: "$parent"
+    echo child:  "$child"
+    echo fdr:    "$fdr"
+    echo fdw:    "$fdw"
+    echo cmdline: "$lsof" +E -p "$parent"
+    "$lsof" +E -p "$parent"
 
     {
-	{
-	    # pipe-no-c 25113 yamato    3r  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,4w 25114,pipe-no-c,3r 25114,pipe-no-c,4w
-	    echo expected pattern: ".* $parent .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
-	    $lsof +E -p "$parent" |
-		grep -q ".* $parent .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
-	} && {
-	    # pipe-no-c 25113 yamato    4w  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25114,pipe-no-c,3r 25114,pipe-no-c,4w
-	    echo expected pattern: ".* $parent .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
-	    $lsof +E -p "$parent" |
-		grep -q ".* $parent .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdr}r ${child},p[-a-z]*,${fdw}w"
-	} && {
-	    # pipe-no-c 25114 yamato    3r  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25113,pipe-no-c,4w 25114,pipe-no-c,4w
-	    echo expected pattern: ".* $child .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdw}w"
-	    $lsof +E -p "$parent" |
-		grep -q ".* $child .* ${fdr}r *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdw}w"
-	} && {
-	    # pipe-no-c 25114 yamato    4w  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25113,pipe-no-c,4w 25114,pipe-no-c,3r
-	    echo expected parent: ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r"
-	    $lsof +E -p "$parent" |
-		grep -q ".* $child .* ${fdw}w *FIFO .* pipe ${parent},p[-a-z]*,${fdr}r ${parent},p[-a-z]*,${fdw}w ${child},p[-a-z]*,${fdr}r"
-	} && {
-	    kill $child
-	    exit 0
-	}
-    } >> $report
-    kill $child
+        # pipe-no-c 25113 yamato    3r  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,4w 25114,pipe-no-c,3r 25114,pipe-no-c,4w
+        echo expected pattern: ".* $parent .* ${fdr}r *FIFO .* pipe $parent,p[-a-z]*,${fdw}w $child,p[-a-z]*,${fdr}r $child,p[-a-z]*,${fdw}w"
+        "$lsof" +E -p "$parent" |
+            grep -q ".* $parent .* ${fdr}r *FIFO .* pipe $parent,p[-a-z]*,${fdw}w $child,p[-a-z]*,${fdr}r $child,p[-a-z]*,${fdw}w"
+    } && {
+        # pipe-no-c 25113 yamato    4w  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25114,pipe-no-c,3r 25114,pipe-no-c,4w
+        echo expected pattern: ".* $parent .* ${fdw}w *FIFO .* pipe $parent,p[-a-z]*,${fdr}r $child,p[-a-z]*,${fdr}r $child,p[-a-z]*,${fdw}w"
+        "$lsof" +E -p "$parent" |
+            grep -q ".* $parent .* ${fdw}w *FIFO .* pipe $parent,p[-a-z]*,${fdr}r $child,p[-a-z]*,${fdr}r $child,p[-a-z]*,${fdw}w"
+    } && {
+        # pipe-no-c 25114 yamato    3r  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25113,pipe-no-c,4w 25114,pipe-no-c,4w
+        echo expected pattern: ".* $child .* ${fdr}r *FIFO .* pipe $parent,p[-a-z]*,${fdr}r $parent,p[-a-z]*,${fdw}w $child,p[-a-z]*,${fdw}w"
+        "$lsof" +E -p "$parent" |
+            grep -q ".* $child .* ${fdr}r *FIFO .* pipe $parent,p[-a-z]*,${fdr}r $parent,p[-a-z]*,${fdw}w $child,p[-a-z]*,${fdw}w"
+    } && {
+        # pipe-no-c 25114 yamato    4w  FIFO   0,12      0t0     616532 pipe 25113,pipe-no-c,3r 25113,pipe-no-c,4w 25114,pipe-no-c,3r
+        echo expected parent: ".* $child .* ${fdw}w *FIFO .* pipe $parent,p[-a-z]*,${fdr}r $parent,p[-a-z]*,${fdw}w $child,p[-a-z]*,${fdr}r"
+        "$lsof" +E -p "$parent" |
+            grep -q ".* $child .* ${fdw}w *FIFO .* pipe $parent,p[-a-z]*,${fdr}r $parent,p[-a-z]*,${fdw}w $child,p[-a-z]*,${fdr}r"
+    } && {
+        kill "$child"
+        exit 0
+    }
+
+    kill "$child"
     exit 1
 }

--- a/dialects/linux/tests/case-20-ux-socket-endpoint-unaccepted.bash
+++ b/dialects/linux/tests/case-20-ux-socket-endpoint-unaccepted.bash
@@ -1,13 +1,22 @@
-#!/bin/sh
+#!/intentionally/invalid/path/to/bash
 
-name=$(basename $0 .sh)
+name=$( basename "$0" .bash )
 lsof=$1
 report=$2
 tdir=$3
 
-TARGET=$tdir/ux
+[[ -n $report && $report != - ]] && exec >> "$report"
 
-$TARGET | {
+# shellcheck disable=SC1037
+tmp=/tmp/$name-$$-
+__cleanup() { rm -f -- "$tmp"* ; }
+trap __cleanup EXIT
+
+out="$tmp"out
+
+target=$tdir/ux
+
+"$target" | {
     #
     # An example of expect output:
     #
@@ -19,65 +28,62 @@ $TARGET | {
     # accept=5
     # path=/tmp/lsof-test-ux-1451659.s
     # end
-    echo "target output:" >> $report
-    while read k v; do
-	if [[ $k = end ]]; then
+    echo "target output:"
+    while read k v ; do
+	if [[ $k = end ]] ; then
 	    break;
+            # If we didn't stop now, we'd stall on EOF
 	fi
-	echo "$k=$v" >> $report
-	eval "$k=$v"
+	echo "$k=$v"
+	eval "$k=\$v"
     done
     #
     # An exapmle of lsof output:
     #
     # COMMAND     PID USER   FD   TYPE             DEVICE SIZE/OFF     NODE NAME
     # ux      1445917  jet    3u  unix 0x000000002d21092b      0t0 75849115 /tmp/lsof-test-ux-1445917.s type=STREAM ->INO=75843930 1445919,ux,5u
-    listen_sock_pat="^ux \+${ppid} \+.* \+${listen}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+${path} \+type=STREAM ->INO=[0-9]\+ \+${pid},ux,${connect2}u"'$'
+    listen_sock_pat="^ux \+$ppid \+.* \+${listen}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+$path \+type=STREAM ->INO=[0-9]\+ \+$pid,ux,${connect2}u"'$'
     # ux      1445917  jet    5u  unix 0x00000000335230a5      0t0 75849117 /tmp/lsof-test-ux-1445917.s type=STREAM ->INO=75843929 1445919,ux,4u
-    accepted_sock_pat="^ux \+${ppid} \+.* \+${accept}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+${path} \+type=STREAM ->INO=[0-9]\+ \+${pid},ux,${connect}u"'$'
+    accepted_sock_pat="^ux \+$ppid \+.* \+${accept}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+$path \+type=STREAM ->INO=[0-9]\+ \+$pid,ux,${connect}u"'$'
     # ux      1445919  jet    4u  unix 0x00000000627d8ccc      0t0 75843929 type=STREAM ->INO=75849117 1445917,ux,5u
-    client_sock_pat="^ux \+${pid} \+.* \+${connect}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+type=STREAM ->INO=[0-9]\+ \+${ppid},ux,${accept}u"'$'
+    client_sock_pat="^ux \+$pid \+.* \+${connect}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+type=STREAM ->INO=[0-9]\+ \+$ppid,ux,${accept}u"'$'
     # ux      1445919  jet    5u  unix 0x00000000cc000ead      0t0 75843930 type=STREAM
-    client2_sock_pat="^ux \+${pid} \+.* \+${connect2}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+type=STREAM"'$'
+    client2_sock_pat="^ux \+$pid \+.* \+${connect2}u \+unix \+0x[0-9a-f]\+ \+0t0 \+[0-9]\+ \+type=STREAM"'$'
     # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     # The last line reflects what unix-diagnose netlink socket reports. The counter part just queued in the listen socket,
     # and is not accepted yet.
     #
-    out=/tmp/${name}-$$
-    if $lsof +E $path > $out; then
-	kill -CONT $ppid
-	if [[ $(wc -l < $out) != $(( 1 + 4 )) ]]; then
-	    echo "Too many file descriptors are found (the expection is 4 but got $(wc -l < $out)):" >> $report
-	    cat $out >> $report
-	    rm $out
+
+    if "$lsof" +E "$path" > "$out" ; then
+	kill -CONT "$ppid"
+        num=$( wc -l < "$out" )
+	if (( num != 1+4 )) ; then
+	    printf 'Too many file descriptors are found (expected %u but got %u):\n' 4 "$num"
+	    cat "$out"
 	    exit 1
-	elif ! grep -q "$listen_sock_pat" < $out; then
-	    echo "don't match the pattern for listen socket" >> $report
-	    echo "expected pattern: $listen_sock_pat" >> $report
-	    cat $out >> $report
-	    rm $out
+	elif ! grep -q "$listen_sock_pat" < "$out" ; then
+	    printf "Doesn't match the pattern for listen socket\n"
+	    printf "expected pattern: %s\n" "$listen_sock_pat"
+	    cat "$out"
 	    exit 1
-	elif ! grep -q "$accepted_sock_pat" < $out; then
-	    echo "don't match the pattern for accepted socket" >> $report
-	    echo "expected pattern: $accepted_sock_pat" >> $report
-	    cat $out >> $report
-	    rm $out
+	elif ! grep -q "$accepted_sock_pat" < "$out" ; then
+	    printf "Doesn't match the pattern for accepted socket\n"
+	    printf "expected pattern: %s\n" "$accepted_sock_pat"
+	    cat "$out"
 	    exit 1
-	elif ! grep -q "$client_sock_pat" < $out; then
-	    echo "don't match the pattern for the 1st client socket" >> $report
-	    echo "expected pattern: $client_sock_pat" >> $report
-	    cat $out >> $report
-	    rm $out
+	elif ! grep -q "$client_sock_pat" < "$out" ; then
+	    printf "Doesn't match the pattern for the 1st client socket\n"
+	    printf "expected pattern: %s\n" "$client_sock_pat"
+	    cat "$out"
 	    exit 1
-	elif ! grep -q "$client2_sock_pat" < $out; then
-	    echo "don't match the pattern for the 2nd client socket" >> $report
-	    echo "expected pattern: $client2_sock_pat" >> $report
-	    cat $out >> $report
-	    rm $out
+	elif ! grep -q "$client2_sock_pat" < "$out" ; then
+	    printf "Doesn't match the pattern for the 2nd client socket\n"
+	    printf "expected pattern: %s\n" "$client2_sock_pat"
+	    cat "$out"
 	    exit 1
 	fi
     else
-	echo "failed to run lsof: $?" >> $report
+	echo "failed to run $lsof: $?"
 	exit 1
     fi
 }

--- a/dialects/linux/tests/case-20-ux-socket-endpoint.bash
+++ b/dialects/linux/tests/case-20-ux-socket-endpoint.bash
@@ -1,41 +1,44 @@
-name=$(basename $0 .bash)
+#!/intentionally/invalid/path/to/bash
+
+name=$( basename "$0" .bash )
 lsof=$1
 report=$2
 
 ux=/tmp/$name-$$.sock
-nc -l -U $ux > /dev/null < /dev/zero &
+nc -l -U "$ux" > /dev/null < /dev/zero &
 server=$!
 sleep 1
-nc -U $ux < /dev/zero  > /dev/null &
+nc -U "$ux" < /dev/zero  > /dev/null &
 client=$!
 
 sleep 1
 
 killBoth()
 {
-    kill -9 $1
-    sleep 1
-    kill -9 $2
+    kill -9 "$1"
+    wait "$1"
+    kill -9 "$2"
+    wait "$2"
 } 2> /dev/null > /dev/null
 
-fclient=/tmp/${name}-client-$$
-$lsof -n -E -P -p $client > $fclient
-if ! cat $fclient | grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ type=STREAM ->INO=[0-9]\+ $server,nc,[0-9]\+u"; then
-    echo "failed in client side" >> $report
-    cat $fclient >> $report
-    killBoth $client $server
+fclient=/tmp/$name-client-$$
+"$lsof" -n -E -P -p "$client" > "$fclient"
+if ! grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ type=STREAM ->INO=[0-9]\+ $server,nc,[0-9]\+u" < "$fclient" ; then
+    echo "failed in client side" >> "$report"
+    cat "$fclient" >> "$report"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-fserver=/tmp/${name}-server-$$
-$lsof -n -E -P -p $server > $fserver
-if ! cat $fserver | grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM ->INO=[0-9]\+ $client,nc,[0-9]\+u"; then
-    echo "failed in server side" >> $report
-    cat $fserver >> $report
-    killBoth $client $server
+fserver=/tmp/$name-server-$$
+"$lsof" -n -E -P -p "$server" > "$fserver"
+if ! grep -q "^.* unix 0x[0-9a-f]\+ \+0t0 \+[0-9]\+ $ux type=STREAM ->INO=[0-9]\+ $client,nc,[0-9]\+u" < "$fserver" ; then
+    echo "failed in server side" >> "$report"
+    cat "$fserver" >> "$report"
+    killBoth "$client" "$server"
     exit 1
 fi
 
-killBoth $client $server
+killBoth "$client" "$server"
 
 exit 0

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -22,48 +22,36 @@ STDTST=	LTnlink LTsock LTszoff LTunix
 OPTTST=	LTbigf LTdnlc LTlock LTnfs 
 
 all:	${CKTSTDB} ${BASTST} ${STDTST} FRC
-	@./${CKTSTDB}; xv=$$?; \
-	if [ $$xv -ne 0 ]; then \
-	  exit 1 ;\
-	fi
+	@./${CKTSTDB} || exit 1
 	@rm -f config.LT*
 	-@err=0; \
-	echo ""; \
+	echo ; \
 	echo "Basic test:"; \
-	./${BASTST}; \
-	if [ $$? -ne 0 ]; then \
-	  exit 1; \
-	fi; \
-	echo ""; \
+	./${BASTST}; || exit 1
+	@echo ; \
 	echo "Standard tests:"; \
 	for i in ${STDTST}; do \
-	  ./$$i; \
-	  if [ $$? -ne 0 ]; then \
-	    err=`expr $$err + 1`; \
-	  fi; \
+	  ./$$i || err=`expr $$err + 1`; \
 	done; \
-	if [ $$err -ne 0 ]; then \
-	  echo "Failed tests: $$err"; \
-	  echo ""; \
-	  echo "See 00FAQ and 00TEST for more information."; \
-	else \
+	if [ $$err = 0 ]; then \
 	  echo "All standard tests succeeded."; \
-	  echo ""; \
-	  grep LT_DIAL_darwin ${CONFCFL} > /dev/null 2>&1; \
-	  if [ $$? -ne 0 ]; then \
+	  echo ; \
+	  if ! grep LT_DIAL_darwin ${CONFCFL} > /dev/null 2>&1 ; then \
 	    echo "Suggestion: try the optional tests: \"make opt\""; \
-	    echo ""; \
+	    echo ; \
 	  fi; \
-	fi;
-	@rm -f config.LT*
+	else \
+	  echo "Failed tests: $$err"; \
+	  echo ; \
+	  echo "See 00FAQ and 00TEST for more information."; \
+	fi; \
+	rm -f config.LT* ; \
+        [ $$rr = 0 ]
 
 auto:	ckDB silent FRC
 
 ckDB:	${CKTSTDB} FRC
-	@echo "" | ./${CKTSTDB}; xv=$$?; \
-	if [ $$xv -ne 0 ]; then \
-	  exit 1 ;\
-	fi
+	@echo "" | ./${CKTSTDB} || exit 1
 
 clean:	FRC
 	rm -f ${BASTST} ${STDTST} ${OPTTST} *.o *.err *.out config.LT*
@@ -112,42 +100,31 @@ LTunix: LTunix.c ${CONFIG} ${LIBOBJ} ${HDR} config.ldflags
 
 opt:	${CKTSTDB} ${OPTTST} FRC
 	@rm -f config.LT*
-	-@err=0; \
-	echo ""; \
+	-@echo ; \
 	echo "Optional tests:"; \
+	err=0; \
 	for i in ${OPTTST}; do \
-	  ./$$i; \
-	  if [ $$? -ne 0 ]; then \
-	    err=`expr $$err + 1`; \
-	  fi; \
+	  ./$$i || err=`expr $$err + 1`; \
 	done; \
-	if [ $$err -ne 0 ]; then \
+	if [ $$err != 0 ]; then \
 	  echo "Failed tests: $$err"; \
 	else \
 	  echo "All optional tests succeeded."; \
 	fi; \
-	echo "";
+	echo ;
 	@rm -f config.LT*
 
 optional: opt
 
 silent:	${BASTST} ${STDTST} FRC
 	@rm -f config.LT*
+	@./${BASTST} > /dev/null 2>&1 || exit 1;
 	@err=0; \
-	./${BASTST} > /dev/null 2>&1; \
-	if [ $$? -ne 0 ]; then \
-	  exit 1; \
-	fi; \
-	for i in ${STDTST}; do \
-	  ./$$i > /dev/null 2>&1; \
-	  if [ $$? -ne 0 ]; then \
-	    err=`expr $$err + 1`; \
-	  fi; \
+        for i in ${STDTST}; do \
+	  ./$$i > /dev/null 2>&1 || err=`expr $$err + 1`; \
 	done; \
 	rm -f config.LT*; \
-	if [ $$err -ne 0 ]; then \
-	  exit 1; \
-	fi
+	[ $$err = 0 ] || exit 1
 
 spotless: clean
 	rm -f config.*

--- a/tests/case-00-hello.bash
+++ b/tests/case-00-hello.bash
@@ -1,13 +1,24 @@
+#!/intentionally/invalid/path/to/bash
+#
+# All the test scripts are invoked with
+#
+#   bash "$path_to_test.bash" "$path_to_lsof" "$path_to_report" "$(dirname "$path_to_test_dir")" "$dialect"
+#
+# therefore it is misleading to include a valid #! line, and even more
+# misleading if it says anything other than "bash".
+#
+
+
 #
 # An example of test case.
 #
 
-name=$(basename $0 .bash)
+name=$( basename "$0" .bash )   # shellcheck disable=SC2034
 
 #
 # The file path for lsof executable.
 #
-lsof=$1
+lsof=$1     # shellcheck disable=SC2034
 
 #
 # Used only when a test case is failed.
@@ -16,17 +27,17 @@ lsof=$1
 # The test harness uses this temporary file to make summary messages.
 # The test harness removes this temporary file.
 #
-report=$2
+report=$2   # shellcheck disable=SC2034
 
 #
 # Directory where this test case is.
 #
-tcasedir=$3
+tcasedir=$3 # shellcheck disable=SC2034
 
 #
 # Dialect of lsof
 #
-dialect=$4
+dialect=$4  # shellcheck disable=SC2034
 
 # Return 0 means the case is run successfully.
 # Return 1 means the case is run in failure.

--- a/tests/case-01-version.bash
+++ b/tests/case-01-version.bash
@@ -1,26 +1,25 @@
+#!/intentionally/invalid/path/to/bash
 #
 # check that the version numbers are updated
 #
 lsof=$1
 report=$2
 
-expected_version=$(sed '/VN/s/.ds VN \([0-9.a-z]*\)/\1/' ./version)
-actual_version=$(./lsof -v 2>&1 | sed -ne 's/^ *revision: *\([0-9.a-z]*\)/\1/p')
-dist_version=$(sed -ne 's/^\([0-9][0-9.a-z]*\)		.*$/\1/p' 00DIST | tail -1)
+expected_version=$( sed '/VN/s/.ds VN \([0-9.a-z]*\)/\1/' ./version )
+actual_version=$( "$lsof" -v 2>&1 | sed -ne 's/^ *revision: *\([0-9.a-z]*\)/\1/p' )
+dist_version=$( sed -ne 's/^\([0-9][0-9.a-z]*\)		.*$/\1/p' 00DIST | tail -1 )
 
-if [ "${expected_version}" != "${actual_version}" ]; then
-    {
-	echo "expected version defined in version file: ${expected_version}"
-	echo "lsof executable says: ${actual_version}"
-    } > $report
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+if [[ "$expected_version" != "$actual_version" ]]; then
+    echo "expected version defined in version file: $expected_version"
+    echo "lsof executable says: $actual_version"
     exit 1
 fi
 
-if [ "${expected_version}" != "${dist_version}" ]; then
-    {
-	echo "expected version defined in version file: ${expected_version}"
-	echo "the last entry of 00DIST is: ${dist_version}"
-    } > $report
+if [ "$expected_version" != "$dist_version" ]; then
+    echo "expected version defined in version file: $expected_version"
+    echo "the last entry of 00DIST is: $dist_version"
     exit 1
 fi
 

--- a/tests/case-13-classic.bash
+++ b/tests/case-13-classic.bash
@@ -1,45 +1,34 @@
-name=$(basename $0 .bash)
-lsof=$1
+#!/intentionally/invalid/path/to/bash
+
+name=$( basename "$0" .bash )
+#lsof=$1  <= IGNORED
 report=$2
-base=$(pwd)
 
-(
-    f=/tmp/${name}-$$
-    cd tests
-    make > $f 2>&1
+[[ -n $report && $report != - ]] && exec >> "$report"
 
-    if ! grep -q "LTbasic \.\.\. OK" $f; then
-	echo '"LTbasic ... OK" is not found in the output' >> $report
-	s=1
+s=0
+# shellcheck disable=SC1037
+f=/tmp/$name-$$-
+cd tests
+
+# TODO: check the return status of 'make'?
+make > "$f" 2>&1
+
+for p in "LTbasic ... OK" \
+         "LTnlink ... OK" \
+         "LTsock ... OK"  \
+         "LTszoff ... OK" \
+         "LTunix ... OK" 
+do
+    if ! grep -q -F "$p" < "$f"; then
+        printf '"%s" is not found in the output\n' "$p"
+        s=1
     fi
+done
 
-    if ! grep -q "LTnlink \.\.\. OK" $f; then
-	echo '"LTnlink ... OK" is not found in the output' >> $report
-	s=1
-    fi
+printf '\noutput\n.............................................................................\n'
+cat "$f"
 
-    if ! grep -q "LTsock \.\.\. OK" $f; then
-	echo '"LTsock ... OK" is not found in the output' >> $report
-	s=1
-    fi
+rm -f -- "$f"
 
-    if ! grep -q "LTszoff \.\.\. OK" $f; then
-	echo '"LTszoff ... OK" is not found in the output' >> $report
-	s=1
-    fi
-
-    if ! grep -q "LTunix \.\.\. OK" $f; then
-	echo '"LTunix ... OK" is not found in the output' >> $report
-	s=1
-    fi
-
-    {
-	echo
-	echo "output"
-	echo .............................................................................
-	cat $f
-    }  >> $report
-    rm $f
-
-    exit $s
-)
+exit "$s"

--- a/tests/case-20-fd-only-inclusion.bash
+++ b/tests/case-20-fd-only-inclusion.bash
@@ -1,36 +1,47 @@
-name=$(basename $0 .bash)
+#!/intentionally/invalid/path/to/bash
+
+#name=$( basename "$0" .bash )  <= IGNORED
 lsof=$1
 report=$2
 
-echo "inclusion test" >> $report
-while read line; do
-    if [[ $line =~ ^f[^0-9].* ]]; then
-	echo "Unexpectedly, a named file descriptor is included: "
-	echo "${line}"
-	echo
-	echo "## whole output for debugging (-d fd -F fd): "
-	${lsof} -p $$ -a -d fd -F fd
-	echo "## whole output for debugging (-d fd): "
-	${lsof} -p $$ -a -d fd
-	echo "## whole output for debugging (no -d): "
-	${lsof} -p $$
-	exit 1
-    fi
-done < <(${lsof} -p $$ -a -d fd -F fd) >> $report
+[[ -n $report && $report != - ]] && exec >> "$report"
 
-echo "exclusion test" >> $report
-while read line; do
-    if [[ $line =~ ^f[0-9]+ ]]; then
-	echo "Unexpectedly, a numbered file descriptor is included: "
-	echo "${line}"
-	echo "## whole output for debugging (-d fd -F fd): "
-	${lsof} -p $$ -a -d '^fd' -F fd
-	echo "## whole output for debugging (-d ^fd): "
-	${lsof} -p $$ -a -d '^fd'
-	echo "## whole output for debugging (no -d): "
-	${lsof} -p $$
+do1test() {
+    local test_type=$1 request_pattern=$2 failure_pattern=$3 desc=$4
+    printf '### %s test ###\n' "$test_type"
+    if
+        IFS= read -r line
+    then
+	printf 'Unexpectedly, %s is included:\n%s\n' "$desc" "$line"
+        # 'cat' will read the remaining output from 'grep',
+        # and thus show any other erroneous lines...
+        cat
+
+	printf '\n## whole output for debugging (%s):\n' \
+                        "-d '$request_pattern' -F fd"
+	"$lsof" -p $$ -a -d "$request_pattern" -F fd
+
+	printf '## whole output for debugging (%s):\n' \
+                        "-d '$request_pattern'"
+	"$lsof" -p $$ -a -d "$request_pattern"
+
+	printf '## whole output for debugging (%s):\n' "no -d"
+	"$lsof" -p $$
+
+        # And now give up!
 	exit 1
-    fi
-done < <(${lsof} -p $$ -a -d "^fd" -F fd) >> $report
+    fi < <(
+            "$lsof" -p $$ -a -d "$request_pattern" -F fd |
+            grep -E "$failure_pattern"
+        )
+}
+
+# TODO: consider simply inverting the test, effectively "grep -v ^f[0-9]"
+
+do1test Inclusion 'fd' '^f[^0-9]' 'a non-filedescriptor'
+
+do1test Exclusion '^fd' '^f[0-9]' 'a filedescriptor'
+
+echo '### Success ###'
 
 exit 0

--- a/tests/case-20-handle-missing-files.bash
+++ b/tests/case-20-handle-missing-files.bash
@@ -1,16 +1,19 @@
+#!/intentionally/invalid/path/to/bash
 # See https://github.com/lsof-org/lsof/issues/90
-name=$(basename $0 .bash)
+
+#name=$( basename "$0" .bash )  <=  IGNORED
 lsof=$1
 report=$2
-msg=$(${lsof} /NO-SUCH-FILE 2>&1)
 
-if [[ "${msg}" == \
-	       *': status error on /NO-SUCH-FILE: No such file or directory' ]]; then
+[[ -n $report && $report != - ]] && exec >> "$report"
+
+if 
+    msg=$( "$lsof" /NO-SUCH-FILE 2>&1 )
+    [[ "$msg" = *': status error on /NO-SUCH-FILE: No such file or directory'* ]]
+then
     exit 0
 else
-    {
-	echo "unexpected output: "
-	echo "${msg}"
-    } > $report
+    echo "unexpected output: "
+    echo "$msg"
     exit 1
 fi

--- a/tests/case-20-repeat-count.bash
+++ b/tests/case-20-repeat-count.bash
@@ -1,14 +1,31 @@
-name=$(basename $0 .bash)
+#!/intentionally/invalid/path/to/bash
+
+#name=$( basename "$0" .bash )  <= IGNORED
 lsof=$1
 report=$2
-base=$(pwd)
 
+[[ -n $report && $report != - ]] && exec >> "$report"
 
-if [ $(${lsof} -r 1c1 -p $$ | tee -a $report | grep -e '=======' | wc -l) != 1 ]; then
+#[[ -n $report && $report != - ]] || report=/dev/stderr
+#exec 2>&1
+
+if msg=$( "$lsof" -r 1c1 -p $$ ) &&
+   num=$( <<<"$msg" grep -cFx ======= ) &&
+   (( num == 1 )); then
+    :
+else
+    printf 'Expected %u reports (each terminated by "======="), got %u\n' 1 "$num"
+    printf '%s\n' "$msg"
     exit 1
 fi
 
-if [ $(${lsof} -r 1c5 -p $$ | tee -a $report | grep -e '=======' | wc -l) != 5 ]; then
+if msg=$( "$lsof" -r 1c5 -p $$ ) &&
+   num=$( <<<"$msg" grep -cFx ======= ) &&
+   (( num == 5 )); then
+    :
+else
+    printf 'Expected %u reports (each terminated by "======="), got %u\n' 5 "$num"
+    printf '%s\n' "$msg"
     exit 1
 fi
 


### PR DESCRIPTION
This includes
1. uniformly assume Bash version 3;
   * the references to `#!/bin/sh` and `.sh` were wrong and misleading;
   * change `var=$((var+1))` to simply `((var++))`
1. updates so that all scripts pass [ShellCheck](https://www.shellcheck.net/) (version 0.3.3) without any warnings:
   * add quotes around `$var` and `$( cmd )` expansions whereever they may be subject to wordsplitting or globbing;
   * use arrays for lists, rather than word-split strings;
   * include `# shellcheck disable=` in a few cases;
1. additional logic so that reports can be written to stdout instead of a named file; the framework can at some future time be adjusted to use redirection rather than naming files;
1. stylistic changes to avoid confusing `${}` and `$()` as they are almost indistinguishable in some fonts:
   * prefer `$var` over `${var}` wherever possible.
   * include whitespace inside `$( cmd )`
1. prefer `(( expr ))` for numeric operations including assignments and tests;
   * avoid `$var` inside `(( ... ))`
1. prefer `[[ $x = *glob* ]]` over `[[ $x =~ .*regex.* ]]`;

Note; I don't have access to test on all platforms, so I recommend re-running the test suite on all dialects when accepting these changes.