### PR TITLE
Don't select the file descriptor field by default.

### DIFF
--- a/00CREDITS
+++ b/00CREDITS
@@ -548,8 +548,9 @@ provided test systems where I was able to do development work.
 	@hardikpnsp (github account)
 	Martin D Kealey
 	Henry Peteet
-	@zhrf2020 and
-	@JustAnotherArchivist
+	@zhrf2020
+	@JustAnotherArchivist and
+	@po5857
 
 If I have omitted a contributor's name, the fault is wholly mine,
 and I apologize for the error.

--- a/00DIST
+++ b/00DIST
@@ -5176,5 +5176,12 @@ July 14, 2018
 		This change closed #116.
 
 
+		Don't select the file descriptor field by default.
+		The version 4.88 introduced the change for selecting the file
+		descriptor field by default. However, the change is not
+		suitable for users who wants to print only PID field.
+		@po5857 suggests the use case and the way to improve the man page.
+
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 October 4, 2020

--- a/Lsof.8
+++ b/Lsof.8
@@ -3272,6 +3272,7 @@ ends each process and file set with a NL (012) character.
 .PP
 .I Lsof
 always produces one field, the PID (`p') field.
+In repeat mode, the marker (`m') is also produced.
 All other fields may be declared optionally in the field identifier
 character list that follows the
 .B \-F
@@ -3282,6 +3283,15 @@ does not normally list \- e.g., PPID, selected with
 .BR \-R " \-"
 specification of the field character \- e.g., ``\fB\-FR\fP'' \-
 also selects the listing of the item.
+.PP
+.I Lsof
+version from 4.88 to 4.93.2 always produced one more field,
+the file descriptor (`f') field. However,
+.I lsof
+in this version doesn't produce it. This change is for supporting
+the use case that a user needs only the PID field, and doesn't
+need the file descriptor field. Specify `f' explicitly if you
+need the field.
 .PP
 It is entirely possible to select a set of fields that cannot
 easily be parsed \- e.g., if the field descriptor field is not
@@ -3312,7 +3322,7 @@ The single character listed first is the field identifier.
 	C	file structure share count
 	d	file's device character code
 	D	file's major/minor device number (0x<hexadecimal>)
-	f	file descriptor (always selected)
+	f	file descriptor
 	F	file structure address (0x<hexadecimal>)
 	G	file flaGs (0x<hexadecimal>; names if \fB+fg\fP follows)
 	g	process group ID
@@ -3321,7 +3331,7 @@ The single character listed first is the field identifier.
 	k	link count
 	l	file's lock status
 	L	process login name
-	m	marker between repeated output
+	m	marker between repeated output (always selected in repeat mode)
 	M	the task comMand name
 	n	file name, comment, Internet address
 	N	node identifier (ox<hexadecimal>

--- a/store.c
+++ b/store.c
@@ -210,7 +210,7 @@ struct fieldsel FieldSel[] = {
     { LSOF_FID_CT,     0,  LSOF_FNM_CT,     &Fsv,     FSV_CT 	 }, /*  2 */
     { LSOF_FID_DEVCH,  0,  LSOF_FNM_DEVCH,  NULL,     0		 }, /*  3 */
     { LSOF_FID_DEVN,   0,  LSOF_FNM_DEVN,   NULL,     0		 }, /*  4 */
-    { LSOF_FID_FD,     1,  LSOF_FNM_FD,     NULL,     0		 }, /*  5 */
+    { LSOF_FID_FD,     0,  LSOF_FNM_FD,     NULL,     0		 }, /*  5 */
     { LSOF_FID_FA,     0,  LSOF_FNM_FA,     &Fsv,     FSV_FA	 }, /*  6 */
     { LSOF_FID_FG,     0,  LSOF_FNM_FG,     &Fsv,     FSV_FG	 }, /*  7 */
     { LSOF_FID_INODE,  0,  LSOF_FNM_INODE,  NULL,     0		 }, /*  8 */


### PR DESCRIPTION
Close #103.

The version 4.88 introduced the change for selecting the file
descriptor field by default. However, the change is not
suitable for users who wants to print only PID field.
@po5857 suggests the use case.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>