### PR TITLE
[linux] enumerate fds monitored by an eventpoll fd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ dialects/linux/tests/eventfd
 dialects/linux/tests/mq_fork
 dialects/linux/tests/mq_open
 dialects/linux/tests/open_with_flags
+dialects/linux/tests/pidfd
 dialects/linux/tests/pipe
 dialects/linux/tests/pty
 dialects/linux/tests/ux

--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ LTunix
 #
 # Dialect specific test related files
 #
+dialects/linux/tests/epoll
 dialects/linux/tests/eventfd
 dialects/linux/tests/mq_fork
 dialects/linux/tests/mq_open

--- a/00DIST
+++ b/00DIST
@@ -5183,5 +5183,26 @@ July 14, 2018
 		@po5857 suggests the use case and the way to improve the man page.
 
 
+		[linux]: enumerate fds monitored by an eventpoll fd
+		With this change, lsof prints an eventpoll fd in the following form:
+
+		    [eventpoll:<fd0>,<fd1>,...,<fdn>...]
+
+		Here fdX is a file descriptor monitored by the eventpoll fd.
+		If an eventpoll fd monitors too many file descriptors, lsof
+		truncates the list of fds. "..." at the end of list implies
+		the truncation.
+
+		Example output:
+
+			# sudo ./lsof -p 1 -a -d 10,11,12
+			COMMAND PID USER   FD      TYPE DEVICE SIZE/OFF  NODE NAME
+			systemd   1 root   10u  a_inode   0,13        0 11624 [eventpoll:11,12]
+			systemd   1 root   11r      REG    0,4        0 17680 /proc/1/mountinfo
+			systemd   1 root   12r  a_inode   0,13        0 11624 inotify
+
+		systemd monitors fd 11 and fd 12 via eventpoll fd 10.
+
+
 Masatake YAMATO <yamato@redhat.com>, a member of the lsof-org team at GitHub
 October 4, 2020

--- a/dialects/linux/dproc.c
+++ b/dialects/linux/dproc.c
@@ -475,6 +475,7 @@ get_fdinfo(p, msk, fi)
  * Read the fdinfo file.
  */
 	while (fgets(buf, sizeof(buf), fs)) {
+	    int opt_flg = 0;
 	    if (get_fields(buf, (char *)NULL, &fp, (int *)NULL, 0) < 2)
 		continue;
 	    if (!fp[0] || !*fp[0] || !fp[1] || !*fp[1])
@@ -505,11 +506,14 @@ get_fdinfo(p, msk, fi)
 		    break;
 
 	    } else if (
-		       ((msk & FDINFO_PID) && !strcmp(fp[0], "Pid:"))
+		       ((msk & FDINFO_PID) && !strcmp(fp[0], "Pid:")
+			&& ((opt_flg = FDINFO_PID)))
 #if	defined(HASEPTOPTS)
-		       || ((msk & FDINFO_EVENTFD_ID) && !strcmp(fp[0], "eventfd-id:"))
+		       || ((msk & FDINFO_EVENTFD_ID) && !strcmp(fp[0], "eventfd-id:")
+			   && ((opt_flg = FDINFO_EVENTFD_ID)))
 #if	defined(HASPTYEPT)
-		       || ((msk & FDINFO_TTY_INDEX) && !strcmp(fp[0], "tty-index:"))
+		       || ((msk & FDINFO_TTY_INDEX) && !strcmp(fp[0], "tty-index:")
+			   && ((opt_flg = FDINFO_TTY_INDEX)))
 #endif	/* defined(HASPTYEPT) */
 #endif	/* defined(HASEPTOPTS) */
 		       ) {
@@ -530,23 +534,20 @@ get_fdinfo(p, msk, fi)
 		     val = -1;
 		}
 
-		char c = fp[0][0];
-		switch (c) {
+		rv |= opt_flg;
+		switch (opt_flg) {
 #if	defined(HASEPTOPTS)
-		case 'e':	/* eventfd-id */
+		case FDINFO_EVENTFD_ID:
 		    fi->eventfd_id = val;
-		    rv |= FDINFO_EVENTFD_ID;
 		    break;
 #if	defined(HASPTYEPT)
-		case 't':	/* tty-index: */
+		case FDINFO_TTY_INDEX:
 		    fi->tty_index = val;
-		    rv |= FDINFO_TTY_INDEX;
 		    break;
 #endif	/* defined(HASPTYEPT) */
 #endif	/* defined(HASEPTOPTS) */
-		case 'P':	/* Pid: */
+		case FDINFO_PID:
 		    fi->pid = val;
-		    rv |= FDINFO_PID;
 		    break;
 		}
 		if (rv == msk)

--- a/dialects/linux/tests/Makefile
+++ b/dialects/linux/tests/Makefile
@@ -1,4 +1,5 @@
 HELPERS = \
+	epoll \
 	eventfd \
 	mq_fork \
 	mq_open \

--- a/dialects/linux/tests/case-20-epoll.bash
+++ b/dialects/linux/tests/case-20-epoll.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+lsof=$1
+report=$2
+tdir=$3
+
+TARGET=$tdir/epoll
+if ! [ -x $TARGET ]; then
+    echo "target executable ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+$TARGET | {
+    read pid epfd
+    if [[ -z "$pid" || -z "$epfd" ]]; then
+	echo "unexpected output form target ( $TARGET )" >> $report
+	exit 1
+    fi
+    {
+	echo pid: $pid
+	echo epfd: $epfd
+	echo cmdline: "$lsof -p $pid -a -d $epfd"
+	$lsof -p $pid -a -d $epfd
+	echo done
+    } >> $report
+    if $lsof -p $pid -a -d $epfd |
+	    grep -q "epoll *[0-9]* *.* *${epfd}u *a_inode *[0-9]*,[0-9]* *[0-9]* *[0-9]* *\[eventpoll:0,1,2\]"; then
+	kill $pid
+	exit 0
+    else
+	kill $pid
+	exit 1
+    fi
+}

--- a/dialects/linux/tests/epoll.c
+++ b/dialects/linux/tests/epoll.c
@@ -1,0 +1,46 @@
+#include <stdio.h>
+#include <sys/epoll.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+int
+main(int argc, char **argv)
+{
+  int epfd = epoll_create (1);
+  if (epfd < 0)
+    {
+      perror ("epoll_create");
+      return 1;
+    }
+
+  struct epoll_event ev;
+
+  ev.events = EPOLLOUT;
+  ev.data.fd = 2;
+  if (epoll_ctl (epfd, EPOLL_CTL_ADD, ev.data.fd, &ev) < 0)
+    {
+      perror ("epoll_ctl");
+      return 1;
+    }
+
+  ev.events = EPOLLOUT;
+  ev.data.fd = 1;
+  if (epoll_ctl (epfd, EPOLL_CTL_ADD, ev.data.fd, &ev) < 0)
+    {
+      perror ("epoll_ctl");
+      return 1;
+    }
+
+  ev.events = EPOLLIN;
+  ev.data.fd = 0;
+  if (epoll_ctl (epfd, EPOLL_CTL_ADD, ev.data.fd, &ev) < 0)
+    {
+      perror ("epoll_ctl");
+      return 1;
+    }
+
+  printf ("%d %d\n", getpid(), epfd);
+  fflush (stdout);
+  getchar ();
+  return 0;
+}


### PR DESCRIPTION
    [linux]: enumerate fds monitored by an eventpoll fd
    With this change, lsof prints an eventpoll fd in the following form:
    
        [eventpoll:<fd0>,<fd1>,...,<fdn>...]
    
    Here fdX is a file descriptor monitored by the eventpoll fd.
    If an eventpoll fd monitors too many file descriptors, lsof
    truncates the list of fds. "..." at the end of list implies
    the truncation.
    
    Example output:
    
            # sudo ./lsof -p 1 -a -d 10,11,12
            COMMAND PID USER   FD      TYPE DEVICE SIZE/OFF  NODE NAME
            systemd   1 root   10u  a_inode   0,13        0 11624 [eventpoll:11,12]
            systemd   1 root   11r      REG    0,4        0 17680 /proc/1/mountinfo
            systemd   1 root   12r  a_inode   0,13        0 11624 inotify
    
    systemd monitors fd 11 and fd 12 via eventpoll fd 10.
    
    Signed-off-by: Masatake YAMATO <yamato@redhat.com>
