### PR TITLE
[linux] handle ffff:ffff in ipv6 addr correctly

### DIFF
--- a/00CREDITS
+++ b/00CREDITS
@@ -546,8 +546,9 @@ provided test systems where I was able to do development work.
 	yasu@utahime.org (email)
 	jamie@catflap.org (email)
 	@hardikpnsp (github account)
-	Martin D Kealey and
-	Henry Peteet
+	Martin D Kealey
+	Henry Peteet and
+	@zhrf2020
 
 If I have omitted a contributor's name, the fault is wholly mine,
 and I apologize for the error.

--- a/00DIST
+++ b/00DIST
@@ -5067,6 +5067,7 @@ July 14, 2018
 		  bash    866421 root    2u   CHR  136,1      0t0    4 /dev/pts/1
 		  bash    866421 root  255u   CHR  136,1      0t0    4 /dev/pts/1
 
+
 		docs: fixed minor grammatical error in instructions in Customize file
 		The change is provided by @hardikpnsp.
 
@@ -5078,6 +5079,32 @@ July 14, 2018
 
 		test cases, [linux]: fix tests for large inode-numbers (i >= 2^32)
 		The change is provided by Henry Peteet.
+
+		[linux] handle ffff:ffff in ipv6 addr correctly
+		The listen address and port of an AF_INET6 socket were not display if
+		the socket listened at an ipv6 address including ffff:ffff.
+
+		Here is a command session demonstrating the bug:
+
+		    # ip -6 addr add abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62 dev lo
+		    # nc -6      -l  abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62 8888 &
+		    [1] 6762
+		    # ./lsof -p 6762 -a -d fd -P -n
+		    COMMAND  PID   USER   FD   TYPE DEVICE SIZE/OFF    NODE NAME
+		    nc      6762 yamato    0u   CHR  136,6      0t0       9 /dev/pts/6
+		    nc      6762 yamato    1u   CHR  136,6      0t0       9 /dev/pts/6
+		    nc      6762 yamato    2u   CHR  136,6      0t0       9 /dev/pts/6
+		    nc      6762 yamato    3u  sock    0,9      0t0 5833594 protocol: TCPv6
+
+		The last line should be:
+
+		    nc      6762 yamato    3u  IPv6 5833594      0t0  TCP [abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62]:8888 (LISTEN)
+
+		The original code decoding an ipv6 address uses UINT32_MAX constant
+		incorrect way.
+
+		@zhrf2020 reported this bug in #102.
+		@zhrf2020 provided the initial version of fix, #109.
 
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 October 4, 2020

--- a/dialects/linux/tests/case-20-inet6-ffffffff-handling.bash
+++ b/dialects/linux/tests/case-20-inet6-ffffffff-handling.bash
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+name=$(basename $0 .bash)
+lsof=$1
+report=$2
+
+if [[ $(id -u) != 0 ]]; then
+    echo "root privileged is needed to run $(basename $0. sh)" >> "${report}"
+    exit 2
+fi
+
+#
+# Derrived from the issue #102 opened by @zhrf2020.
+#
+
+v6addr=abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62
+port=9999
+dev=lo
+
+if ! ip -6 address add "${v6addr}" dev "${dev}"; then
+    echo "failed to add ipv6 address "${v6addr}" to ${dev}" >> "${report}"
+    exit 2
+fi
+
+ip -6 address show >> "${report}"
+
+nc -6 -l "${v6addr}" "${port}" &
+pid=$!
+
+sleep 1
+
+expectation="n[${v6addr}]:$port"
+result=1
+if "${lsof}" -p "${pid}" -a -d fd -P -n -F n \
+    | tee -a "${report}" \
+    | fgrep -q "$expectation"; then
+    result=0
+fi
+
+nc -6 "${v6addr}" "${port}" < /dev/null > /dev/null
+sleep 1
+
+ip -6 address delete "${v6addr}" dev "${dev}"
+
+if [[ "${result}" != 0 ]]; then
+    echo "failed to find \"$expectation\" in the outpuf of lsof" >> "${report}"
+fi
+
+exit "${result}"


### PR DESCRIPTION
Close #102
Close #109

The listen address and port of an AF_INET6 socket were not display if
the socket listened at an ipv6 address including ffff:ffff.

Here is a command session demonstrating the bug:

    # ip -6 addr add abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62 dev lo
    # nc -6      -l  abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62 8888 &
    [1] 6762
    # ./lsof -p 6762 -a -d fd -P -n
    COMMAND  PID   USER   FD   TYPE DEVICE SIZE/OFF    NODE NAME
    nc      6762 yamato    0u   CHR  136,6      0t0       9 /dev/pts/6
    nc      6762 yamato    1u   CHR  136,6      0t0       9 /dev/pts/6
    nc      6762 yamato    2u   CHR  136,6      0t0       9 /dev/pts/6
    nc      6762 yamato    3u  sock    0,9      0t0 5833594 protocol: TCPv6

The last line should be:

    nc      6762 yamato    3u  IPv6 5833594      0t0  TCP [abcd:ef10:ffff:ffff:ffff:ffff:ffff:ff62]:8888 (LISTEN)

The original code decoding an ipv6 address uses UINT32_MAX constant
incorrect way.

@zhrf2020 reported this bug in #102.
The test case is based on the report.

@zhrf2020 provided the initial version of fix, #109.
This change is based on the version.