### PR TITLE
Fix man page definition of the `o` field on programmatic output

### DIFF
--- a/Lsof.8
+++ b/Lsof.8
@@ -3325,7 +3325,7 @@ The single character listed first is the field identifier.
 	M	the task comMand name
 	n	file name, comment, Internet address
 	N	node identifier (ox<hexadecimal>
-	o	file's offset (decimal)
+	o	file's offset (0t<decimal> or 0x<hexadecimal>, see \fB\-o\fP \fIo\fP)
 	p	process ID (always selected)
 	P	protocol name
 	r	raw device number (0x<hexadecimal>)


### PR DESCRIPTION
#118