### PR TITLE
[freebsd] cirrus-ci: disabled

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,29 +1,29 @@
-freebsd13_task:
-  freebsd_instance:
-    image: freebsd-13-0-current-amd64-v20200604
-  timeout_in: 120m
-  install_script: pkg install -y git bash
-  script:
-    - ./Configure -n freebsd
-    - make
-    - bash ./check.bash freebsd
+# freebsd13_task:
+#   freebsd_instance:
+#     image: freebsd-13-0-current-amd64-v20200604
+#   timeout_in: 120m
+#   install_script: pkg install -y git bash
+#   script:
+#     - ./Configure -n freebsd
+#     - make
+#     - bash ./check.bash freebsd
 
-freebsd12_task:
-  freebsd_instance:
-    image: freebsd-12-1-release-amd64
-  timeout_in: 120m
-  install_script: pkg install -y git bash
-  script:
-    - ./Configure -n freebsd
-    - make
-    - bash ./check.bash freebsd
+# freebsd12_task:
+#   freebsd_instance:
+#     image: freebsd-12-1-release-amd64
+#   timeout_in: 120m
+#   install_script: pkg install -y git bash
+#   script:
+#     - ./Configure -n freebsd
+#     - make
+#     - bash ./check.bash freebsd
 
-freebsd11_task:
-  freebsd_instance:
-    image: freebsd-11-3-release-amd64
-  timeout_in: 120m
-  install_script: pkg install -y git bash
-  script:
-    - ./Configure -n freebsd
-    - make
-    - bash ./check.bash freebsd
+# freebsd11_task:
+#   freebsd_instance:
+#     image: freebsd-11-3-release-amd64
+#   timeout_in: 120m
+#   install_script: pkg install -y git bash
+#   script:
+#     - ./Configure -n freebsd
+#     - make
+#     - bash ./check.bash freebsd

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ part of them. The current status of maintaince is as follows:
 
 <dl>
 <dt>freebsd</dt>
-<dd>partially maintained, and tested on Cirrus CI</dd>
+<dd>partially maintained, but testing on Cirrus CI is temporary disabled</dd>
 <dt>linux</dt>
 <dd>fully maintained, and tested on Travis CI</dd>
 <dt>darwin</dt>
-<dd>not maintained, but tested on Travis CI</dd>
+<dd>not maintained, but partially tested on Travis CI</dd>
 </dl>
 
 If you are interested in maintaining a dialect, let us know via the


### PR DESCRIPTION
https://github.com/lsof-org/lsof/pull/94#issuecomment-639180877h

    lrosenman commented on Jun 5

    @masatake the FreeBSD CI is failed due to the Cirrus stuff using outdated images.
    I'll see if I can figure out how to fix that for all 3 FreeBSD versions.

Till we find the way to update the images, disable the testing.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>