### PR TITLE
Revise exit status

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5316,6 +5316,9 @@ July 14, 2018
 		In the original code, lsof returned 1 when it failed to find a
 		search item. With the new option, lsof returns 0 in the case.
 
+		Document -Q option in manpage/00QUICKSTART, and adjust -h
+		output by @dilinger (Andres Salomon).
+
 
 The lsof-org team at GitHub
 November 25, 2020

--- a/00DIST
+++ b/00DIST
@@ -5311,5 +5311,11 @@ July 14, 2018
 		@qianzhangyl reported the original issue (#186).
 
 
+		Add -Q option for adjusting exit status when failed to find a
+		search item
+		In the original code, lsof returned 1 when it failed to find a
+		search item. With the new option, lsof returns 0 in the case.
+
+
 The lsof-org team at GitHub
 November 25, 2020

--- a/00QUICKSTART
+++ b/00QUICKSTART
@@ -739,17 +739,23 @@
 16. The Lsof Exit Code and Shell Scripts
 ========================================
 
-  When lsof exits successfully it returns an exit code based on
+  When lsof executes successfully, it returns an exit code based on
   the result of its search for specified files.  (If no files were
   specified, then the successful exit code is 0 (zero).)
 
   If lsof was asked to search for specific files, including any
   files on specified file systems, it returns an exit code of 0
   (zero) if it found all the specified files and at least one file
-  on each specified file system.  Otherwise it returns a 1 (one).
+  on each specified file system.  Otherwise it returns a 1 (one) if
+  any part of the search failed.
 
-  If lsof detects an error and makes an unsuccessful exit, it
-  returns an exit code of 1 (one).
+  This behavior can be modified by calling lsof with -Q, which will
+  tell it to provide a successful exit code of 0 (zero) even if any
+  part of the file or filesystem search failed.
+
+  If lsof detects a generic (non-search) error during its execution,
+  it returns an exit code of 1 (one).  The -Q option will not
+  affect this behavior.
 
   You can use the exit code in a shell script to search for files
   on a file system and take action based on the result -- e.g.,
@@ -761,6 +767,18 @@
       echo "<file_system_name> has some users."
     else
       echo "<file_system_name> may have no users."
+    fi
+
+  The -Q option can help in certain circumstances.  For example, if
+  you want to log filesystem users without caring if there are no
+  users:
+
+    #!/bin/sh
+    lsof -Q <file_system_name>  > fs_users.log
+    if test $? -ne 0
+    then
+      echo "Error: Something actually went wrong!" 1>&2
+      exit 1
     fi
 
 
@@ -1003,6 +1021,13 @@ D.  Miscellaneous Lsof Options
 		-r.  Example:
 
 		    $ lsof -r30
+
+	-Q	tells lsof not to consider it an error if it was
+		given search terms and any part of the search came
+		up empty. This will silence any reports of missing
+		files to stderr. Additionally, lsof will exit with
+		a non-error code despite any missing files or
+		filesystems with no open files.
 
 	-v	displays information about the building of the
 		lsof executable.

--- a/Lsof.8
+++ b/Lsof.8
@@ -10,7 +10,7 @@ lsof \- list open files
 .SH SYNOPSIS
 .B lsof
 [
-.B \-?abChlnNOPRtUvVX
+.B \-?abChlnNOPQRtUvVX
 ] [
 .BI \-A " A"
 ] [
@@ -1403,6 +1403,21 @@ Inhibiting the conversion may make
 .I lsof
 run a little faster.
 It is also useful when port name lookup is not working properly.
+.TP \w'names'u+4
+.B \-Q
+ignore failed search terms. When
+.I lsof
+is told to search for users of a file, or for users of a device,
+or for a specific PID, or for certain protocols in use by that PID,
+and so on,
+.I lsof
+will return an error if any of the search results are empty. The
+.B \-Q
+option will change this behavior so that
+.I lsof
+will instead return a successful exit code (0) even if any of the
+search results are empty. In addition, missing search terms will not
+be reported to stderr.
 .TP \w'names'u+4
 .BI +|\-r " [t[c<N>][m<fmt>]]"
 puts
@@ -4205,9 +4220,17 @@ If the
 option is specified,
 .I lsof
 will indicate the search items it failed to list.
+If the
+.B \-Q
+option is specified,
+.I lsof
+will ignore any search item failures and only return an error if
+something unusual and unrecoverable happened.
 .PP
-It returns a zero (0) if no errors were detected and if it was able to
-list some information about all the specified search arguments.
+It returns a zero (0) if no errors were detected and if either the
+.B \-Q
+option was specified or it was able to list some information about
+all the specified search arguments.
 .PP
 .PP
 When
@@ -4270,6 +4293,13 @@ To list all open IPv4 network files in use by the process whose PID is
 .IP
 lsof \-i 4 \-a \-p 1234
 .PP
+If it's okay for PID 1234 to not exist, or for PID 1234 to not have any
+open IPv4 network files, add
+.B \-Q
+:
+.IP
+lsof \-Q \-i 4 \-a \-p 1234
+.PP
 Presuming the UNIX dialect supports IPv6, to list only open IPv6
 network files, use:
 .IP
@@ -4294,9 +4324,14 @@ To list all open files on device /dev/hd4, use:
 .IP
 lsof /dev/hd4
 .PP
-To find the process that has /u/abe/foo open, use:
+To find the process that has /u/abe/foo open without worrying if
+there are none, use:
 .IP
-lsof /u/abe/foo
+lsof \-Q /u/abe/foo
+.PP
+To take action only if a process has /u/abe/foo open, use:
+.IP
+lsof /u/abe/foo \&\& echo "still in use"
 .PP
 To send a SIGHUP to the processes that have /u/abe/bar open, use:
 .IP

--- a/arg.c
+++ b/arg.c
@@ -176,7 +176,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 		    if (!(ap = (char *)malloc((MALLOC_S)(k + 1)))) {
 			(void) fprintf(stderr, "%s: no space for copy of %s\n",
 			    Pn, path);
-			Exit(1);
+			Error();
 		    }
 		    (void) strncpy(ap, path, k);
 		    ap[k] = '\0';
@@ -227,7 +227,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 		    if (!mmp) {
 			(void) fprintf(stderr,
 			    "%s: no space for mount pointers\n", Pn);
-			Exit(1);
+			Error();
 		    }
 		}
 		mmp[nm++] = mp;
@@ -250,7 +250,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 	     */
 		if (!(sfp = (struct sfile *)malloc(sizeof(struct sfile)))) {
 		    (void) fprintf(stderr, "%s: no space for files\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 		sfp->next = Sfile;
 		Sfile = sfp;
@@ -362,7 +362,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 			(void) fprintf(stderr,
 			    "%s: no space for file name: ", Pn);
 			safestrprt(fnm, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 
 #if	defined(HASPROCFS)
@@ -382,7 +382,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 			(void) fprintf(stderr,
 			    "%s: no space for file system name: ", Pn);
 			safestrprt(fsnm, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 
 #if	defined(HASPROCFS)
@@ -394,7 +394,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 		    (void) fprintf(stderr,
 			"%s: no space for argument file name: ", Pn);
 			safestrprt(av[i], stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 
 #if	defined(HASPROCFS)
@@ -446,7 +446,7 @@ ck_file_arg(i, ac, av, fv, rs, sbp)
 		    (void) fprintf(stderr, "%s: no space for %s ID: ",
 			Pn, Mtprocfs->dir);
 		    safestrprt(path, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		pfi->pid = pid;
 		pfi->f = 0;
@@ -563,7 +563,7 @@ ctrl_dcache(c)
 	    if (!(DCpathArg = mkstrcpy(c, (MALLOC_S *)NULL))) {
 		(void) fprintf(stderr, "%s: no space for -D path: ", Pn);
 		safestrprt(c, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	}
 	return(0);
@@ -677,7 +677,7 @@ enter_cmd_rx(x)
 	if (!(xp = (char *)malloc(xl + 1))) {
 	    (void) fprintf(stderr, "%s: no regexp space for: ", Pn);
 	    safestrprt(x, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	(void) strncpy(xp, xb, xl);
 	xp[(int)xl] = '\0';
@@ -698,7 +698,7 @@ enter_cmd_rx(x)
 	    if (!CmdRx) {
 		(void) fprintf(stderr, "%s: no space for regexp: ", Pn);
 		safestrprt(x, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	}
 	i = NCmdRxU;
@@ -753,7 +753,7 @@ enter_efsys(e, rdlnk)
 	if (!(ec = mkstrcpy(e, (MALLOC_S *)NULL))) {
 	    (void) fprintf(stderr, "%s: no space for -e string: ", Pn);
 	    safestrprt(e, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	if (rdlnk)
 	    path = ec;
@@ -779,7 +779,7 @@ enter_efsys(e, rdlnk)
 	if (!(ep = (efsys_list_t *)malloc((MALLOC_S)(sizeof(efsys_list_t))))) {
 	   (void) fprintf(stderr, "%s: no space for \"-e %s\" entry\n",
 		Pn, e);
-	   Exit(1);
+	   Error();
 	}
 	ep->path = path;
 	ep->pathl = i;
@@ -813,7 +813,7 @@ enter_fd(f)
 	if (!(fc = mkstrcpy(f, (MALLOC_S *)NULL))) {
 	    (void) fprintf(stderr, "%s: no space for fd string: ", Pn);
 	    safestrprt(f, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Isolate each file descriptor in the comma-separated list, then enter it
@@ -910,7 +910,7 @@ enter_fd_lst(nm, lo, hi, excl)
  */
 	if (!(f = (struct fd_lst *)malloc((MALLOC_S)sizeof(struct fd_lst)))) {
 	   (void) fprintf(stderr, "%s: no space for FD list entry\n", Pn);
-	   Exit(1);
+	   Error();
 	}
 	if (nm) {
 
@@ -931,7 +931,7 @@ enter_fd_lst(nm, lo, hi, excl)
 		if (!(f->nm = mkstrcpy(nm, (MALLOC_S *)NULL))) {
 		    (void) fprintf(stderr,
 			"%s: no space for copy of: %s\n", Pn, nm);
-		    Exit(1);
+		    Error();
 		}
 		lo = 1;
 		hi = 0;
@@ -1091,7 +1091,7 @@ enter_dir(d, descend)
 		    (void) fprintf(stderr,
 			"%s: no space for path to entries in directory: %s\n",
 			Pn, dn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    (void) snpf(fp, (size_t)fpl, "%s%s", dn, sl ? "/" : "");
@@ -1136,7 +1136,7 @@ enter_dir(d, descend)
 			safestrprt(dn, stderr, 0);
 			putc('/', stderr);
 			safestrprtn(dp->d_name, dnamlen, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 		}
 		(void) strncpy(fp + dnl + sl, dp->d_name, dnamlen);
@@ -1296,7 +1296,7 @@ enter_id(ty, p)
 	    (void) fprintf(stderr, "%s: enter_id \"", Pn);
 	    safestrprt(p, stderr, 0);
 	    (void) fprintf(stderr, "\", invalid type: %d\n", ty);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Convert and store the ID.
@@ -1365,7 +1365,7 @@ enter_id(ty, p)
 		if (!s) {
 		    (void) fprintf(stderr, "%s: no space for %d process%s IDs",
 			Pn, mx, (ty == PGID) ? " group" : "");
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    s[n].f = 0;
@@ -1854,7 +1854,7 @@ enter_nwad(n, sp, ep, s, he)
 		(void) fprintf(stderr,
 		    "%s: no space for Internet argument: -i ", Pn);
 		safestrprt(s, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	} else
 	    n->arg = (char *)NULL;
@@ -2009,7 +2009,7 @@ no_IorX_space:
 
 			(void) fprintf(stderr, "%s: no %s table space\n",
 			    Pn, ty);
-			Exit(1);
+			Error();
 		    }
 		}
 		if (!UdpStX) {
@@ -2050,7 +2050,7 @@ no_IorX_space:
 	if (!(ssc = mkstrcpy(cp, (MALLOC_S *)NULL))) {
 	    (void) fprintf(stderr,
 		"%s: no temporary state argument space for: %s\n", Pn, ss);
-	    Exit(1);
+	    Error();
 	}
 	cp = ssc;
 	err = 0;
@@ -2344,14 +2344,14 @@ enter_uid(us)
 		    Suid = (struct seluid *)realloc((MALLOC_P *)Suid, len);
 		if (!Suid) {
 		    (void) fprintf(stderr, "%s: no space for UIDs", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    if (nn) {
 		if (!(lp = mkstrcpy(lnm, (MALLOC_S *)NULL))) {
 		    (void) fprintf(stderr, "%s: no space for login: ", Pn);
 		    safestrprt(lnm, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		Suid[Nuid].lnm = lp;
 	    } else

--- a/dialects/aix/ddev.c
+++ b/dialects/aix/ddev.c
@@ -148,7 +148,7 @@ printdevname(dev, rdev, f, nty)
 	    if (!(cp = (char *)malloc((MALLOC_S)(len + 1)))) {
 		(void) fprintf(stderr, "%s: no nma space for: (%s %s)\n",
 		    Pn, ttl, dp->name);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(cp, len + 1, "(%s %s)", ttl, dp->name);
 	    (void) add_nma(cp, len);
@@ -245,7 +245,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(Dstk[Dstkx], stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    (void) free((FREE_P *)Dstk[Dstkx]);
 	    Dstk[Dstkx] = (char *)NULL;
@@ -267,7 +267,7 @@ readdev(skip)
 		    (void) fprintf(stderr, "%s: no space for: ", Pn);
 		    safestrprt(path, stderr, 0);
 		    safestrprt(dp->d_name, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 
 #if	defined(USE_STAT)
@@ -315,7 +315,7 @@ readdev(skip)
 			if (!Devtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for character device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    Devtp[i].rdev = sb.st_rdev;
@@ -323,7 +323,7 @@ readdev(skip)
 		    if (!(Devtp[i].name = mkstrcpy(fp, (MALLOC_S *)NULL))) {
 			(void) fprintf(stderr, "%s: no space for: ", Pn);
 			safestrprt(fp, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 		    Devtp[i].v = 0;
 		    i++;
@@ -339,13 +339,13 @@ readdev(skip)
 			    (void) fprintf(stderr,
 				"%s: no space for clone device: ", Pn);
 			    safestrprt(fp, stderr, 1);
-			    Exit(1);
+			    Error();
 			}
 			if (!(c->cd.name = mkstrcpy(fp, (MALLOC_S)NULL))) {
 			    (void) fprintf(stderr,
 				"%s: no space for clone name: ", Pn);
 			    safestrprt(fp, stderr, 1);
-			    Exit(1);
+			    Error();
 			}
 			c->cd.inode = (INODETYPE)sb.st_ino;
 			c->cd.rdev = sb.st_rdev;
@@ -377,7 +377,7 @@ readdev(skip)
 			if (!BDevtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for block device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    BDevtp[j].rdev = sb.st_rdev;
@@ -422,7 +422,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for block device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (j = 0; j < BNdev; j++) {
 		BSdev[j] = &BDevtp[j];
@@ -448,7 +448,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for character device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (i = 0; i < Ndev; i++) {
 		Sdev[i] = &Devtp[i];
@@ -458,7 +458,7 @@ readdev(skip)
 	    Ndev = rmdupdev(&Sdev, Ndev, "char");
 	} else {
 	    (void) fprintf(stderr, "%s: no character devices found\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(HASDCACHE)
@@ -552,7 +552,7 @@ rmdupdev(dp, n, nm)
 	{
 	    (void) fprintf(stderr, "%s: can't realloc %s device pointers\n",
 		Pn, nm);
-	    Exit(1);
+	    Error();
 	}
 	return(j);
 }
@@ -614,7 +614,7 @@ bad_clone_sect:
 		    (void) fprintf(stderr,
 			"%s: no space for cached clone: ", Pn);
 		    safestrprt(buf, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Enter the clone device number.
@@ -654,7 +654,7 @@ bad_cached_clone:
 		    (void) fprintf(stderr,
 			"%s: no space for cached clone path: ", Pn);
 		    safestrprt(buf, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		c->cd.v = 0;
 		c->next = Clone;
@@ -689,7 +689,7 @@ bad_cached_clone:
  */
 	(void) fprintf(stderr, "%s: internal rw_clone_sect error: %d\n",
 	    Pn, m);
-	Exit(1);
+	Error();
 }
 #endif	/* defined(HASDCACHE) && AIXV>=4140 */
 

--- a/dialects/aix/ddev.c
+++ b/dialects/aix/ddev.c
@@ -339,13 +339,13 @@ readdev(skip)
 			    (void) fprintf(stderr,
 				"%s: no space for clone device: ", Pn);
 			    safestrprt(fp, stderr, 1);
-			    exit(1);
+			    Exit(1);
 			}
 			if (!(c->cd.name = mkstrcpy(fp, (MALLOC_S)NULL))) {
 			    (void) fprintf(stderr,
 				"%s: no space for clone name: ", Pn);
 			    safestrprt(fp, stderr, 1);
-			    exit(1);
+			    Exit(1);
 			}
 			c->cd.inode = (INODETYPE)sb.st_ino;
 			c->cd.rdev = sb.st_rdev;

--- a/dialects/aix/dfile.c
+++ b/dialects/aix/dfile.c
@@ -120,7 +120,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d (dev,ino) hash buckets\n",
 		Pn, SFDIHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFrd = (struct hsfile *)calloc((MALLOC_S)SFRDHASH,
 					       sizeof(struct hsfile))))
@@ -128,7 +128,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d rdev hash buckets\n",
 		Pn, SFRDHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFsd = (struct hsfile *)calloc((MALLOC_S)SFFSHASH,
 					       sizeof(struct hsfile))))
@@ -136,7 +136,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d file sys hash buckets\n",
 		Pn, SFFSHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyMPC = (struct hsfile *)calloc((MALLOC_S)SFMPCHASH,
 					       sizeof(struct hsfile))))
@@ -144,7 +144,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d MPC file hash buckets\n",
 		Pn, SFMPCHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyNm = (struct hsfile *)calloc((MALLOC_S)SFNMHASH,
 					      sizeof(struct hsfile))))
@@ -152,7 +152,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d name hash buckets\n",
 		Pn, SFNMHASH);
-	    Exit(1);
+	    Error();
 	}
 	hs++;
 /*
@@ -216,7 +216,7 @@ hashSfile()
 			(void) fprintf(stderr,
 			    "%s: can't allocate hsfile bucket for: %s\n",
 			    Pn, s->aname);
-			Exit(1);
+			Error();
 		    }
 		    sn->s = s;
 		    sn->next = sh->next;
@@ -478,7 +478,7 @@ readvfs(vn)
 	if (!(vp = (struct l_vfs *)malloc((MALLOC_S)sizeof(struct l_vfs)))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->dir = (char *)NULL;
 	vp->fsname = (char *)NULL;
@@ -504,7 +504,7 @@ vfs_exit:
 	if (!(mp = (void *)malloc((MALLOC_S)ul))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for mount data\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	if (kread((KA_T)v.vfs_mdata, (char *)mp, (int)ul)) {
 	    (void) free((FREE_P *)mp);
@@ -563,7 +563,7 @@ vfs_exit:
 readvfs_aix1:
 		(void) fprintf(stderr, "%s: PID %d, readvfs, no space\n",
 		    Pn, Lp->pid);
-		Exit(1);
+		Error();
 	    }
 	} else
 	    vp->dir = (char *)NULL;

--- a/dialects/aix/dmnt.c
+++ b/dialects/aix/dmnt.c
@@ -229,7 +229,7 @@ no_space_for_mount:
 
 		(void) fprintf(stderr, "%s: no space for mount at %s (%s)\n",
 		    Pn, fs, dir);
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {

--- a/dialects/aix/dnode.c
+++ b/dialects/aix/dnode.c
@@ -298,7 +298,7 @@ process_node(va)
 #endif	/* defined(HAS_AFS) */
 
 			      );
-		Exit(1);
+		Error();
 	    }
 	}
 /*

--- a/dialects/aix/dproc.c
+++ b/dialects/aix/dproc.c
@@ -261,12 +261,12 @@ ckkv(d, er, ev, ea)
 
 	    (void) fprintf(stderr, "%s: can't execute %s: %s\n",
 		Pn, OSLEVELPATH, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if ((sb.st_mode & (S_IROTH | S_IXOTH)) != (S_IROTH | S_IXOTH)) {
 	    (void) fprintf(stderr, "%s: can't execute %s, modes: %o\n",
 		Pn, OSLEVELPATH, sb.st_mode);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Open a pipe for receiving the version number from OSLEVEL.  Fork a
@@ -275,7 +275,7 @@ ckkv(d, er, ev, ea)
 	if (pipe(p)) {
 	    (void) fprintf(stderr, "%s: can't create pipe to: %s\n",
 		Pn, OSLEVELPATH);
-	    Exit(1);
+	    Error();
 	}
 	if ((pid = fork()) == 0) {
 	    (void) close(1);
@@ -290,7 +290,7 @@ ckkv(d, er, ev, ea)
 	if (pid < 0) {
 	    (void) fprintf(stderr, "%s: can't fork a child for %s: %s\n",
 		Pn, OSLEVELPATH, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	(void) close(p[1]);
 	br = read(p[0], buf, sizeof(buf) - 1);
@@ -430,7 +430,7 @@ gather_proc_info()
 	    if (!(P = (struct PROCINFO *)malloc((MALLOC_S)PROCSIZE))) {
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for 1 proc\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    Np = 1;
 	}
@@ -441,7 +441,7 @@ gather_proc_info()
 	    {
 		(void) fprintf(stderr, "%s: no space for %d procinfo's\n",
 		    Pn, Np);
-		Exit(1);
+		Error();
 	    }
 	}
 #else	/* AIXV>=4300 */
@@ -451,7 +451,7 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for %d procs\n",
 		    Pn, PROCINFO_INCR);
-		Exit(1);
+		Error();
 	    }
 	    Np = PROCINFO_INCR;
 	}
@@ -466,7 +466,7 @@ gather_proc_info()
 		if (!(P = (struct PROCINFO *)realloc((MALLOC_P *)P, msz))) {
 		    (void) fprintf(stderr,
 			"%s: no more space for proc storage\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 		Np += PROCINFO_INCR;
 	    }
@@ -564,7 +564,7 @@ gather_proc_info()
 		    (void) fprintf(stderr,
 			"%s: can't allocate fdsinfo struct for PID %d\n",
 			Pn, pid);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    pid = p->p_pid;
@@ -803,7 +803,7 @@ get_kernel_access()
 		"%s: FATAL: compiled for a kernel of %s bit size.\n", Pn, kbb);
 	    (void) fprintf(stderr,
 		"      The bit size of this kernel is %s.\n", kbr);
-	    Exit(1);
+	    Error();
 	}
 #endif	/* defined(AIX_KERNBITS) */
 
@@ -828,7 +828,7 @@ get_kernel_access()
  * See if the non-KMEM memory file is readable.
  */
 	if (Memory && !is_readable(Memory, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -840,7 +840,7 @@ get_kernel_access()
 	    oe++;
 	}
 	if (oe)
-	    Exit(1);
+	    Error();
 
 #if	defined(WILLDROPGID)
 /*
@@ -857,7 +857,7 @@ get_kernel_access()
 	{
 	    (void) fprintf(stderr, "%s: can't get kernel's %s address\n",
 		Pn, Nl[X_UADDR].n_name);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(HAS_AFS)
@@ -1045,7 +1045,7 @@ getsoinfo()
 					    sizeof(so_hash_t *))))
 	{
 	    (void) fprintf(stderr, "%s: no space for *.so hash buckets\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Cache the loader module information, complete with stat(2) results.
@@ -1069,7 +1069,7 @@ getsoinfo()
 	    if (!(rn = mkstrcpy(lp->mi_name, (MALLOC_S *)NULL))) {
 		(void) fprintf(stderr, "%s: no space for name: %s\n", Pn,
 		    lp->mi_name);
-		Exit(1);
+		Error();
 	    }
 	/*
 	 * Resolve symbolic links.
@@ -1092,7 +1092,7 @@ getsoinfo()
 	    if (!(sp = (so_hash_t *)malloc((MALLOC_S)sizeof(so_hash_t)))) {
 		(void) fprintf(stderr, "%s: no space for *.so hash entry: %s\n",
 		    Pn, ln);
-		Exit(1);
+		Error();
 	    }
 	    sp->dev = sb.st_dev;
 	    sp->nlink = (int)sb.st_nlink;
@@ -1201,7 +1201,7 @@ lowpgsp(sig)
 	int sig;
 {
 	(void) fprintf(stderr, "%s: FATAL: system paging space is low.\n", Pn);
-	Exit(1);
+	Error();
 }
 #endif	/* defined(SIGDANGER) */
 
@@ -1311,7 +1311,7 @@ process_text(sid)
 		if (!f) {
 		    (void) fprintf(stderr,
 			"%s: no space for text file pointers\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    f[n++] = le->fp;

--- a/dialects/darwin/kmem/ddev.c
+++ b/dialects/darwin/kmem/ddev.c
@@ -163,7 +163,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(Dstk[Dstkx], stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    (void) free((FREE_P *)Dstk[Dstkx]);
 	    Dstk[Dstkx] = (char *)NULL;
@@ -187,7 +187,7 @@ readdev(skip)
 		    (void) fprintf(stderr, "%s: no space for: ", Pn);
 		    safestrprt(path, stderr, 0);
 		    safestrprtn(dp->d_name, dnamlen, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		if (STATFN(fp, &sb) != 0) {
 		    if (errno == ENOENT)	/* a sym link to nowhere? */
@@ -241,7 +241,7 @@ readdev(skip)
 			if (!Devtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for character device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    Devtp[i].rdev = sb.st_rdev;
@@ -250,7 +250,7 @@ readdev(skip)
 			(void) fprintf(stderr,
 			    "%s: no space for device name: ", Pn);
 			safestrprt(fp, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 		    Devtp[i].v = 0;
 		    i++;
@@ -273,7 +273,7 @@ readdev(skip)
 			if (!BDevtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for block device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    BDevtp[j].name = fp;
@@ -317,7 +317,7 @@ readdev(skip)
 		sz = (MALLOC_S)(ADevU * sizeof(dev_t));
 		if (!(ADev = (dev_t *)realloc((MALLOC_P *)ADev, sz))) {
 		    (void) fprintf(stderr, "%s: can't reduce ADev[]\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	}
@@ -347,7 +347,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for block device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (j = 0; j < BNdev; j++) {
 		BSdev[j] = &BDevtp[j];
@@ -377,7 +377,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for character device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (i = 0; i < Ndev; i++) {
 		Sdev[i] = &Devtp[i];
@@ -387,7 +387,7 @@ readdev(skip)
 	    Ndev = rmdupdev(&Sdev, Ndev, "char");
 	} else {
 	    (void) fprintf(stderr, "%s: no character devices found\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 }
 
@@ -422,7 +422,7 @@ rmdupdev(dp, n, nm)
 	{
 	    (void) fprintf(stderr, "%s: can't realloc %s device pointers\n",
 		Pn, nm);
-	    Exit(1);
+	    Error();
 	}
 	return(j);
 }
@@ -471,7 +471,7 @@ saveADev(s)
 		ADev = (dev_t *)malloc(sz);
 	    if (!ADev) {
 		(void) fprintf(stderr, "%s: no space for ADev[]\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 	ADev[ADevU++] = s->st_dev;

--- a/dialects/darwin/kmem/dmnt.c
+++ b/dialects/darwin/kmem/dmnt.c
@@ -89,7 +89,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(mb->f_mntfromname, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {
@@ -193,14 +193,14 @@ readvfs(vm)
 	if (!(vp = (struct l_vfs *)malloc(sizeof(struct l_vfs)))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	if (!(vp->dir = mkstrcpy(m.m_stat.f_mntonname, (MALLOC_S *)NULL))
 	||  !(vp->fsname = mkstrcpy(m.m_stat.f_mntfromname, (MALLOC_S *)NULL)))
 	{
 	    (void) fprintf(stderr, "%s: PID %d, no space for mount names\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->addr = vm;
 	vp->fsid = m.m_stat.f_fsid;
@@ -217,7 +217,7 @@ readvfs(vm)
 		    (void) fprintf(stderr,
 			"%s: no space for fs type name: ", Pn);
 		    safestrprt(m.m_stat.f_fstypename, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    } else
 		vp->typnm = "";

--- a/dialects/darwin/kmem/dnode.c
+++ b/dialects/darwin/kmem/dnode.c
@@ -82,7 +82,7 @@ getvpath(va, rv)
 	    if (!(bp = (char *)malloc((MALLOC_S)bl))) {
 		(void) fprintf(stderr, "%s: no space (%d) for path assembly\n",
 		    Pn, (int)bl);
-		Exit(1);
+		Error();
 	    }
 	}
 	pp = bp + bl - 1;
@@ -220,7 +220,7 @@ getvpath(va, rv)
 		if (!(cb = (char *)malloc((MALLOC_S)(MAXPATHLEN + 1)))) {
 		    (void) fprintf(stderr, "%s: no space (%d) for CWD\n",
 			Pn, (int)bl);
-		    Exit(1);
+		    Error();
 		}
 		if (!getcwd(cb, (size_t)(MAXPATHLEN + 1))) {
 		    if (!Fwarn) {
@@ -285,7 +285,7 @@ getvpath_alloc:
 	if (!(ap = (char *)malloc(pl + 1))) {
 	    (void) fprintf(stderr, "%s: no getvpath space (%d)\n",
 		Pn, pl + 1);
-	    Exit(1);
+	    Error();
 	}
 	(void) memmove(ap, pp, pl + 1);
 	return(ap);

--- a/dialects/darwin/kmem/dproc.c
+++ b/dialects/darwin/kmem/dproc.c
@@ -133,7 +133,7 @@ enter_vn_text(va, n)
 	    if (!Vp) {
 		(void) fprintf(stderr, "%s: no txt ptr space, PID %d\n",
 		    Pn, Lp->pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -177,7 +177,7 @@ gather_proc_info()
  */
 	if (read_procs()) {
 	    (void) fprintf(stderr, "%s: can't read process table\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Examine proc structures and their associated information.
@@ -275,7 +275,7 @@ gather_proc_info()
 		if (!ofb) {
 		    (void) fprintf(stderr, "%s: PID %d, no file * space\n",
 			Pn, p->p_pid);
-		    Exit(1);
+		    Error();
 		}
 		ofbb = nb;
 	    }
@@ -291,7 +291,7 @@ gather_proc_info()
 		if (!pof) {
 		    (void) fprintf(stderr, "%s: PID %d, no file flag space\n",
 			Pn, p->p_pid);
-		    Exit(1);
+		    Error();
 		}
 		pofb = nb;
 	    }
@@ -347,12 +347,12 @@ getcmdnm(pid)
 	    if (sysctl(mib, 2, &am, &sz, NULL, 0) == -1) {
 		(void) fprintf(stderr, "%s: can't get arg max, PID %d\n",
 		    Pn, pid);
-		Exit(1);
+		Error();
 	    }
 	    if (!(ap = (char *)malloc((MALLOC_S)am))) {
 		(void) fprintf(stderr, "%s: no arg ptr (%d) space, PID %d\n",
 		    Pn, am, pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -433,7 +433,7 @@ get_kernel_access()
  */
 	if ((Memory && !is_readable(Memory, 1))
 	||  (Nmlst && !is_readable(Nmlst, 1)))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -444,13 +444,13 @@ get_kernel_access()
 	    (void) fprintf(stderr, "%s: open(%s): %s\n", Pn,
 	        Memory ? Memory : KMEM,
 		strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	(void) build_Nl(Drive_Nl);
 	if (nlist(Nmlst, Nl) < 0) {
 	    (void) fprintf(stderr, "%s: can't read namelist from %s\n",
 		Pn, Nmlst);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(WILLDROPGID)
@@ -624,7 +624,7 @@ read_procs()
 	    if (get_Nl_value("aproc", Drive_Nl, &Akp) < 0 || !Akp) {
 		(void) fprintf(stderr, "%s: can't get proc table address\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -633,12 +633,12 @@ read_procs()
  */
 	if (get_Nl_value("nproc", Drive_Nl, &kp) < 0 || !kp) {
 	    (void) fprintf(stderr, "%s: can't get nproc address\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (kread(kp, (char *)&np, sizeof(np))) {
 	    (void) fprintf(stderr, "%s: can't read process count from %s\n",
 		Pn, print_kptr(kp, (char *)NULL, 0));
-	    Exit(1);
+	    Error();
 	}
 	for (np += np, pe = PINCRSZ; pe < np; pe += PINCRSZ)
 	    ;
@@ -652,7 +652,7 @@ read_procs()
 	    Proc = (struct proc *)realloc((MALLOC_P *)Proc, msz);
 	if (!Proc) {
 	    (void) fprintf(stderr, "%s: no space for proc table\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	msz = (MALLOC_S)(pe * sizeof(KA_T));
 	if (!Pa)
@@ -661,7 +661,7 @@ read_procs()
 	    Pa = (KA_T *)realloc((MALLOC_P *)Pa, msz);
 	if (!Pa) {
 	    (void) fprintf(stderr, "%s: no space for proc addr table\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	Npa = pe;
 /*
@@ -680,7 +680,7 @@ read_procs()
 	}
 	if (!Phash) {
 	    (void) fprintf(stderr, "%s: no space for proc address hash\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Read the proc structures on the kernel's chain.
@@ -702,7 +702,7 @@ read_procs()
 	    if (!(ph = (struct phash *)malloc((MALLOC_S)sizeof(struct phash))))
 	    {
 		(void) fprintf(stderr, "%s: no space for phash struct\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    ph->ka = kp;
 	    ph->la = p;
@@ -719,13 +719,13 @@ read_procs()
 		if (!(Proc = (struct proc *)realloc((MALLOC_P *)Proc, msz))) {
 		    (void) fprintf(stderr, "%s: no additional proc space\n",
 			Pn);
-		    Exit(1);
+		    Error();
 		}
 		msz = (int)((Npa + PINCRSZ) * sizeof(KA_T));
 		if (!(Pa = (KA_T *)realloc((MALLOC_P *)Pa, msz))) {
 		    (void) fprintf(stderr,
 			"%s: no additional proc addr space\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 		Npa += PINCRSZ;
 	    }
@@ -736,7 +736,7 @@ read_procs()
  */
 	if (i >= pe) {
 	    (void) fprintf(stderr, "%s: can't follow kernel proc chain\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * If not in repeat mode, reduce Pa[] and Proc[] to their minimums.
@@ -745,13 +745,13 @@ read_procs()
 	    msz = (MALLOC_S)(Np * sizeof(struct proc));
 	    if (!(Proc = (struct proc *)realloc((MALLOC_P *)Proc, msz))) {
 		(void) fprintf(stderr, "%s: can't reduce proc table\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    msz = (MALLOC_S)(Np * sizeof(KA_T));
 	    if (!(Pa = (KA_T *)realloc((MALLOC_P *)Pa, msz))) {
 		(void) fprintf(stderr, "%s: can't reduce proc addr table\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	    Npa = Np;
 	}

--- a/dialects/darwin/libproc/ddev.c
+++ b/dialects/darwin/libproc/ddev.c
@@ -164,7 +164,7 @@ printdevname(dev, rdev, f, nty)
 	    if (!(cp = (char *)malloc((MALLOC_S)(len + 1)))) {
 		(void) fprintf(stderr, "%s: no nma space for: (%s %s)\n",
 		    Pn, ttl, dp->name);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(cp, len + 1, "(%s %s)", ttl, dp->name);
 	    (void) add_nma(cp, len);
@@ -233,7 +233,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(Dstk[Dstkx], stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    (void) free((FREE_P *)Dstk[Dstkx]);
 	    Dstk[Dstkx] = (char *)NULL;
@@ -257,7 +257,7 @@ readdev(skip)
 		    (void) fprintf(stderr, "%s: no space for: ", Pn);
 		    safestrprt(path, stderr, 0);
 		    safestrprtn(dp->d_name, dnamlen, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		if (STATFN(fp, &sb) != 0) {
 		    if (errno == ENOENT)	/* a sym link to nowhere? */
@@ -311,7 +311,7 @@ readdev(skip)
 			if (!Devtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for character device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    Devtp[i].rdev = sb.st_rdev;
@@ -320,7 +320,7 @@ readdev(skip)
 			(void) fprintf(stderr,
 			    "%s: no space for device name: ", Pn);
 			safestrprt(fp, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 		    Devtp[i].v = 0;
 		    i++;
@@ -343,7 +343,7 @@ readdev(skip)
 			if (!BDevtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for block device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    BDevtp[j].name = fp;
@@ -387,7 +387,7 @@ readdev(skip)
 		sz = (MALLOC_S)(ADevU * sizeof(dev_t));
 		if (!(ADev = (dev_t *)realloc((MALLOC_P *)ADev, sz))) {
 		    (void) fprintf(stderr, "%s: can't reduce ADev[]\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	}
@@ -417,7 +417,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for block device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (j = 0; j < BNdev; j++) {
 		BSdev[j] = &BDevtp[j];
@@ -447,7 +447,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for character device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (i = 0; i < Ndev; i++) {
 		Sdev[i] = &Devtp[i];
@@ -457,7 +457,7 @@ readdev(skip)
 	    Ndev = rmdupdev(&Sdev, Ndev, "char");
 	} else {
 	    (void) fprintf(stderr, "%s: no character devices found\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 }
 
@@ -492,7 +492,7 @@ rmdupdev(dp, n, nm)
 	{
 	    (void) fprintf(stderr, "%s: can't realloc %s device pointers\n",
 		Pn, nm);
-	    Exit(1);
+	    Error();
 	}
 	return(j);
 }
@@ -541,7 +541,7 @@ saveADev(s)
 		ADev = (dev_t *)malloc(sz);
 	    if (!ADev) {
 		(void) fprintf(stderr, "%s: no space for ADev[]\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 	ADev[ADevU++] = s->st_dev;

--- a/dialects/darwin/libproc/dfile.c
+++ b/dialects/darwin/libproc/dfile.c
@@ -394,7 +394,7 @@ process_kqueue(pid, fd)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(kq), nb);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Enter the kernel queue file information.
@@ -479,7 +479,7 @@ process_pipe(pid, fd)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 	       sizeof(pi), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_pipe_common(&pi);
@@ -508,7 +508,7 @@ process_fileport_pipe(pid, fp)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 	       sizeof(pi), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_pipe_common(&pi);
@@ -542,7 +542,7 @@ process_psem(pid, fd)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(ps), nb);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Enter the semaphore file information.
@@ -624,7 +624,7 @@ process_pshm(pid, fd)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(ps), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_pshm_common(&ps);
@@ -653,7 +653,7 @@ process_fileport_pshm(pid, fp)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(ps), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_pshm_common(&ps);
@@ -706,7 +706,7 @@ process_vnode(pid, fd)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(vi), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_vnode_common(&vi);
@@ -743,7 +743,7 @@ process_fileport_vnode(pid, fp)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(vi), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_vnode_common(&vi);

--- a/dialects/darwin/libproc/dmnt.c
+++ b/dialects/darwin/libproc/dmnt.c
@@ -121,7 +121,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(mb->f_mntfromname, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {

--- a/dialects/darwin/libproc/dproc.c
+++ b/dialects/darwin/libproc/dproc.c
@@ -151,7 +151,7 @@ enter_vn_text(vip, n)
 	    if (!Vips) {
 		(void) fprintf(stderr, "%s: PID %d: no text recording space\n",
 		    Pn, Lp->pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -241,7 +241,7 @@ gather_proc_info()
 	if ((nb = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0)) <= 0) {
 	    (void) fprintf(stderr, "%s: can't get PID byte count: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if (nb > NbPids) {
 	    while (nb > NbPids) {
@@ -255,7 +255,7 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for %d PIDs\n", Pn,
 		    (int)(NbPids / sizeof(int *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -265,7 +265,7 @@ gather_proc_info()
 	    if ((nb = proc_listpids(PROC_ALL_PIDS, 0, Pids, NbPids)) <= 0) {
 		(void) fprintf(stderr, "%s: can't get list of PIDs: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 
 	    if ((nb + sizeof(int)) < NbPids) {
@@ -286,7 +286,7 @@ gather_proc_info()
 		    (void) fprintf(stderr,
 			"%s: can't allocate space for %d PIDs\n", Pn,
 			(int)(NbPids / sizeof(int *)));
-		    Exit(1);
+		    Error();
 		}
 	    }
 	}
@@ -312,7 +312,7 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "      too few bytes; expected %ld, got %d\n",
 		    sizeof(tai), nb);
-		Exit(1);
+		Error();
 	    }
 	/*
 	 * Check for process or command exclusion.
@@ -355,7 +355,7 @@ gather_proc_info()
 		    (void) fprintf(stderr,
 			"      too few bytes; expected %ld, got %d\n",
 			sizeof(vpi), nb);
-		    Exit(1);
+		    Error();
 		} else
 		    cres = 0;
 	    }
@@ -488,7 +488,7 @@ process_fds(pid, n, ckscko)
 	    (void) fprintf(stderr,
 		"%s: PID %d: can't allocate space for %d FDs\n",
 		Pn, pid, (int)(NbFds / sizeof(struct proc_fdinfo)));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Get FD information for the process.
@@ -623,7 +623,7 @@ process_fileports(pid, ckscko)
 		if (Fps && ((nb = proc_pidinfo(pid, PROC_PIDLISTFILEPORTS, 0, NULL, 0)) <= 0)) {
 		    (void) fprintf(stderr, "%s: can't get fileport byte count: %s\n",
 					Pn, strerror(errno));
-		    Exit(1);
+		    Error();
 		}
 
 		/*
@@ -728,7 +728,7 @@ process_text(pid)
 		(void) fprintf(stderr,
 		    "      too few bytes; expected %ld, got %d\n",
 		    sizeof(rwpi), nb);
-		Exit(1);
+		Error();
 	    }
 	    if (rwpi.prp_vip.vip_path[0])
 		enter_vn_text(&rwpi.prp_vip, &n);
@@ -768,7 +768,7 @@ process_threads(pid, n)
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for %d Threads\n", Pn,
 		    (int)(NbThreads / sizeof(int *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -824,7 +824,7 @@ process_threads(pid, n)
 		(void) fprintf(stderr,
 		    "      too few bytes; expected %ld, got %d\n",
 		    sizeof(tpi), nb);
-		Exit(1);
+		Error();
 	    }
 	    if (tpi.pvip.vip_path[0]) {
 		alloc_lfile(TWD, -1);

--- a/dialects/darwin/libproc/dsock.c
+++ b/dialects/darwin/libproc/dsock.c
@@ -411,7 +411,7 @@ process_socket(pid, fd)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(si), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_socket_common(&si);
@@ -440,7 +440,7 @@ process_fileport_socket(pid, fp)
 	    (void) fprintf(stderr,
 		"      too few bytes; expected %ld, got %d\n",
 		sizeof(si), nb);
-	    Exit(1);
+	    Error();
 	}
 
 	process_socket_common(&si);

--- a/dialects/du/ddev.c
+++ b/dialects/du/ddev.c
@@ -163,7 +163,7 @@ printdevname_again:
 	    if (!(cp = (char *)malloc((MALLOC_S)(len + 1)))) {
 		(void) fprintf(stderr, "%s: no nma space for: (%s %s)\n",
 		    Pn, ttl, dp->name);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(cp, len + 1, "(%s %s)", ttl, dp->name);
 	    (void) add_nma(cp, len);
@@ -258,7 +258,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(Dstk[Dstkx], stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    (void) free((FREE_P *)Dstk[Dstkx]);
 	    Dstk[Dstkx] = (char *)NULL;
@@ -281,7 +281,7 @@ readdev(skip)
 		    (void) fprintf(stderr, "%s: no space for: ", Pn);
 		    safestrprt(path, stderr, 0);
 		    safestrprt(dp->d_name, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 
 #if	defined(USE_STAT)
@@ -330,14 +330,14 @@ readdev(skip)
 			if (!Devtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for character device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    Devtp[i].inode = (INODETYPE)sb.st_ino;
 		    if (!(Devtp[i].name = mkstrcpy(fp, (MALLOC_S *)NULL))) {
 			(void) fprintf(stderr, "%s: no space for: ", Pn);
 			safestrprt(fp, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 		    Devtp[i].rdev = sb.st_rdev;
 		    Devtp[i].v = 0;
@@ -352,7 +352,7 @@ readdev(skip)
 			    (void) fprintf(stderr,
 				"%s: no space for clone device: ", Pn);
 			    safestrprt(fp, stderr, 1);
-			    Exit(1);
+			    Error();
 			}
 			c->dx = i;
 			c->next = Clone;
@@ -379,7 +379,7 @@ readdev(skip)
 			if (!BDevtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for block device\n", Pn);
-				Exit(1);
+				Error();
 			}
 		    }
 		    BDevtp[j].inode = (INODETYPE)sb.st_ino;
@@ -424,7 +424,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for block device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (j = 0; j < BNdev; j++) {
 		BSdev[j] = &BDevtp[j];
@@ -454,7 +454,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for character device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (i = 0; i < Ndev; i++) {
 		Sdev[i] = &Devtp[i];
@@ -464,7 +464,7 @@ readdev(skip)
 	    Ndev = rmdupdev(&Sdev, Ndev, "char");
 	} else {
 	    (void) fprintf(stderr, "%s: no character devices found\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(HASDCACHE)
@@ -719,7 +719,7 @@ rmdupdev(dp, n, nm)
 	{
 	    (void) fprintf(stderr, "%s: can't realloc %s device pointers\n",
 		Pn, nm);
-	    Exit(1);
+	    Error();
 	}
 	return(j);
 }

--- a/dialects/du/dmnt.c
+++ b/dialects/du/dmnt.c
@@ -128,7 +128,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(mb->f_mntfromname, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {
@@ -260,7 +260,7 @@ readvfs(vm)
 	if (!(vp = (struct l_vfs *)malloc(sizeof(struct l_vfs)))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 
 #if	DUV<40000
@@ -284,7 +284,7 @@ readvfs(vm)
 	{
 	    (void) fprintf(stderr, "%s: PID %d, no space for mount names\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->addr = vm;
 	vp->fsid = m.m_stat.f_fsid;

--- a/dialects/du/dnode.c
+++ b/dialects/du/dnode.c
@@ -305,7 +305,7 @@ load_flinfo()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte local lock hash buckets\n",
 		    Pn, L_FLINFO_HSZ * sizeof(struct l_flinfo *));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -328,7 +328,7 @@ load_flinfo()
 	    if (!(lfi = (struct l_flinfo *)malloc(sizeof(struct l_flinfo)))) {
 		(void) fprintf(stderr,
 		    "%s: no space for local vnode lock info struct\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    lfi->vp = fi.vp;
 	    lfi->lp = (struct l_lock *)NULL;
@@ -347,7 +347,7 @@ load_flinfo()
 		if (!(ll = (struct l_lock *)malloc(sizeof(struct l_lock)))) {
 		    (void) fprintf(stderr,
 			"%s: no space for local lock struct\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 		ll->next = lfi->lp;
 		lfi->lp = ll;
@@ -418,13 +418,13 @@ process_node(va)
 	 */
 	    if (!(v = (struct vnode *)malloc(sizeof(struct vnode)-1+Vnmxp))) {
 		(void) fprintf(stderr, "%s: no space for vnode buffer\n", Pn);
-		Exit(1);
+		Error();
 	    }
 
 #if	DUV>=30000
 	    if (!(fv = (struct vnode *)malloc(sizeof(struct vnode)-1+Vnmxp))) {
 		(void) fprintf(stderr, "%s: no space for fvnode buffer\n", Pn);
-		Exit(1);
+		Error();
 	    }
 #endif	/* DUV>=30000 */
 

--- a/dialects/du/dproc.c
+++ b/dialects/du/dproc.c
@@ -130,7 +130,7 @@ enter_vn_text(va, n)
 	    if (!Vp) {
 		(void) fprintf(stderr, "%s: no txt ptr space, PID %d\n",
 		    Pn, Lp->pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -284,7 +284,7 @@ gather_proc_info()
 				(void) fprintf(stderr,
 				    "%s: PID %d, no file * space\n",
 				    Pn, Lp->pid);
-				Exit(1);
+				Error();
 			    }
 			    nufb = b;
 			}
@@ -305,7 +305,7 @@ gather_proc_info()
 				    (void) fprintf(stderr,
 					"%s: PID %d: no file flags space\n",
 					Pn, Lp->pid);
-				    Exit(1);
+				    Error();
 				}
 				pofb = b;
 			    }
@@ -444,7 +444,7 @@ get_kernel_access()
 	    if (!(Nmlst = get_nlist_path(1))) {
 		(void) fprintf(stderr, "%s: can't get kernel name list path\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* DUV<40000 */
@@ -461,7 +461,7 @@ get_kernel_access()
  * See if the non-KMEM memory file is readable.
  */
 	if (Memory && !is_readable(Memory, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -470,7 +470,7 @@ get_kernel_access()
 	if ((Kd = open(Memory ? Memory : KMEM, O_RDONLY, 0)) < 0) {
 	    (void) fprintf(stderr, "%s: can't open %s: %s\n", Pn,
 		Memory ? Memory : KMEM, sys_errlist[errno]);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(WILLDROPGID)
@@ -484,7 +484,7 @@ get_kernel_access()
  * See if the name list file is readable.
  */
 	if (Nmlst && !is_readable(Nmlst, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -503,7 +503,7 @@ get_kernel_access()
 	    (void) fprintf(stderr,
 		"%s: can't read kernel name list from %s: %s\n",
 		Pn, Nmlst ? Nmlst : "knlist(3)", strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 
 #if	DUV<30000
@@ -520,12 +520,12 @@ get_kernel_access()
 
 	{
 	    (void) fprintf(stderr, "%s: can't read proc table info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("vnmaxp", Drive_Nl, &v) < 0 || !v
 	||  kread(v, (char *)&Vnmxp, sizeof(Vnmxp))) {
 	    (void) fprintf(stderr, "%s: can't determine vnode length\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("cldev", Drive_Nl, &v) < 0 || !v
 	||  kread(v, (char *)&dev, sizeof(dev))) {
@@ -564,7 +564,7 @@ get_nlist_path(ap)
 	    if (rv < 0) {
 		(void) fprintf(stderr, "%s: can't get booted file name: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    return((char *)NULL);
 	}
@@ -599,7 +599,7 @@ get_nlist_path(ap)
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes for boot file path: %s\n",
 		Pn, len, ba);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(ps, len, "%s", ba);
 	return(ps);
@@ -812,13 +812,13 @@ read_proc()
 	 */
 	    if (Np < 1) {
 		(void) fprintf(stderr, "%s: proc table has no entries\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    len = (MALLOC_S)(PAPSINIT * sizeof(struct proc));
 	    if (!(Ps = (struct proc *)malloc(len))) {
 		(void) fprintf(stderr, "%s: no proc table space (%d bytes)\n",
 		    Pn, len);
-		Exit(1);
+		Error();
 	    }
 
 #if	DUV>=30000
@@ -829,7 +829,7 @@ read_proc()
 	    if (!(Pa = (KA_T *)malloc(len))) {
 		(void) fprintf(stderr,
 		    "%s: no proc address table space (%d bytes)\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 #endif	/* DUV>=30000 */
 
@@ -852,7 +852,7 @@ read_proc()
 			(void) fprintf(stderr,
 			    "%s: no more proc table space (%d bytes)\n",
 			    Pn, len);
-			Exit(1);
+			Error();
 		    }
 		    p = &Ps[Psn];
 
@@ -862,7 +862,7 @@ read_proc()
 			(void) fprintf(stderr,
 			    "%s: no more proc address table space (%d bytes)\n",
 			    Pn, len);
-			Exit(1);
+			Error();
 		    }
 #endif	/* DUV>=30000 */
 
@@ -898,7 +898,7 @@ read_proc()
  */
 	if (try >= PROCTRYLM) {
 	    (void) fprintf(stderr, "%s: can't read proc table\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (Psn < Np && !RptTm) {
 
@@ -912,7 +912,7 @@ read_proc()
 		(void) fprintf(stderr,
 		    "%s: can't reduce proc table to %d bytes\n",
 		    Pn, len);
-		Exit(1);
+		Error();
 	    }
 
 #if	DUV>=30000
@@ -921,7 +921,7 @@ read_proc()
 		(void) fprintf(stderr,
 		    "%s: can't reduce proc address table to %d bytes\n",
 		    Pn, len);
-		Exit(1);
+		Error();
 	    }
 #endif	/* DUV>=30000 */
 
@@ -1204,7 +1204,7 @@ ncache_ckrootid(na, id)
 	    if (!ic) {
 		(void) fprintf(stderr,
 		    "%s: no space for root node VPID table\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    nia += 10;
 	}
@@ -1291,7 +1291,7 @@ ncache_isroot(na, cp)
 	    if (!nc) {
 		(void) fprintf(stderr,
 		    "%s: no space for root node address table\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    nca += 10;
 	}
@@ -1374,7 +1374,7 @@ ncache_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for processor addresses\n",
 			Pn, len);
-		Exit(1);
+		Error();
 	    }
 	    if (kread(ka, (char *)pp, len)) {
 		if (!Fwarn)
@@ -1422,7 +1422,7 @@ ncache_load()
 		(void) fprintf(stderr,
 		    "%s: no space for %d namecache entries (%d bytes)\n",
 		    Pn, ncpc * ncpus, len);
-		Exit(1);
+		Error();
 	    }
 	} else {
 
@@ -1469,7 +1469,7 @@ ncache_load()
 		(void) fprintf(stderr,
 		    "%s: no space for %d byte name cache hash buckets\n",
 		    Pn, (int)(i * sizeof(struct l_nch *)));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Assign hash pointers to the accumulated namecache entries.
@@ -1502,7 +1502,7 @@ ncache_load()
 	 */
 	    if (!(lp = (struct l_nch *)malloc(sizeof(struct l_nch)))) {
 		(void) fprintf(stderr, "%s: can't allocate l_nch entry\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    lp->nc = &nc[i];
 	    lp->nxt = Nchash[h];

--- a/dialects/freebsd/dmnt.c
+++ b/dialects/freebsd/dmnt.c
@@ -123,7 +123,7 @@ Dev2Udev(c)
  */
 	if ((n = getmntinfo(&mb, MNT_NOWAIT)) <= 0) {
 	    (void) fprintf(stderr, "%s: no mount information\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	for (; n; n--, mb++) {
 
@@ -149,7 +149,7 @@ Dev2Udev_no_space:
 		(void) fprintf(stderr, " (");
 		safestrprt(mb->f_mntfromname, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {
@@ -223,7 +223,7 @@ Dev2Udev_no_space:
 
 	}
 	(void) fprintf(stderr, "%s: can't determine user device random seed.\n",	    Pn);
-	Exit(1);
+	Error();
 
 # endif	/* !defined(HAS_CONF_MINOR) */
 
@@ -284,7 +284,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(mb->f_mntfromname, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {
@@ -414,14 +414,14 @@ readvfs(vm)
 	if (!(vp = (struct l_vfs *)malloc(sizeof(struct l_vfs)))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	if (!(vp->dir = mkstrcpy(m.m_stat.f_mntonname, (MALLOC_S *)NULL))
 	||  !(vp->fsname = mkstrcpy(m.m_stat.f_mntfromname, (MALLOC_S *)NULL)))
 	{
 	    (void) fprintf(stderr, "%s: PID %d, no space for mount names\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->addr = vm;
 	vp->fsid = m.m_stat.f_fsid;
@@ -442,7 +442,7 @@ readvfs(vm)
 		    (void) fprintf(stderr,
 			"%s: no space for fs type name: ", Pn);
 		    safestrprt(m.m_stat.f_fstypename, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    } else
 		vp->typnm = "";

--- a/dialects/freebsd/dproc.c
+++ b/dialects/freebsd/dproc.c
@@ -96,7 +96,7 @@ enter_vn_text(va, n)
 	    if (!Vp) {
 		(void) fprintf(stderr, "%s: no txt ptr space, PID %d\n",
 		    Pn, Lp->pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -235,7 +235,7 @@ gather_proc_info()
 		kvm_geterr(Kd)
 
 	    );
-	    Exit(1);
+	    Error();
 	}
 /*
  * Examine proc structures and their associated information.
@@ -397,7 +397,7 @@ gather_proc_info()
 		if (!ofb) {
 		    (void) fprintf(stderr, "%s: PID %d, no file * space\n",
 			Pn, p->P_PID);
-		    Exit(1);
+		    Error();
 		}
 		ofbb = nb;
 	    }
@@ -424,7 +424,7 @@ gather_proc_info()
 		    if (!pof) {
 			(void) fprintf(stderr,
 			    "%s: PID %d, no file flag space\n", Pn, p->P_PID);
-			Exit(1);
+			Error();
 		    }
 		    pofb = nb;
 		}
@@ -497,7 +497,7 @@ get_kernel_access()
 	    if (!(Nmlst = get_nlist_path(1))) {
 		(void) fprintf(stderr,
 		    "%s: can't get kernel name list path\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* defined(N_UNIX) */
@@ -515,7 +515,7 @@ get_kernel_access()
  */
 	if ((Memory && !is_readable(Memory, 1))
 	||  (Nmlst && !is_readable(Nmlst, 1)))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -541,13 +541,13 @@ get_kernel_access()
 #endif	/* defined(_PATH_MEM) */
 
 		strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	(void) build_Nl(Drive_Nl);
 	if (kvm_nlist(Kd, Nl) < 0) {
 	    (void) fprintf(stderr, "%s: can't read namelist from %s\n",
 		Pn, Nmlst);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(X_BADFILEOPS)
@@ -598,7 +598,7 @@ get_nlist_path(ap)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for boot file path: %s\n",
 		    Pn, (int)bfl, bf);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(bfc, bfl, "%s", bf);
 	    return(bfc);

--- a/dialects/hpux/kmem/dmnt.c
+++ b/dialects/hpux/kmem/dmnt.c
@@ -126,7 +126,7 @@ completevfs(vfs, dev)
 	    if (!(vfs->dir = mkstrcpy(v->vfs_name, (MALLOC_S *)NULL))) {
 		(void) fprintf(stderr, "%s: no space for vfs name: ", Pn);
 		safestrprt(v->vfs_name, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    if (statsafely(v->vfs_name, &sb) == 0)
 		vfs->dev = sb.st_dev;
@@ -167,7 +167,7 @@ readvfs(lv)
 	if ((vp = (struct l_vfs *)malloc(sizeof(struct l_vfs))) == NULL) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->dev = 0;
 	vp->dir = (char *)NULL;

--- a/dialects/hpux/kmem/dnode.c
+++ b/dialects/hpux/kmem/dnode.c
@@ -371,7 +371,7 @@ process_node(va)
 #endif	/* defined(HAS_AFS) */
 
 		);
-		Exit(1);
+		Error();
 	    }
 	}
 	if (readvnode(va, v)) {

--- a/dialects/hpux/kmem/dproc.c
+++ b/dialects/hpux/kmem/dproc.c
@@ -231,12 +231,12 @@ gather_proc_info()
 		if (kread(v, (char *)&oftsz, sizeof(oftsz))) {
 		    (void) fprintf(stderr, "%s: can't get FD chunk size\n",
 			Pn);
-		    Exit(1);
+		    Error();
 		}
 		if (!oftsz) {
 		    (void) fprintf(stderr, "%s: bad FD chunk size: %d\n",
 			Pn, oftsz);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    ofasz = (int)(oftsz / SFDCHUNK);
@@ -244,12 +244,12 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "%s: FD chunk size (%d) not exact multiple of %d\n",
 		    Pn, oftsz, SFDCHUNK);
-		Exit(1);
+		Error();
 	    }
 	    if (!(oftp = (char *)malloc((MALLOC_S)oftsz))) {
 		(void) fprintf(stderr, "%s: no space for %d FD bytes\n",
 		    Pn, oftsz);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* HPUXV>=1100 */
@@ -521,14 +521,14 @@ get_kernel_access()
 		(void) fprintf(stderr,
 		    "%s: sysconf(_SC_KERNEL_BITS) returns: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    if (rv != (long)HPUXKERNBITS) {
 		(void) fprintf(stderr,
 		    "%s: FATAL: %s was built for a %d bit kernel, but this\n",
 		    Pn, Pn, HPUXKERNBITS);
 		(void) fprintf(stderr, "      is a %ld bit kernel.\n", rv);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* HPUXV>=1030 */
@@ -567,7 +567,7 @@ get_kernel_access()
  * See if the non-KMEM memory file is readable.
  */
 	if (Memory && !is_readable(Memory, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -579,7 +579,7 @@ get_kernel_access()
 	    (void) fprintf(stderr, "%s: can't open ", Pn);
 	    safestrprt(Memory ? Memory : KMEM, stderr, 0);
 	    (void) fprintf(stderr, ": %s\n", strerror(errno_save));
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(WILLDROPGID)
@@ -593,7 +593,7 @@ get_kernel_access()
  * See if the name list file is readable.
  */
 	if (Nmlst && !is_readable(Nmlst, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 	(void) build_Nl(Drive_Nl);
@@ -609,7 +609,7 @@ get_kernel_access()
 	    if (!(nl = (struct NLIST_TYPE *)malloc(Nll))) {
 		(void) fprintf(stderr,
 		    "%s: no space (%d) for Nl[] copy\n", Pn, Nll);
-		Exit(1);
+		Error();
 	    }
 	    (void) memcpy((void *)nl, (void *)Nl, (size_t)Nll);
 	}
@@ -621,7 +621,7 @@ get_kernel_access()
 	if (NLIST_TYPE(Nmlst ? Nmlst : N_UNIX, Nl) < 0) {
 	    (void) fprintf(stderr, "%s: can't read namelist from: ", Pn);
 	    safestrprt(Nmlst ? Nmlst : N_UNIX, stderr, 1);
-            Exit(1);
+            Error();
 	}
 	if (get_Nl_value("proc", Drive_Nl, &v) < 0 || !v
 	||  kread((KA_T)v, (char *)&Kp, sizeof(Kp))
@@ -629,7 +629,7 @@ get_kernel_access()
 	||  kread((KA_T)v, (char *)&Np, sizeof(Np))
 	||  !Kp || Np < 1) {
 	    (void) fprintf(stderr, "%s: can't read proc table info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("vfops", Drive_Nl, (KA_T *)&Vnfops) < 0)
 	    Vnfops = (KA_T)NULL;
@@ -637,11 +637,11 @@ get_kernel_access()
 #if	HPUXV<800 && defined(hp9000s300)
 	if (get_Nl_value("upmap", Drive_Nl, (unsigned long *)&Usrptmap) < 0) {
 	    (void) fprintf(stderr, "%s: can't get kernel's Usrptmap\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("upt", Drive_Nl, (unsigned long *)&usrpt) < 0) {
 	    (void) fprintf(stderr, "%s: can't get kernel's usrpt\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 #endif	/* HPUXV<800 && defined(hp9000s300) */
 
@@ -649,12 +649,12 @@ get_kernel_access()
 	proc = (struct proc *)Kp;
 	if (get_Nl_value("ubase", Drive_Nl, (unsigned long *)&ubase) < 0) {
 	    (void) fprintf(stderr, "%s: can't get kernel's ubase\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("npids", Drive_Nl, &v) < 0 || !v
 	||  kread((KA_T)v, (char *)&npids, sizeof(npids))) {
 	    (void) fprintf(stderr, "%s: can't get kernel's npids\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 #endif	/* HPUXV<800 && defined(hp9000s800) */
 
@@ -811,7 +811,7 @@ process_text(vasp)
 		if (!Vp) {
 		    (void) fprintf(stderr,
 			"%s: no more space for text vnode pointers\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    Vp[i++] = va;

--- a/dialects/hpux/kmem/dsock.c
+++ b/dialects/hpux/kmem/dsock.c
@@ -864,7 +864,7 @@ process_socket(sa)
 			    (void) fprintf(stderr,
 				"%s: no space (%d) for UNIX socket address\n",
 				Pn, dbl);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    if (kread((KA_T)db.db_base, dbf, db.db_size) == 0) {

--- a/dialects/hpux/pstat/dfile.c
+++ b/dialects/hpux/pstat/dfile.c
@@ -206,7 +206,7 @@ ncache_alloc()
 	{
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d local name cache entries\n", Pn, Nceh);
-	    Exit(1);
+	    Error();
 	}
 	if (Ncfsid)
 	    return;
@@ -215,7 +215,7 @@ ncache_alloc()
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d local file system cache entries\n",
 		Pn, NFSIDH);
-	    Exit(1);
+	    Error();
 	}
 }
 
@@ -328,7 +328,7 @@ ncache_loadfs(fsid, fh)
  */
 	if (!(f = (struct l_fic *)malloc(sizeof(struct l_fic)))) {
 	    (void) fprintf(stderr, "%s: no fsid structure space\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	f->fsid = *fsid;
 	f->nc = 0;
@@ -355,13 +355,13 @@ ncache_loadfs(fsid, fh)
 		    (void) fprintf(stderr,
 			"%s: no name entry space (%d) for:%s\n",
 			Pn, nl + 1, mp[i].psr_name);
-		    Exit(1);
+		    Error();
 		}
 		if (!(nn = (struct l_nc *)malloc(sizeof(struct l_nc)))) {
 		    (void) fprintf(stderr,
 			"%s: no name cache entry space (%d) for: %s\n",
 			Pn, (int)sizeof(struct l_nc), mp[i].psr_name);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Fill in name cache entry, complete with name and name length.
@@ -606,7 +606,7 @@ ncache_size()
 
 	if (pstat_getdynamic(&pd, sizeof(pd), 1, 0) != 1) {
 	    (void) fprintf(stderr, "%s: can't get dynamic status\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	Ndnlc = (int)pd.psd_dnlc_size;
 	for (Nceh = 1; Nceh < (Ndnlc + Ndnlc); Nceh <<= 1)

--- a/dialects/hpux/pstat/dproc.c
+++ b/dialects/hpux/pstat/dproc.c
@@ -166,7 +166,7 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d FD status entries\n", Pn,
 		    FDS_ALLOC_INIT);
-		Exit(1);
+		Error();
 	    }
 	    for (fdsa = 0; fdsa < FDS_ALLOC_INIT; fdsa++) {
 		if (Fand && Fdl)
@@ -330,7 +330,7 @@ gather_proc_info()
 			    (void) fprintf(stderr,
 				"%s: can't reallocate %d FD status entries\n",
 				Pn, l);
-			    Exit(1);
+			    Error();
 			}
 			while (fdsa < l) {
 			    fds[fdsa] = (ck_fd_status(NULL, fdsa) == 2) ? 1 : 0;
@@ -474,13 +474,13 @@ get_kernel_access()
 	    (void) fprintf(stderr,
 		"%s: FATAL: can't determine PSTAT static size: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if (pstat_getstatic(&pst, (size_t)pst.pst_static_size, 1, 0) != 1) {
 	    (void) fprintf(stderr,
 		"%s: FATAL: can't read %ld bytes of pst_static\n",
 		Pn, (long)pst.pst_static_size);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Check all the pst_static members defined in PstatCk[].
@@ -511,7 +511,7 @@ get_kernel_access()
 	}
 	if (!err)
 	    return;
-	Exit(1);
+	Error();
 }
 
 
@@ -580,7 +580,7 @@ no_txtvm_space:
 		(void) fprintf(stderr,
 		    "%s: no memory for text and VM info array; PID: %d\n",
 		    Pn, (int)p->pst_pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -733,7 +733,7 @@ read_files(p, n)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for pst_filinfo\n",
 			Pn, nb);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*
@@ -788,7 +788,7 @@ ps_alloc_error:
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for pst_status table\n",
 			Pn, nb);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*
@@ -850,7 +850,7 @@ read_vmreg(p, n)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for pst_vm_status\n",
 			Pn, nb);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*

--- a/dialects/hpux/pstat/dsock.c
+++ b/dialects/hpux/pstat/dsock.c
@@ -1438,7 +1438,7 @@ process_stream(f, ckscko)
 	    if (!s) {
 		(void) fprintf(stderr,
 		    "%s: no space for %ld pst_stream bytes\n", Pn, (long)nb);
-		Exit(1);
+		Error();
 	    }
 	    nsa = nsn;
 	}

--- a/dialects/linux/dfile.c
+++ b/dialects/linux/dfile.c
@@ -114,7 +114,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d (dev,ino) hash buckets\n",
 		Pn, SFDIHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFrd = (struct hsfile *)calloc((MALLOC_S)SFRDHASH,
 					       sizeof(struct hsfile))))
@@ -122,7 +122,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d rdev hash buckets\n",
 		Pn, SFRDHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFsd = (struct hsfile *)calloc((MALLOC_S)SFFSHASH,
 					       sizeof(struct hsfile))))
@@ -130,7 +130,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d file sys hash buckets\n",
 		Pn, SFFSHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyNm = (struct hsfile *)calloc((MALLOC_S)SFNMHASH,
 					      sizeof(struct hsfile))))
@@ -138,7 +138,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d name hash buckets\n",
 		Pn, SFNMHASH);
-	    Exit(1);
+	    Error();
 	}
 	hs++;
 /*
@@ -196,7 +196,7 @@ hashSfile()
 			(void) fprintf(stderr,
 			    "%s: can't allocate hsfile bucket for: %s\n",
 			    Pn, s->aname);
-			Exit(1);
+			Error();
 		    }
 		    sn->s = s;
 		    sn->next = sh->next;

--- a/dialects/linux/dmnt.c
+++ b/dialects/linux/dmnt.c
@@ -107,7 +107,7 @@ cvtoe(os)
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes for octal-escaping.\n",
 		Pn, ol + 1);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Copy the string, replacing octal-escaped characters as they are found.
@@ -158,7 +158,7 @@ cvtoe(os)
 		    (void) fprintf(stderr,
 			"%s: can't realloc %d bytes for octal-escaping.\n",
 			Pn, cl + 1);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*
@@ -300,7 +300,7 @@ getmntdev(dn, dnl, s, ss)
 			(void) fprintf(stderr,
 			    "%s: no space for mount supplement hash buckets\n",
 			    Pn);
-			Exit(1);
+			Error();
 		    }
 		}
 		h = hash_mnt(path);
@@ -330,13 +330,13 @@ getmntdev(dn, dnl, s, ss)
 		    (void) fprintf(stderr,
 			"%s: no space for mount supplement entry: %d \"%s\"\n",
 			Pn, ln, buf);
-		    Exit(1);
+		    Error();
 		}
 		if (!(mpn->dn = (char *)malloc(sz + 1))) {
 		    (void) fprintf(stderr,
 			"%s: no space for mount supplement path: %d \"%s\"\n",
 			Pn, ln, buf);
-		    Exit(1);
+		    Error();
 		}
 		(void) strcpy(mpn->dn, path);
 		mpn->dnl = sz;
@@ -625,7 +625,7 @@ readmnt()
 		    (void) fprintf(stderr,
 			"%s: can't allocate mounts struct for: ", Pn);
 		    safestrprt(dn, stderr, 1);
-		    Exit(1);
+		    Error();
 	        }
 	    }
 	    mp->dir = dn;
@@ -678,7 +678,7 @@ readmnt()
 		    (void) fprintf(stderr,
 			"%s: can't allocate space for: ", Pn);
 		    safestrprt(dn, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		ignstat = 1;
 	    } else

--- a/dialects/linux/dnode.c
+++ b/dialects/linux/dnode.c
@@ -178,7 +178,7 @@ endpoint_enter(pxinfo_t **pinfo_hash, const char *table_name, int id)
 		"%s: no space for pipeinfo for %s, PID %d, FD %s\n",
 		table_name,
 		Pn, Lp->pid, Lf->fd);
-	    Exit(1);
+	    Error();
 	}
 	np->ino = id;
 	np->lf = Lf;
@@ -258,7 +258,7 @@ enter_pinfo()
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for %d pipe info buckets\n", Pn, PINFOBUCKS);
-		    Exit(1);
+		    Error();
 	    }
 	}
 	endpoint_enter(Pinfo, "pipeinfo", Lf->inode);
@@ -314,7 +314,7 @@ enter_ptmxi(mn)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for %d pty info buckets\n", Pn, PINFOBUCKS);
-		    Exit(1);
+		    Error();
 	    }
 	}
 	endpoint_enter(PtyInfo, "pty", mn);
@@ -436,7 +436,7 @@ enter_psxmqinfo()
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for %d posix mq info buckets\n", Pn, PINFOBUCKS);
-		    Exit(1);
+		    Error();
 	    }
 	}
 	endpoint_enter(PSXMQinfo, "psxmqinfo", Lf->inode);
@@ -487,7 +487,7 @@ enter_evtfdinfo(int id)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for %d envet fd info buckets\n", Pn, PINFOBUCKS);
-		    Exit(1);
+		    Error();
 	    }
 	}
 	endpoint_enter(EvtFDinfo, "evtfdinfo", id);
@@ -606,7 +606,7 @@ get_fields(ln, sep, fr, eb, en)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for field pointers.\n",
 			Pn, (int)len);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    fp[n++] = bp;
@@ -657,7 +657,7 @@ get_locks(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d lock hash bytes\n",
 		    Pn, (int)(sizeof(struct llock *) * PIDBUCKS));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -751,7 +751,7 @@ get_locks(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate llock: PID %d; dev %x; inode %s\n",
 		    Pn, pid, (int)dev, buf);
-		Exit(1);
+		Error();
 	    }
 	    lp->pid = pid;
 	    lp->dev = dev;

--- a/dialects/linux/dproc.c
+++ b/dialects/linux/dproc.c
@@ -177,7 +177,7 @@ enter_cntx_arg(cntx)
  */
 	if (!(cntxp = (cntxlist_t *)malloc((MALLOC_S)sizeof(cntxlist_t)))) {
 	    (void) fprintf(stderr, "%s: no space for context: %s\n", Pn, cntx);
-	    Exit(1);
+	    Error();
 	}
 	cntxp->f = 0;
 	cntxp->cntx = cntx;
@@ -205,7 +205,7 @@ alloc_cbf(len, cbf, cbfa)
 	if (!*cbf) {
 	    (void) fprintf(stderr,
 		"%s: can't allocate command %d bytes\n", Pn, (int)len);
-	     Exit(1);
+	     Error();
 	}
 	return(len);
 }
@@ -247,7 +247,7 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for \"%s/\"<pid>\n",
 		    Pn, (int)pidpathl, PROCFS);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(pidpath, pidpathl, "%s/", PROCFS);
 	}
@@ -310,7 +310,7 @@ gather_proc_info()
 	if (!ps) {
 	    if (!(ps = opendir(PROCFS))) {
 		(void) fprintf(stderr, "%s: can't open %s\n", Pn, PROCFS);
-		Exit(1);
+		Error();
 	    }
 	} else
 	    (void) rewinddir(ps);
@@ -327,7 +327,7 @@ gather_proc_info()
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for \"%s/%s/\"\n",
 			Pn, (int)pidpathl, PROCFS, dp->d_name);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    (void) snpf(pidpath + pidx, pidpathl - pidx, "%s/", dp->d_name);
@@ -397,7 +397,7 @@ gather_proc_info()
 				    tidpathl);
 				(void) fprintf(stderr, " for \"%s/%s/stat\"\n",
 				    taskpath, dp->d_name);
-				Exit(1);
+				Error();
 			    }
 			}
 			(void) snpf(tidpath, tidpathl, "%s/%s/stat", taskpath,
@@ -733,7 +733,7 @@ make_proc_path(pp, pl, np, nl, sf)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for %s%s\n",
 		    Pn, (int)rl, pp, sf);
-		Exit(1);
+		Error();
 	    }
 	    *nl = rl;
 	    *np = cp;
@@ -867,7 +867,7 @@ open_proc_stream(p, m, buf, sz, act)
 	int act;			/* fopen() failure action:
 					 *     0 : return (FILE *)NULL
 					 *   <>0 : fprintf() an error message
-					 *         and Exit(1)
+					 *         and Error()
 					 */
 {
 	FILE *fs;			/* opened stream */
@@ -881,7 +881,7 @@ open_proc_stream(p, m, buf, sz, act)
 		return((FILE *)NULL);
 	    (void) fprintf(stderr, "%s: can't fopen(%s, \"%s\"): %s\n",
 		Pn, p, m, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Return the stream if no buffer change is required.
@@ -904,7 +904,7 @@ open_proc_stream(p, m, buf, sz, act)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for %s stream buffer\n",
 		    Pn, (int)tsz, p);
-		Exit(1);
+		Error();
 	    }
 	    *sz = tsz;
 	}
@@ -914,7 +914,7 @@ open_proc_stream(p, m, buf, sz, act)
 	if (setvbuf(fs, *buf, _IOFBF, tsz)) {
 	    (void) fprintf(stderr, "%s: setvbuf(%s)=%d failure: %s\n",
 		Pn, p, (int)tsz, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	return(fs);
 }
@@ -1002,7 +1002,7 @@ process_id(idp, idpl, cmd, uid, pid, ppid, pgid, tid, tcmd)
 		    "%s: PID %d, TID %d, no space for task name: ",
 		    Pn, pid, tid);
 		safestrprt(tcmd, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* defined(HASTASKS) */
@@ -1184,7 +1184,7 @@ process_id(idp, idpl, cmd, uid, pid, ppid, pgid, tid, tcmd)
 			(void) fprintf(stderr,
 			    "%s: no context error space: PID %ld",
 			    Pn, (long)Lp->pid);
-			Exit(1);
+			Error();
 		    }
 		}
 	    } else if (CntxArg) {
@@ -1508,7 +1508,7 @@ process_proc_map(p, s, ss)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for saved maps, PID %d\n",
 			Pn, (int)len, Lp->pid);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    sm[ns].dev = dev;
@@ -1798,7 +1798,7 @@ statEx(p, s, ss)
 		(void) fprintf(stderr,
 		    "%s: PID %ld: no statEx path space: %s\n",
 		    Pn, (long)Lp->pid, p);
-		Exit(1);
+		Error();
 	    }
 	    ca = sz + 1;
 	}

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -863,7 +863,7 @@ get_ax25(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d AX25 hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct ax25sin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -935,7 +935,7 @@ get_ax25(p)
 		    (void) fprintf(stderr,
 		      "%s: can't allocate %d destination AX25 addr bytes: %s\n",
 		      Pn, (int)(len + 1), fp[3]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(da, len + 1, "%s", fp[3]);
 	    } else
@@ -950,7 +950,7 @@ get_ax25(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d source AX25 address bytes: %s\n",
 			Pn, (int)(len + 1), fp[2]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(sa, len + 1, "%s", fp[2]);
 	    } else
@@ -965,7 +965,7 @@ get_ax25(p)
 		    (void) fprintf(stderr,
 		      "%s: can't allocate %d destination AX25 dev bytes: %s\n",
 		      Pn, (int)(len + 1), fp[1]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(dev_ch, len + 1, "%s", fp[1]);
 	    } else
@@ -978,7 +978,7 @@ get_ax25(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte ax25sin structure\n",
 		    Pn, (int)sizeof(struct ax25sin));
-		Exit(1);
+		Error();
 	    }
 	    ap->da = da;
 	    ap->dev_ch = dev_ch;
@@ -1024,7 +1024,7 @@ enter_uxsinfo (up)
 	    (void) fprintf(stderr,
 		"%s: no space for pipeinfo in uxsinfo, PID %d\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	np->ino = Lf->inode;
 	np->lf = Lf;
@@ -1155,7 +1155,7 @@ get_uxpeeri()
 	if ((ns = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_SOCK_DIAG)) == -1) {
 	    (void) fprintf(stderr, "%s: netlink socket error: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Request peer information.
@@ -1412,7 +1412,7 @@ enter_netsinfo_common (void *tp,
 	    (void) fprintf(stderr,
 			   "%s: no space for pipeinfo in netsinfo, PID %d\n",
 			   Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	np->ino = Lf->inode;
 	np->lf = Lf;
@@ -1797,7 +1797,7 @@ get_icmp(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d icmp hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct icmpin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -1863,7 +1863,7 @@ get_icmp(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d local icmp address bytes: %s\n",
 			Pn, (int)(lal + 1), fp[1]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(la, lal + 1, "%s", fp[1]);
 	    }
@@ -1875,7 +1875,7 @@ get_icmp(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d remote icmp address bytes: %s\n",
 			Pn, (int)(ral + 1), fp[2]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(ra, ral + 1, "%s", fp[2]);
 	    }
@@ -1887,7 +1887,7 @@ get_icmp(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte icmp structure\n",
 		    Pn, (int)sizeof(struct icmpin));
-		Exit(1);
+		Error();
 	    }
 	    icmpp->inode = inode;
 	    icmpp->la = la;
@@ -1942,7 +1942,7 @@ get_ipx(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d IPX hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct ipxsin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -2018,7 +2018,7 @@ get_ipx(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d local IPX address bytes: %s\n",
 			Pn, (int)(len + 1), fp[0]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(la, len + 1, "%s", fp[0]);
 	    } else
@@ -2033,7 +2033,7 @@ get_ipx(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d remote IPX address bytes: %s\n",
 			Pn, (int)(len + 1), fp[1]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(ra, len + 1, "%s", fp[1]);
 	    } else
@@ -2046,7 +2046,7 @@ get_ipx(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte ipxsin structure\n",
 		    Pn, (int)sizeof(struct ipxsin));
-		Exit(1);
+		Error();
 	    }
 	    ip->inode = inode;
 	    ip->la = la;
@@ -2094,7 +2094,7 @@ get_netlink(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d netlink hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct nlksin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -2154,7 +2154,7 @@ get_netlink(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte Netlink structure\n",
 		    Pn, (int)sizeof(struct nlksin));
-		Exit(1);
+		Error();
 	    }
 	    lp->inode = inode;
 	    lp->pr = pr;
@@ -2200,7 +2200,7 @@ get_pack(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d packet hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct packin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -2265,7 +2265,7 @@ get_pack(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte packet structure\n",
 		    Pn, (int)sizeof(struct packin));
-		Exit(1);
+		Error();
 	    }
 	    pp->inode = inode;
 	    pp->pr = (int)pr;
@@ -2316,7 +2316,7 @@ get_raw(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d raw hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct rawsin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -2375,7 +2375,7 @@ get_raw(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d local raw address bytes: %s\n",
 			Pn, (int)(lal + 1), fp[1]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(la, lal + 1, "%s", fp[1]);
 	    }
@@ -2387,7 +2387,7 @@ get_raw(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d remote raw address bytes: %s\n",
 			Pn, (int)(ral + 1), fp[2]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(ra, ral + 1, "%s", fp[2]);
 	    }
@@ -2399,7 +2399,7 @@ get_raw(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d remote raw state bytes: %s\n",
 			Pn, (int)(spl + 1), fp[2]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(sp, spl + 1, "%s", fp[3]);
 	    }
@@ -2411,7 +2411,7 @@ get_raw(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte rawsin structure\n",
 		    Pn, (int)sizeof(struct rawsin));
-		Exit(1);
+		Error();
 	    }
 	    rp->inode = inode;
 	    rp->la = la;
@@ -2472,7 +2472,7 @@ get_sctp()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d SCTP hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct sctpsin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -2573,7 +2573,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			  "%s: can't allocate %d SCTP ASSOC bytes: %s\n",
 			  Pn, (int)(len + 1), fp[0]);
-			Exit(1);
+			Error();
 		    }
 		    if (!d) {
 			if (plen)
@@ -2603,7 +2603,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			  "%s: can't allocate %d SCTP ASSOC-ID bytes: %s\n",
 			  Pn, (int)(len + 1), fp[6]);
-			Exit(1);
+			Error();
 		    }
 		    if (!d) {
 			if (plen)
@@ -2634,7 +2634,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			  "%s: can't allocate %d SCTP LPORT bytes: %s\n",
 			  Pn, (int)(len + 1), fp[j]);
-			Exit(1);
+			Error();
 		    }
 		    if (!d) {
 			if (plen)
@@ -2664,7 +2664,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			  "%s: can't allocate %d SCTP RPORT bytes: %s\n",
 			  Pn, (int)(len + 1), fp[12]);
-			Exit(1);
+			Error();
 		    }
 		    if (!d) {
 			if (plen)
@@ -2684,7 +2684,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			  "%s: can't allocate %d SCTP LADDRS bytes\n",
 			  Pn, (int)len);
-			Exit(1);
+			Error();
 		    }
 		    if (la) {
 			if (isainb(ta, la)) {
@@ -2695,7 +2695,7 @@ get_sctp()
 				(void) fprintf(stderr,
 				  "%s: can't reallocate %d SCTP LADDRS bytes\n",
 				  Pn, (int)len);
-				Exit(1);
+				Error();
 			    }
 			    (void) snpf(la + plen, len + 2, ",%s", ta);
 			    (void) free((FREE_P *)ta);
@@ -2713,7 +2713,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			  "%s: can't allocate %d SCTP RADDRS bytes\n",
 			  Pn, (int)len);
-			Exit(1);
+			Error();
 		    }
 		    if (ra) {
 			if (isainb(ta, ra)) {
@@ -2724,7 +2724,7 @@ get_sctp()
 				(void) fprintf(stderr,
 				  "%s: can't reallocate %d SCTP RADDRS bytes\n",
 				  Pn, (int)len);
-				Exit(1);
+				Error();
 			    }
 			    (void) snpf(ra + plen, len + 2, ",%s", ta);
 			    (void) free((FREE_P *)ta);
@@ -2742,7 +2742,7 @@ get_sctp()
 			(void) fprintf(stderr,
 			    "%s: can't allocate %d byte sctpsin structure\n",
 			    Pn, (int)sizeof(struct sctpsin));
-			Exit(1);
+			Error();
 		    }
 		    sp->inode = inode;
 		    sp->next = SCTPsin[h];
@@ -2880,7 +2880,7 @@ get_tcpudp(p, pr, clr)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for TCP&UDP hash buckets\n",
 		    Pn, (int)(TcpUdp_bucks * sizeof(struct tcp_udp *)));
-		Exit(1);
+		Error();
 	    }
 #if	defined(HASEPTOPTS)
 	    if (FeptE && (!(TcpUdpIPC = (struct tcp_udp **)calloc(IPCBUCKS,
@@ -2888,7 +2888,7 @@ get_tcpudp(p, pr, clr)
 		(void) fprintf(stderr,
 			       "%s: can't allocate %d bytes for TCP&UDP local IPC hash buckets\n",
 			       Pn, (int)(IPCBUCKS * sizeof(struct tcp_udp *)));
-		Exit(1);
+		Error();
 	    }
 #endif	/* defined(HASEPTOPTS) */
 	}
@@ -2978,7 +2978,7 @@ get_tcpudp(p, pr, clr)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for tcp_udp struct\n",
 		    Pn, (int)sizeof(struct tcp_udp));
-		Exit(1);
+		Error();
 	    }
 	    tp->inode = inode;
 	    tp->faddr = faddr;
@@ -3058,7 +3058,7 @@ get_raw6(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d raw6 hash pointer bytes\n",
 		    Pn, (int)(INOBUCKS * sizeof(struct rawsin *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -3117,7 +3117,7 @@ get_raw6(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d local raw6 address bytes: %s\n",
 			Pn, (int)(lal + 1), fp[1]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(la, lal + 1, "%s", fp[1]);
 	    }
@@ -3129,7 +3129,7 @@ get_raw6(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d remote raw6 address bytes: %s\n",
 			Pn, (int)(ral + 1), fp[2]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(ra, ral + 1, "%s", fp[2]);
 	    }
@@ -3141,7 +3141,7 @@ get_raw6(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d remote raw6 state bytes: %s\n",
 			Pn, (int)(spl + 1), fp[2]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(sp, spl + 1, "%s", fp[3]);
 	    }
@@ -3153,7 +3153,7 @@ get_raw6(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d byte rawsin structure for IPv6\n",
 		    Pn, (int)sizeof(struct rawsin));
-		Exit(1);
+		Error();
 	    }
 	    rp->inode = inode;
 	    rp->la = la;
@@ -3261,7 +3261,7 @@ get_tcpudp6(p, pr, clr)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for TCP6&UDP6 hash buckets\n",
 		    Pn, (int)(TcpUdp6_bucks * sizeof(struct tcp_udp6 *)));
-		Exit(1);
+		Error();
 	    }
 #if	defined(HASEPTOPTS)
 	    if (FeptE && (!(TcpUdp6IPC = (struct tcp_udp6 **)calloc(IPCBUCKS,
@@ -3269,7 +3269,7 @@ get_tcpudp6(p, pr, clr)
 		(void) fprintf(stderr,
 			       "%s: can't allocate %d bytes for TCP6&UDP6 local IPC hash buckets\n",
 			       Pn, (int)(IPCBUCKS * sizeof(struct tcp_udp6 *)));
-		Exit(1);
+		Error();
 	    }
 #endif	/* defined(HASEPTOPTS) */
 	}
@@ -3355,7 +3355,7 @@ get_tcpudp6(p, pr, clr)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for tcp_udp6 struct\n",
 		    Pn, (int)sizeof(struct tcp_udp6));
-		Exit(1);
+		Error();
 	    }
 	    tp6->inode = inode;
 	    tp6->faddr = faddr;
@@ -3445,7 +3445,7 @@ get_unix(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for Unix socket info\n",
 		    Pn, (int)(INOBUCKS * sizeof(uxsin_t *)));
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -3505,7 +3505,7 @@ get_unix(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for UNIX PCB: %s\n",
 			Pn, (int)(len + 1), fp[0]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(pcb, len + 1, "0x%s", fp[0]);
 	    }
@@ -3514,7 +3514,7 @@ get_unix(p)
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for UNIX path \"%s\"\n",
 			Pn, (int)(len + 1), fp[7]);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(path, len + 1, "%s", fp[7]);
 	    } else
@@ -3552,7 +3552,7 @@ get_unix(p)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for uxsin struct\n",
 		    Pn, (int)sizeof(uxsin_t));
-		Exit(1);
+		Error();
 	    }
 	    up->inode = inode;
 	    up->next = (uxsin_t *)NULL;
@@ -3752,7 +3752,7 @@ print_ax25info(ap)
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes for AX25 sock state, PID: %d\n",
 		Pn, (int)(pl + 1), Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(cp, pl + 1, "%s", pbuf);
 	Lf->nma = cp;
@@ -3779,7 +3779,7 @@ print_ipxinfo(ip)
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes for IPX sock state, PID: %d\n",
 		Pn, (int)(pl + 1), Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(cp, pl + 1, "%s", pbuf);
 	Lf->nma = cp;

--- a/dialects/n+obsd/dmnt.c
+++ b/dialects/n+obsd/dmnt.c
@@ -108,7 +108,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(mb->f_mntfromname, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if ((ln = Readlink(dn)) == NULL) {
 		if (!Fwarn) {
@@ -231,14 +231,14 @@ readvfs(vm)
 	if (!(vp = (struct l_vfs *)malloc(sizeof(struct l_vfs)))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	if (!(vp->dir = mkstrcpy(m.m_stat.f_mntonname, (MALLOC_S *)NULL))
 	||  !(vp->fsname = mkstrcpy(m.m_stat.f_mntfromname, (MALLOC_S *)NULL)))
 	{
 	    (void) fprintf(stderr, "%s: PID %d, no space for mount names\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->addr = vm;
 

--- a/dialects/n+obsd/dproc.c
+++ b/dialects/n+obsd/dproc.c
@@ -78,7 +78,7 @@ ckkv(d, er, ev, ea)
 	if (sysctl(m, 2, v, &l, NULL, 0) < 0) {
 	    (void) fprintf(stderr, "%s: CTL_KERN, KERN_OSRELEASE: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Warn if the actual and expected releases don't match.
@@ -130,7 +130,7 @@ enter_vn_text(va, n)
 	    if (!Vp) {
 		(void) fprintf(stderr, "%s: no txt ptr space, PID %d\n",
 		    Pn, Lp->pid);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -191,7 +191,7 @@ gather_proc_info()
 	if (!P) {
 	    (void) fprintf(stderr, "%s: can't read process table: %s\n",
 		Pn, kvm_geterr(Kd));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Examine proc structures and their associated information.
@@ -288,7 +288,7 @@ gather_proc_info()
 		if (!ofb) {
 		    (void) fprintf(stderr, "%s: PID %d, no file * space\n",
 			Pn, p->P_PID);
-		    Exit(1);
+		    Error();
 		}
 		ofbb = nb;
 	    }
@@ -306,7 +306,7 @@ gather_proc_info()
 		    if (!pof) {
 			(void) fprintf(stderr,
 			    "%s: PID %d, no file flag space\n", Pn, p->P_PID);
-		        Exit(1);
+		        Error();
 		    }
 		    pofb = nb;
 		}
@@ -376,7 +376,7 @@ get_kernel_access()
 	    if (!(Nmlst = get_nlist_path(1))) {
 		(void) fprintf(stderr,
 		    "%s: can't get kernel name list path\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* defined(N_UNIX) */
@@ -394,7 +394,7 @@ get_kernel_access()
  */
 	if ((Memory && !is_readable(Memory, 1))
 	||  (Nmlst && !is_readable(Nmlst, 1)))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -413,13 +413,13 @@ get_kernel_access()
 #endif	/* defined(_PATH_MEM) */
 
 		strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	(void) build_Nl(Drive_Nl);
 	if (kvm_nlist(Kd, Nl) < 0) {
 	    (void) fprintf(stderr, "%s: can't read namelist from %s\n",
 		Pn, Nmlst);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(WILLDROPGID)
@@ -465,7 +465,7 @@ get_nlist_path(ap)
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for boot file path: %s\n",
 		    Pn, bfl, bf);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(bfc, bfl, "%s", bf);
 	    return(bfc);

--- a/dialects/n+os/dnode.c
+++ b/dialects/n+os/dnode.c
@@ -196,7 +196,7 @@ load_svnc()
 		(void) fprintf(stderr,
 		    "%s: no space for %d local shadow vnode hash buckets\n",
 		    Pn, LF_SVNODE_HSZ);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -223,7 +223,7 @@ load_svnc()
 		    (void) fprintf(stderr,
 			"%s: no space for local shadow vnode -- PID: %ld\n",
 			Pn, Lp->pid);
-		    Exit(1);
+		    Error();
 		}
 		lsv->vp = (KA_T)sv.lf_vnodep;
 		lsv->lp = (struct l_lockf *)NULL;
@@ -245,7 +245,7 @@ load_svnc()
 			(void) fprintf(stderr,
 			    "%s: no space for local lock struct -- PID: %ld\n",
 			    Pn, Lp->pid);
-			Exit(1);
+			Error();
 		    }
 		    lsf->type = lf.lf_type;
 		    lsf->start = lf.lf_start;
@@ -333,7 +333,7 @@ process_node(va)
 #endif	/* defined(HAS_AFS) */
 
 			      );
-		Exit(1);
+		Error();
 	    }
 	}
 	if (readvnode(va, v)) {

--- a/dialects/n+os/dproc.c
+++ b/dialects/n+os/dproc.c
@@ -82,7 +82,7 @@ ckkv(d, er, ev, ea)
 	if ((kr = host_kernel_version(host_self(), kv)) != KERN_SUCCESS) {
 	    (void) snpf(m, sizeof(m), "%s: can't get kernel version:", Pn);
 	    mach_error(m, kr);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Skip blank-separated tokens until reaching "Mach".  The kernel version
@@ -222,7 +222,7 @@ gather_proc_info()
 		    uf = (struct file **)realloc((MALLOC_P *)uf, nb);
 		if (!uf) {
 		    (void) fprintf(stderr, "%s: no uu_ofile space\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 		ufb = nb;
 	    }
@@ -239,7 +239,7 @@ gather_proc_info()
 			pof = (char *)realloc((MALLOC_P *)pof, nb);
 		    if (!pof) {
 			(void) fprintf(stderr, "%s: no uu_pofile space\n", Pn);
-			Exit(1);
+			Error();
 		    }
 		    pofb = nb;
 		}
@@ -304,7 +304,7 @@ get_kernel_access()
  * See if the non-KMEM memory file is readable.
  */
 	if (Memory && !is_readable(Memory, 1))
-		Exit(1);
+		Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -313,7 +313,7 @@ get_kernel_access()
 	if ((Kd = open(Memory ? Memory : KMEM, O_RDONLY, 0)) < 0) {
 		(void) fprintf(stderr, "%s: can't open %s: %s\n", Pn,
 			Memory ? Memory : KMEM, strerror(errno));
-		Exit(1);
+		Error();
 	}
 
 #if	defined(WILLDROPGID)
@@ -327,7 +327,7 @@ get_kernel_access()
  * See if the name list file is readable.  Build Nl.
  */
 	if (Nmlst && !is_readable(Nmlst, 1))
-		Exit(1);
+		Error();
 #endif	/* defined(WILLDROPGID) */
 
 	(void) build_Nl(Drive_Nl);
@@ -343,7 +343,7 @@ get_kernel_access()
 		if (!(nl = (struct nlist *)malloc(Nll))) {
 			(void) fprintf(stderr,
 				"%s: no space (%d) for Nl[] copy\n", Pn, Nll);
-			Exit(1);
+			Error();
 		}
 		(void) bcopy((char *)Nl, (char *)nl, Nll);
 	}
@@ -355,12 +355,12 @@ get_kernel_access()
 	if (nlist(Nmlst ? Nmlst : VMUNIX, Nl) < 0) {
 		(void) fprintf(stderr, "%s: can't read namelist from %s\n",
 			Pn, Nmlst ? Nmlst : VMUNIX);
-                Exit(1);
+                Error();
 	}
 	if (get_Nl_value("aproc", Drive_Nl, &lv) < 0 || !lv) {
 		(void) fprintf(stderr, "%s: can't get proc table address\n",
 			Pn);
-		Exit(1);
+		Error();
 	}
 
 #if	defined(HAS_AFS)
@@ -616,7 +616,7 @@ process_map(map)
 		{
 		    (void) fprintf(stderr, "%s: no txt ptr space, PID %d\n",
 			Pn, Lp->pid);
-		    Exit(1);
+		    Error();
 		}
 		Nv = 10;
 	    } else if (n >= Nv) {
@@ -626,7 +626,7 @@ process_map(map)
 		{
 		    (void) fprintf(stderr,
 			"%s: no more txt ptr space, PID %d\n", Pn, Lp->pid);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    Vp[n++] = (KA_T)vmp.vs_vp;
@@ -660,7 +660,7 @@ read_proc()
 		if ((apax = get_Nl_value("aproc", Drive_Nl, &apav)) < 0) {
 		    (void) fprintf(stderr,
 			"%s: can't get process table address pointer\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    if (kread((KA_T)apav, (char *)&Kp, sizeof(Kp))) {
@@ -681,13 +681,13 @@ read_proc()
 		    {
 			(void) fprintf(stderr, "%s: no proc table space\n",
 			    Pn);
-			Exit(1);
+			Error();
 		    }
 		    if (!(Pa = (KA_T *)malloc((MALLOC_S)(sz * sizeof(KA_T)))))
 		    {
 			(void) fprintf(stderr, "%s: no proc pointer space\n",
 			    Pn);
-			Exit(1);
+			Error();
 		    }
 		}
 	/*
@@ -715,7 +715,7 @@ read_proc()
 					(void) fprintf(stderr,
 						"%s: no more (%d) proc space\n",
 						Pn, sz);
-					Exit(1);
+					Error();
 				}
 				if (!(Pa = (KA_T *)realloc((MALLOC_P *)Pa,
 					(MALLOC_S)(sizeof(KA_T) * sz))))
@@ -723,7 +723,7 @@ read_proc()
 					(void) fprintf(stderr,
 					    "%s: no more (%d) proc ptr space\n",
 					    Pn, sz);
-					Exit(1);
+					Error();
 				}
 			}
 		}
@@ -738,7 +738,7 @@ read_proc()
  */
 	if (try >= PROCTRYLM) {
 		(void) fprintf(stderr, "%s: can't read proc table\n", Pn);
-		Exit(1);
+		Error();
 	}
 	if (Np < sz && !RptTm) {
 
@@ -752,7 +752,7 @@ read_proc()
 			(void) fprintf(stderr,
 				"%s: can't reduce proc table to %d\n",
 				Pn, Np);
-			Exit(1);
+			Error();
 		}
 		if (!(Pa = (KA_T *)realloc((MALLOC_P *)Pa,
 			  (MALLOC_S)(sizeof(KA_T) * Np))))
@@ -760,7 +760,7 @@ read_proc()
 			(void) fprintf(stderr,
 				"%s: can't reduce proc ptrs to %d\n",
 				Pn, Np);
-			Exit(1);
+			Error();
 		}
 	}
 }

--- a/dialects/osr/dmnt.c
+++ b/dialects/osr/dmnt.c
@@ -70,7 +70,7 @@ readmnt()
  */
 	if ((fd = open(MNTTAB, O_RDONLY, 0)) < 0) {
 	    (void) fprintf(stderr, "%s: can't open %s\n", Pn, MNTTAB);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Read the first mount table entry.
@@ -159,7 +159,7 @@ no_space_for_mount:
 		    (void) fprintf(stderr, " (");
 		    safestrprt(dvnm, stderr, 0);
 		    (void) fprintf(stderr, ")\n");
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*

--- a/dialects/osr/dproc.c
+++ b/dialects/osr/dproc.c
@@ -91,7 +91,7 @@ Ckkv(d, er, ev, ea)
 	if (__scoinfo(&s, sizeof(s)) < 0) {
 	    (void) fprintf(stderr, "%s: can't get __scoinfo: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 /*
  * Warn if the actual and expected releases don't match.
@@ -137,7 +137,7 @@ gather_proc_info()
 		(void) fprintf(stderr,
 		    "%s: no space for %d byte user structure buffer\n",
 		    Pn, ual);
-		Exit(1);
+		Error();
 	    }
 	    u = (struct user *)ua;
 	}
@@ -148,7 +148,7 @@ gather_proc_info()
 	    if (!(pb = (char *)malloc(sizeof(struct proc) * PROCBFRD))) {
 		(void) fprintf(stderr, "%s: no space for %d proc structures\n",
 		    Pn, PROCBFRD);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -253,7 +253,7 @@ gather_proc_info()
 						   (MALLOC_S)nf);
 			if (!pofb) {
 			    (void) fprintf(stderr, "%s: no pofile space\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 			npofb = nf;
 		    }
@@ -318,7 +318,7 @@ get_cdevsw()
 	if (!(Cdevsw = (char **)malloc(Cdevcnt * sizeof(char *)))) {
 	    (void) fprintf(stderr, "%s: no space for %d cdevsw[] names\n",
 		Pn, Cdevcnt);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Allocate temporary space for a copy of cdevsw[] and read it.
@@ -327,7 +327,7 @@ get_cdevsw()
 	if (!(tmp = (struct cdevsw *)malloc(i))) {
 	    (void) fprintf(stderr, "%s: no space for %d cdevsw[] entries\n",
 		Pn, Cdevcnt);
-	    Exit(1);
+	    Error();
 	}
 	if (kread((KA_T)v[0], (char *)tmp, i)) {
 	    (void) free((FREE_P *)Cdevsw);
@@ -358,7 +358,7 @@ get_cdevsw()
 	    if (!(Cdevsw[i] = (char *)malloc(len))) {
 		(void) fprintf(stderr, "%s: no space for cdevsw[%d] name: %s\n",
 		   Pn, i, buf);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(Cdevsw[i], len, "%s", buf);
 	    if (!HaveCloneMajor && strcmp(buf, "clone") == 0) {
@@ -396,7 +396,7 @@ get_kernel_access()
  * See if the name list file is readable.
  */
 	if (Nmlst && !is_readable(Nmlst, 1))
-	    Exit(1);
+	    Error();
 /*
  * Access kernel symbols.
  */
@@ -410,7 +410,7 @@ get_kernel_access()
 
 	{
 	    (void) fprintf(stderr, "%s: can't read kernel name list.\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Open access to kernel memory.
@@ -429,7 +429,7 @@ get_kernel_access()
  */
 	if (get_Nl_value("proc", Drive_Nl, &Kp) < 0 || !Kp) {
 	    (void) fprintf(stderr, "%s: no proc table pointer\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 
 #if	OSRV<500
@@ -443,14 +443,14 @@ get_kernel_access()
 	    (void) fprintf(stderr,
 		"%s: can't read pregion count (%d) from %s\n", Pn, Npp,
 		    print_kptr(v, (char *)NULL, 0));
-	    Exit(1);
+	    Error();
 	}
 	Prsz = (MALLOC_S)(Npp * sizeof(struct pregion));
 	if (!(Pr = (struct pregion *)malloc(Prsz))) {
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d pregions\n",
 		Pn, Npp);
-	    Exit(1);
+	    Error();
 	}
 #endif	/* OSRV< 500 */
 
@@ -462,7 +462,7 @@ get_kernel_access()
 	{
 	    (void) fprintf(stderr,
 		"%s: can't read system configuration info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Read system clock values -- Hz and lightning bolt timer.
@@ -520,13 +520,13 @@ get_kernel_access()
 	    (void) fprintf(stderr,
 		"%s: bad extended device table size (%d) at %s.\n",
 		Pn, nxdevmaps, print_kptr(v, (char *)NULL, 0));
-	    Exit(1);
+	    Error();
 	}
 	len = (MALLOC_S)((nxdevmaps + 1) * sizeof(struct XDEVMAP));
 	if (!(Xdevmap = (struct XDEVMAP *)malloc(len))) {
 	    (void) fprintf(stderr, "%s: no space for %d byte xdevmap table\n",
 		Pn, len);
-	    Exit(1);
+	    Error();
 	}
 	v = (KA_T)0;
 	if (get_Nl_value("xdm", Drive_Nl, &v) < 0 || !v
@@ -534,7 +534,7 @@ get_kernel_access()
 	{
 	    (void) fprintf(stderr,
 		"%s: can't read %d byte xdevmap table at #x\n", Pn, len, v);
-	    Exit(1);
+	    Error();
 	}
 #endif	/* OSRV>=40 */
 
@@ -640,7 +640,7 @@ get_nlist_return_path:
 			(void) fprintf(stderr,
 			    "%s: can't allocate %d bytes for: %s\n",
 			    Pn, len , pp);
-			Exit(1);
+			Error();
 		    }
 		    (void) snpf(tp, len, "%s", pp);
 		    return(tp);
@@ -745,7 +745,7 @@ kread(addr, buf, len)
 
 static int
 open_kmem(nx)
-	int nx;				/* no Exit(1) if 1 */
+	int nx;				/* no Error() if 1 */
 {
 	if (Kd >= 0)
 	    return(0);
@@ -755,7 +755,7 @@ open_kmem(nx)
 	if (Memory && !is_readable(Memory, 1)) {
 	    if (nx)
 		return(1);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Open kernel memory access.
@@ -765,7 +765,7 @@ open_kmem(nx)
 		return(1);
 	    (void) fprintf(stderr, "%s: can't open %s: %s\n", Pn,
 		Memory ? Memory : KMEM, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	return(0);
 }
@@ -843,7 +843,7 @@ process_text(prp)
 		if (!(Nc = (KA_T *)malloc((MALLOC_S)(sizeof(KA_T) * 10)))) {
 		    (void) fprintf(stderr, "%s: no txt ptr space, PID %d\n",
 			Pn, Lp->pid);
-		    Exit(1);
+		    Error();
 		}
 		Nn = 10;
 	    } else if (j >= Nn) {
@@ -853,7 +853,7 @@ process_text(prp)
 		{
 		    (void) fprintf(stderr,
 			"%s: no more txt ptr space, PID %d\n", Pn, Lp->pid);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    Nc[j++] = na;
@@ -905,27 +905,27 @@ readfsinfo()
 	if ((Fsinfomax = sysfs(GETNFSTYP)) == -1) {
 	    (void) fprintf(stderr, "%s: sysfs(GETNFSTYP) error: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if (Fsinfomax == 0)
 	    return;
 	if (!(Fsinfo = (char **)malloc((MALLOC_S)(Fsinfomax * sizeof(char *)))))
 	{
 	    (void) fprintf(stderr, "%s: no space for sysfs info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 1; i <= Fsinfomax; i++) {
 	    if (sysfs(GETFSTYP, i, buf) == -1) {
 		(void) fprintf(stderr, "%s: sysfs(GETFSTYP) error: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    buf[FSTYPSZ] = '\0';
 	    len = strlen(buf) + 1;
 	    if (!(Fsinfo[i-1] = (char *)malloc((MALLOC_S)len))) {
 		(void) fprintf(stderr,
 		    "%s: no space for file system entry %s\n", Pn, buf);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(Fsinfo[i-1], len, "%s", buf);
 	}
@@ -1157,7 +1157,7 @@ DNLC_load()
 		    "%s: can't allocate %d bytes for DNLC chunk\n",
 		    Pn, chl);
 		cha = 0;
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -1255,7 +1255,7 @@ DTFS_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for DTFS name cache\n",
 		    Pn, kcl);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -1336,7 +1336,7 @@ HTFS_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for HTFS name cache\n",
 		    Pn, kcl);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -1398,7 +1398,7 @@ LNC_enter(le, nm, nl, fs)
 		(void) fprintf(stderr,
 		    "%s: no more space for %d byte local name cache: %s\n",
 		    Pn, len, fs);
-		Exit(1);
+		Error();
 	    }
 	}
 	lc = &LNC_nc[LNC_csz];
@@ -1451,7 +1451,7 @@ LNC_nosp(len)
 	    (void) fprintf(stderr,
 		"%s: no space for %d byte local name cache\n",
 		Pn, len);
-	Exit(1);
+	Error();
 }
 
 
@@ -1532,7 +1532,7 @@ ncache_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for name cache hash table\n",
 		    Pn, LNCHHLEN * sizeof(struct lnch_hh));
-		Exit(1);
+		Error();
 	    }
 	} else
 	    (void) zeromem((void *)LNC_hh, (LNCHHLEN * sizeof(struct lnch_hh)));
@@ -1800,7 +1800,7 @@ NFS_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for NFS name cache\n",
 		    Pn, kcl);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -1902,7 +1902,7 @@ NFS_root(r)
 	    if (!rc) {
 		(void) fprintf(stderr, "%s: no space for root rnode table\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 	rc[rnc++] = r;
@@ -1960,7 +1960,7 @@ SYSV_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for SYSV name cache\n",
 		    Pn, kcl);
-		Exit(1);
+		Error();
 	    }
 	}
 /*

--- a/dialects/osr/dsock.c
+++ b/dialects/osr/dsock.c
@@ -414,7 +414,7 @@ udp_tm(tm)
 	if (!(cp = (char *)malloc(len))) {
 	    (void) fprintf(stderr, "%s: no space for %d character UDP time\n",
 		Pn, len);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(cp, len, "%s", buf);
 	Lf->nma = cp;

--- a/dialects/sun/ddev.c
+++ b/dialects/sun/ddev.c
@@ -85,7 +85,7 @@ make_devtp(s, p)
 	    if (!Devtp) {
 		(void) fprintf(stderr, "%s: no space for character device\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -95,7 +95,7 @@ make_devtp(s, p)
 	if (!(Devtp[Devx].name = mkstrcpy(p, (MALLOC_S *)NULL))) {
 	    (void) fprintf(stderr, "%s: no space for /dev/", Pn);
 	    safestrprt(p, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	Devtp[Devx].rdev = s->st_rdev;
 	Devtp[Devx].v = 0;
@@ -164,7 +164,7 @@ printchdevname_again:
 	    if (!(cp = (char *)malloc((MALLOC_S)(len + 1)))) {
 		(void) fprintf(stderr, "%s: no nma space for: (%s %s)\n",
 		    Pn, ttl, dp->name);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(cp, len + 1, "(%s %s)", ttl, dp->name);
 	    (void) add_nma(cp, len);
@@ -247,7 +247,7 @@ read_clone()
 	if (!(path = mkstrcat(DVCH_DEVPATH, -1, "/", 1, "pseudo ", -1, &pl))) {
 	    (void) fprintf(stderr, "%s: no space for %s/pseudo\n",
 		DVCH_DEVPATH, Pn);
-	    Exit(1);
+	    Error();
 	}
 	path[pl - 1] = '\0';
 	if (!(dfp = OpenDir(path))) {
@@ -282,7 +282,7 @@ read_clone()
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(path, stderr, 0);
 		safestrprt(dp->d_name, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 
 #if	defined(USE_STAT)
@@ -326,7 +326,7 @@ read_clone()
 		    (void) fprintf(stderr,
 			"%s: no space for network clone device: ", Pn);
 		    safestrprt(fp, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Allocate space for the path name.
@@ -334,7 +334,7 @@ read_clone()
 		if (!(c->cd.name = mkstrcpy(fp, (MALLOC_S *)NULL))) {
 		    (void) fprintf(stderr, "%s: no space for clone name: ", Pn);
 		    safestrprt(fp, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Save the inode and device numbers.  Clear the verify flag.
@@ -368,7 +368,7 @@ read_clone()
 		    (void) fprintf(stderr,
 			"%s: no space for pseudo device: ", Pn);
 		    safestrprt(fp, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Save the path name, and inode and device numbers.  Clear the
@@ -441,7 +441,7 @@ readdev(skip)
 	{
 	    (void) fprintf(stderr, "%s: no space for: %s/pseudo\n",
 		Pn, DVCH_DEVPATH);
-	    Exit(1);
+	    Error();
 	}
 	read_clone();
 	Dstk = (char **)NULL;
@@ -476,7 +476,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(Dstk[Dstkx], stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    (void) free((FREE_P *)Dstk[Dstkx]);
 	    Dstk[Dstkx] = (char *)NULL;
@@ -499,7 +499,7 @@ readdev(skip)
 		    (void) fprintf(stderr, "%s: no space for: ", Pn);
 		    safestrprt(path, stderr, 0);
 		    safestrprt(dp->d_name, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 
 #if	defined(USE_STAT)
@@ -563,7 +563,7 @@ readdev(skip)
 			if (!BDevtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for block device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    BDevtp[j].rdev = sb.st_rdev;
@@ -610,7 +610,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for block device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (j = 0; j < BNdev; j++) {
 		BSdev[j] = &BDevtp[j];
@@ -636,7 +636,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for character device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (i = 0; i < Ndev; i++) {
 		Sdev[i] = &Devtp[i];
@@ -646,7 +646,7 @@ readdev(skip)
 	    Ndev = rmdupdev(&Sdev, Ndev, 1);
 	} else {
 	    (void) fprintf(stderr, "%s: no character devices found\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(HASDCACHE)
@@ -748,7 +748,7 @@ bad_clone_sect:
 		    (void) fprintf(stderr,
 			"%s: no space for cached clone: ", Pn);
 		    safestrprt(buf, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Enter the clone device number.
@@ -812,7 +812,7 @@ bad_clone_sect:
 		    (void) fprintf(stderr,
 			"%s: no space for cached clone path: ", Pn);
 		    safestrprt(buf, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		c->cd.v = 0;
 		c->next = Clone;
@@ -850,7 +850,7 @@ bad_clone_sect:
  */
 	(void) fprintf(stderr, "%s: internal rw_clone_sect error: %d\n",
 	    Pn, m);
-	Exit(1);
+	Error();
 	return(1);		/* to make code analyzers happy */
 }
 
@@ -930,7 +930,7 @@ bad_pseudo_sect:
 		    (void) fprintf(stderr,
 			"%s: no space for cached pseudo: ", Pn);
 		    safestrprt(buf, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Enter the pseudo device number.
@@ -984,7 +984,7 @@ bad_pseudo_sect:
 		    (void) fprintf(stderr,
 			"%s: no space for cached pseudo path: ", Pn);
 		    safestrprt(buf, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		*(cp + len - 1) = '\0';
 		(void) snpf(p->pd.name, len, "%s", cp);
@@ -1136,7 +1136,7 @@ rmdupdev(dp, n, ty)
 	{
 	    (void) fprintf(stderr, "%s: can't realloc %s device pointers\n",
 		Pn, ty ? "char" : "block");
-	    Exit(1);
+	    Error();
 	}
 	return(j);
 }

--- a/dialects/sun/dfile.c
+++ b/dialects/sun/dfile.c
@@ -146,7 +146,7 @@ hashSfile()
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for %d clone hash buckets\n",
 		    Pn, SFCDHASH);
-		Exit(1);
+		Error();
 	    }
 	}
 	if (!(HbyFdi = (struct hsfile *)calloc((MALLOC_S)SFDIHASH,
@@ -155,7 +155,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d (dev,ino) hash buckets\n",
 		Pn, SFDIHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFrd = (struct hsfile *)calloc((MALLOC_S)SFRDHASH,
 					       sizeof(struct hsfile))))
@@ -163,7 +163,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d rdev hash buckets\n",
 		Pn, SFRDHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFsd = (struct hsfile *)calloc((MALLOC_S)SFFSHASH,
 					       sizeof(struct hsfile))))
@@ -171,7 +171,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d file sys hash buckets\n",
 		Pn, SFFSHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyNm = (struct hsfile *)calloc((MALLOC_S)SFNMHASH,
 					      sizeof(struct hsfile))))
@@ -179,7 +179,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d name hash buckets\n",
 		Pn, SFNMHASH);
-	    Exit(1);
+	    Error();
 	}
 	hs++;
 /*
@@ -238,7 +238,7 @@ hashSfile()
 			(void) fprintf(stderr,
 			    "%s: can't allocate hsfile bucket for: %s\n",
 			    Pn, s->aname);
-			Exit(1);
+			Error();
 		    }
 		    sn->s = s;
 		    sn->next = sh->next;

--- a/dialects/sun/dmnt.c
+++ b/dialects/sun/dmnt.c
@@ -168,7 +168,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(dir, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {
@@ -371,7 +371,7 @@ readvfs(ka, la, lv)
 	if (!(vp = (struct l_vfs *)malloc(sizeof(struct l_vfs)))) {
 	    (void) fprintf(stderr, "%s: PID %d, no space for vfs\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 	vp->dir = (char *)NULL;
 	vp->fsname = (char *)NULL;

--- a/dialects/sun/dnode.c
+++ b/dialects/sun/dnode.c
@@ -573,13 +573,13 @@ build_Voptab()
 					    sizeof(v_optab_t)))
 	) {
 	    (void) fprintf(stderr, "%s: no space for Voptab\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (!(FxToVoptab = (v_optab_t **)calloc((MALLOC_S)Fsinfomax,
 						sizeof(v_optab_t *)))
 	) {
 	    (void) fprintf(stderr, "%s: no space for FxToVoptab\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 0; i < VXVOP_NUM; i++) {
 	    Vvops[i] = (KA_T)NULL;
@@ -620,7 +620,7 @@ build_Voptab()
 	    if (!(nv = (v_optab_t *)malloc((MALLOC_S)sizeof(v_optab_t)))) {
 		(void) fprintf(stderr, "%s: out of Voptab space at: %s\n",
 			Pn, bp->dnm);
-		Exit(1);
+		Error();
 	    }
 	    nv->fsys = bp->fsys;
 	    nv->fx = -1;
@@ -823,7 +823,7 @@ CTF_init(i, t, r)
     if (!isas) {
 	if (sysinfo(SI_ARCHITECTURE_K, isa, sizeof(isa) - 1) == -1) {
 	    (void) fprintf(stderr, "%s: sysinfo: %s\n", Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	isas = 1;
 	isa[sizeof(isa) - 1] = '\0';
@@ -871,7 +871,7 @@ CTF_init(i, t, r)
     if ((f = ctf_open(kmp, &err)) == NULL) {
 	(void) fprintf(stderr, "%s: ctf_open: %s: %s\n",
 	    Pn, kmp, ctf_errmsg(err));
-	Exit(1);
+	Error();
     }
     for (err = 0; r->name; r++) {
 	if (CTF_getmem(f, kmp, r->name, r->mem))
@@ -879,7 +879,7 @@ CTF_init(i, t, r)
     }
     (void) ctf_close(f);
     if (err)
-	Exit(1);
+	Error();
     *i = 1;
 }
 
@@ -1447,7 +1447,7 @@ process_node(va)
 #endif	/* defined(HAS_AFS) */
 
 			      );
-		Exit(1);
+		Error();
 	    }
 	}
 	if (readvnode(va, v)) {
@@ -3821,7 +3821,7 @@ vfs_read_error:
 			    (void) fprintf(stderr,
 				"%s: no space for (COMMON): PID %d; FD %s\n",
 				Pn, Lp->pid, Lf->fd);
-			    Exit(1);
+			    Error();
 			}
 			(void) snpf(Lf->nma, len, "(COMMON)");
 		    }
@@ -5396,7 +5396,7 @@ vop2ty(vp, fx)
 		if (!(nv = (v_optab_t *)malloc((MALLOC_S)sizeof(v_optab_t)))) {
 		    (void) fprintf(stderr, "%s: can't add \"%s\" to Voptab\n",
 			Pn, Fsinfo[fx]);
-		    Exit(1);
+		    Error();
 		}
 		*nv = *v;
 		nv->v_op = ka;

--- a/dialects/sun/dnode2.c
+++ b/dialects/sun/dnode2.c
@@ -149,14 +149,14 @@ add2em(em, fmt, arg)
 	    if (!(eml = (MALLOC_S)strlen(em))) {
 		(void) fprintf(stderr, "%s: add2em: previous message empty\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	    al = eml + nl + 3;
 	    em = (char *)realloc((MALLOC_P *)em, al);
 	}
 	if (!em) {
 	    (void) fprintf(stderr, "%s: no VxFS error message space\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(em + eml, al - eml, "%s%s%s",
 	    eml ? "" : EMSGPFX,
@@ -239,7 +239,7 @@ getioffs(vx, vxl, dev, devl, ino, inol, nl, nll, sz, szl)
 	    return(add2em((char *)NULL, "zero length %s", "vx_inode"));
 	if (!(tv = (char *)malloc((MALLOC_S)tvl))) {
 	    (void) fprintf(stderr, "%s: no vx_inode space\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	*vx = tv;
 	*vxl = tvl;
@@ -312,7 +312,7 @@ print_vxfs_rnl_path(lf)
 		if (!rm) {
 		    (void) fprintf(stderr,
 			"%s: no RNL mount point cache space\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    i = rmu;

--- a/dialects/sun/dproc.c
+++ b/dialects/sun/dproc.c
@@ -176,7 +176,7 @@ close_kvm()
 	if (Kd) {
 	    if (kvm_close(Kd) != 0) {
 		(void) fprintf(stderr, "%s: kvm_close failed\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    Kd = (kvm_t *)NULL;
 	}
@@ -430,7 +430,7 @@ gather_proc_info()
 		    {
 			(void) fprintf(stderr,
 			    "%s: no space for zone name hash\n", Pn);
-			Exit(1);
+			Error();
 		    }
 		}
 		for (zp = ZoneNm[zh]; zp; zp = zp->next) {
@@ -446,13 +446,13 @@ gather_proc_info()
 		    {
 			(void) fprintf(stderr,
 			    "%s: no zone name cache space: %s\n", Pn, zn);
-			Exit(1);
+			Error();
 		    }
 		    if (!(zp->zn = mkstrcpy(zn, (MALLOC_S *)NULL))) {
 			(void) fprintf(stderr,
 			    "%s: no zone name space at PID %d: %s\n",
 			    Pn, (int)Lp->pid, zn);
-			Exit(1);
+			Error();
 		    }
 		    zp->next = ZoneNm[zh];
 		    ZoneNm[zh] = zp;
@@ -613,7 +613,7 @@ get_kernel_access()
 	    if (sysinfo(SI_ISALIST, isa, (long)sizeof(isa)) < 0) {
 		(void) fprintf(stderr, "%s: can't get ISA list: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    for (cp = isa; *cp;) {
 		if (strncmp(cp, ARCH64B, strlen(ARCH64B)) == 0) {
@@ -631,7 +631,7 @@ get_kernel_access()
 		(void) fprintf(stderr,
 		    "      but this machine has booted a %d bit kernel.\n",
 		    (int)kbits);
-		Exit(1);
+		Error();
 	    }
 	}
 #endif	/* solaris>=70000 */
@@ -640,7 +640,7 @@ get_kernel_access()
  * Get kernel symbols.
  */
 	if (Nmlst && !is_readable(Nmlst, 1))
-	    Exit(1);
+	    Error();
 	(void) build_Nl(Drive_Nl);
 
 #if	defined(HAS_AFS)
@@ -654,7 +654,7 @@ get_kernel_access()
 	    if (!(nl = (struct nlist *)malloc(Nll))) {
 		(void) fprintf(stderr, "%s: no space (%d) for Nl[] copy\n",
 		    Pn, Nll);
-		Exit(1);
+		Error();
 	    }
 	    (void) memcpy((void *)nl, (void *)Nl, (size_t)Nll);
 	}
@@ -663,7 +663,7 @@ get_kernel_access()
 	if (nlist(Nmlst ? Nmlst : N_UNIX, Nl) < 0) {
 	    (void) fprintf(stderr, "%s: can't read namelist from %s\n",
 		Pn, Nmlst ? Nmlst : N_UNIX);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(HAS_AFS)
@@ -735,7 +735,7 @@ get_kernel_access()
  * See if the non-KMEM memory file is readable.
  */
 	if (Memory && !is_readable(Memory, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -753,7 +753,7 @@ get_kernel_access()
 	    (void) fprintf(stderr,
 		"%s: can't read kernel base address from %s\n",
 		Pn, print_kptr(v, (char *)NULL, 0));
-	    Exit(1);
+	    Error();
 	}
 #endif	/* solaris>=20500 */
 
@@ -823,7 +823,7 @@ enter_zone_arg(zn)
 	    if (!(ZoneArg = (znhash_t **)calloc(HASHZONE, sizeof(znhash_t *))))
 	    {
 		(void) fprintf(stderr, "%s: no space for zone arg hash\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -848,7 +848,7 @@ enter_zone_arg(zn)
  */
 	if (!(zpn = (znhash_t *)malloc((MALLOC_S)sizeof(znhash_t)))) {
 	    (void) fprintf(stderr, "%s no hash space for zone: %s\n", Pn, zn);
-	    Exit(1);
+	    Error();
 	}
 	zpn->f = 0;
 	zpn->zn = zn;
@@ -984,7 +984,7 @@ kread(addr, buf, len)
 			return(1);
 		    if (!(kp = (kvmhash_t *)malloc(sizeof(kvmhash_t)))) {
 			(void) fprintf(stderr, "%s: no kvmhash_t space\n", Pn);
-			Exit(1);
+			Error();
 		    }
 		    kp->nxt = KVMhb[h];
 		    pa = kp->pa = (pa & ~(KPHYS)PSMask);
@@ -1055,14 +1055,14 @@ open_kvm()
 		Nmlst ? Nmlst : "default",
 		Memory  ? Memory  : "default",
 		strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 
 #if	solaris>=20501 && solaris<70000
 	if ((Kmd = open((Memory ? Memory : KMEM), O_RDONLY)) < 0) {
 	    (void) fprintf(stderr, "%s: open(\"/dev/mem\"): %s\n", Pn,
 		strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 #endif	/* solaris>=20501 && solaris<70000 */
 
@@ -1326,20 +1326,20 @@ readfsinfo()
 	if ((Fsinfomax = sysfs(GETNFSTYP)) == -1) {
 	    (void) fprintf(stderr, "%s: sysfs(GETNFSTYP) error: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if (Fsinfomax == 0)
 		return;
 	if (!(Fsinfo = (char **)malloc((MALLOC_S)(Fsinfomax * sizeof(char *)))))
 	{
 	    (void) fprintf(stderr, "%s: no space for sysfs info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 1; i <= Fsinfomax; i++) {
 	    if (sysfs(GETFSTYP, i, buf) == -1) {
 		(void) fprintf(stderr, "%s: sysfs(GETFSTYP) error: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    if (buf[0] == '\0') {
 		Fsinfo[i-1] = "";
@@ -1350,7 +1350,7 @@ readfsinfo()
 	    if (!(Fsinfo[i-1] = (char *)malloc((MALLOC_S)len))) {
 		(void) fprintf(stderr,
 		    "%s: no space for file system entry %s\n", Pn, buf);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(Fsinfo[i-1], len, "%s", buf);
 
@@ -1395,7 +1395,7 @@ readkam(addr)
 		     (void) fprintf(stderr,
 			"%s: no space (%d) for KVM hash buckets\n",
 			Pn, (int)(KVMHASHBN * sizeof(kvmhash_t *)));
-		    Exit(1);
+		    Error();
 		}
 	    } else if (!addr) {
 		for (i = 0; i < KVMHASHBN; i++) {
@@ -1456,7 +1456,7 @@ read_proc()
 		    P = (struct proc *)malloc(len);
 		if (!P) {
 		    (void) fprintf(stderr, "%s: no proc table space\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Pre-allocate PGID and PID number space.
@@ -1469,7 +1469,7 @@ read_proc()
 			Pgid = (int *)malloc(len);
 		    if (!Pgid) {
 			(void) fprintf(stderr, "%s: no PGID table space\n", Pn);
-			Exit(1);
+			Error();
 		    }
 		}
 		if (Pid)
@@ -1478,7 +1478,7 @@ read_proc()
 		    Pid = (int *)malloc(len);
 		if (!Pid) {
 		    (void) fprintf(stderr, "%s: no PID table space\n", Pn);
-		    Exit(1);
+		    Error();
 		}
 		Npa = n;
 	    }
@@ -1491,7 +1491,7 @@ read_proc()
 		if (!PrAct || kread(PrAct, (char *)&paf, sizeof(pa))) {
 		    (void) fprintf(stderr, "%s: can't read practive from %s\n",
 			Pn, print_kptr(PrAct, (char *)NULL, 0));
-		    Exit(1);
+		    Error();
 		}
 		ct = 1;
 		ctl = knp << 3;
@@ -1505,7 +1505,7 @@ read_proc()
 		if (kvm_setproc(Kd) != 0) {
 		    (void) fprintf(stderr, "%s: kvm_setproc: %s\n", Pn,
 			strerror(errno));
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*
@@ -1523,7 +1523,7 @@ read_proc()
 		    if (!(P = (struct proc *)realloc((MALLOC_P *)P, len))) {
 			(void) fprintf(stderr,
 			    "%s: no more (%d) proc space\n", Pn, Npa);
-			Exit(1);
+			Error();
 		    }
 		/*
 		 * Expand the PGID and PID tables.
@@ -1533,13 +1533,13 @@ read_proc()
 			if (!(Pgid = (int *)realloc((MALLOC_P *)Pgid, len))) {
 			    (void) fprintf(stderr,
 				"%s: no more (%d) PGID space\n", Pn, Npa);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    if (!(Pid = (int *)realloc((MALLOC_P *)Pid, len))) {
 			(void) fprintf(stderr,
 			    "%s: no more (%d) PID space\n", Pn, Npa);
-			Exit(1);
+			Error();
 		    }
 		}
 	    /*
@@ -1631,7 +1631,7 @@ read_proc()
  */
 	if (try >= PROCTRYLM) {
 	    (void) fprintf(stderr, "%s: can't read proc table\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (Np < Npa && !RptTm) {
 
@@ -1643,7 +1643,7 @@ read_proc()
 	    if (!(P = (struct proc *)realloc((MALLOC_P *)P, len))) {
 		(void) fprintf(stderr, "%s: can't reduce proc table to %d\n",
 		    Pn, Np);
-		Exit(1);
+		Error();
 	    }
 	/*
 	 * Reduce the Solaris PGID and PID tables to their minimum if
@@ -1654,13 +1654,13 @@ read_proc()
 		if (!(Pgid = (int *)realloc((MALLOC_P *)Pgid, len))) {
 		    (void) fprintf(stderr,
 			"%s: can't reduce PGID table to %d\n", Pn, Np);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    if (!(Pid = (int *)realloc((MALLOC_P *)Pid, len))) {
 		(void) fprintf(stderr,
 		    "%s: can't reduce PID table to %d\n", Pn, Np);
-		Exit(1);
+		Error();
 	    }
 	    Npa = Np;
 	}
@@ -1680,7 +1680,7 @@ restoregid()
 		(void) fprintf(stderr,
 		    "%s: can't set effective GID to %d: %s\n",
 		    Pn, (int)Savedgid, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    Setgid = 1;
 	}
@@ -1824,7 +1824,7 @@ ncache_isroot(va, cp)
 	    if (!vc) {
 		(void) fprintf(stderr, "%s: no space for root vnode table\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 	vc[vcn++] = va;
@@ -1911,7 +1911,7 @@ ncache_load()
 	    if (!(khl = (nc_hash_t *)malloc((MALLOC_S)len))) {
 		(void) fprintf(stderr,
 		    "%s: can't allocate DNLC hash space: %d\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 	/*
 	 * Allocate space for a kernel DNLC entry, plus additional name space
@@ -1922,7 +1922,7 @@ ncache_load()
 	    {
 		(void) fprintf(stderr,
 		    "%s: can't allocate DNLC ncache_t space\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    nmo = offsetof(struct ncache, name);
 	/*
@@ -1949,7 +1949,7 @@ no_local_space:
 
 		(void) fprintf(stderr,
 		    "%s: no space for %d byte local name cache\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 	} else {
 
@@ -2030,7 +2030,7 @@ no_local_space:
 			) {
 			    (void) fprintf(stderr,
 				"%s: can't extend DNLC ncache_t buffer\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    cp = &nc->name[XNC + 1];
@@ -2046,7 +2046,7 @@ no_local_space:
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for name cache name\n",
 			Pn, len + 1);
-		    Exit(1);
+		    Error();
 		}
 		(void) strncpy(cp, nc->name, len);
 		cp[len] = '\0';
@@ -2061,7 +2061,7 @@ no_local_space:
 		    ) {
 			(void) fprintf(stderr,
 			    "%s: can't enlarge local name cache\n", Pn);
-			Exit(1);
+			Error();
 		    }
 		    lc = &Ncache[n];
 		}
@@ -2123,7 +2123,7 @@ no_local_space:
 	    (void) fprintf(stderr,
 		"%s: no space for %d name cache hash pointers\n",
 		Pn, Nhl + Nlu);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 0, lc = Ncache; i < Nlu; i++, lc++) {
 	    for (hp = ncachehash(lc->vp), h = 1; *hp; hp++) {

--- a/dialects/uw/dmnt.c
+++ b/dialects/uw/dmnt.c
@@ -103,7 +103,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(me.mnt_mountp, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    if (!(ln = Readlink(dn))) {
 		if (!Fwarn) {

--- a/dialects/uw/dnode.c
+++ b/dialects/uw/dnode.c
@@ -142,7 +142,7 @@ ent_fa(a1, a2, d)
 	    (void) fprintf(stderr,
 		"%s: no space for fattach addresses at PID %d, FD %s\n",
 		Pn, Lp->pid, Lf->fd);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(cp, len, "%s", buf);
 	Lf->nma = cp;
@@ -309,7 +309,7 @@ examine_stream(vs, q, mch, mn, sn, sqp)
 		    if (!ab) {
 			(void) fprintf(stderr,
 			    "%s: no space for stream chain", Pn);
-			Exit(1);
+			Error();
 		    }
 		}
 		(void) snpf(ap, aba - (al - 1), "%s%s",
@@ -1436,7 +1436,7 @@ get_lock_state:
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for l_ino name addition\n",
 			msz, Pn);
-		    Exit(1);
+		    Error();
 		}
 		(void) snpf(cp, msz + 1, "%s", i.nm);
 		Lf->nma = cp;

--- a/dialects/uw/dnode3.c
+++ b/dialects/uw/dnode3.c
@@ -243,7 +243,7 @@ readdosfslino(v, i)
 		if (!(nm = (char *)malloc(nml))) {
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d bytes for DOS name\n", nml, Pn);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*

--- a/dialects/uw/dproc.c
+++ b/dialects/uw/dproc.c
@@ -183,7 +183,7 @@ gather_proc_info()
 		    (void) fprintf(stderr,
 			"%s: PID %d; no space for %d file descriptors\n",
 			Pn, pid, nf);
-		    Exit(1);
+		    Error();
 		}
 		nfea = nf;
 	    }
@@ -247,7 +247,7 @@ get_clonemaj()
 	if (!(cd = (struct cdevsw *)malloc(len))) {
 	    (void) fprintf(stderr, "%s: can't allocate %d bytes for cdevsw\n",
 		Pn);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Read the cdevsw[] from kernel memory.
@@ -313,7 +313,7 @@ get_kernel_access()
  * See if the non-KMEM memory file is readable.
  */
 	if (Memory && !is_readable(Memory, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -322,7 +322,7 @@ get_kernel_access()
 	if ((Kd = open(Memory ? Memory : KMEM, O_RDONLY, 0)) < 0) {
 	    (void) fprintf(stderr, "%s: can't open %s: %s\n", Pn,
 		Memory ? Memory : KMEM, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(WILLDROPGID)
@@ -336,7 +336,7 @@ get_kernel_access()
  * See if the name list file is readable.
  */
 	if (Nmlst && !is_readable(Nmlst, 1))
-	    Exit(1);
+	    Error();
 #endif	/* defined(WILLDROPGID) */
 
 /*
@@ -346,18 +346,18 @@ get_kernel_access()
         if (nlist(Nmlst ? Nmlst : N_UNIX, Nl) < 0) {
 	    (void) fprintf(stderr, "%s: can't read kernel name list from %s\n",
 		Pn, Nmlst ? Nmlst : N_UNIX);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("var", Drive_Nl, &v) < 0 || !v
 	||  kread((KA_T)v, (char *)&Var, sizeof(Var))) {
 	    (void) fprintf(stderr,
 		"%s: can't read system configuration info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("proc", Drive_Nl, &Pract) < 0 || !Pract) {
 	    (void) fprintf(stderr,
 		"%s: can't find active process chain pointer\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (get_Nl_value("sgdnops", Drive_Nl, &Sgdnops) < 0 || !Sgdnops)
 	    Sgdnops = (unsigned long)0;
@@ -511,27 +511,27 @@ readfsinfo()
 	if ((Fsinfomax = sysfs(GETNFSTYP)) == -1) {
 	    (void) fprintf(stderr, "%s: sysfs(GETNFSTYP) error: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if (Fsinfomax == 0)
 	    return;
 	if (!(Fsinfo = (char **)malloc((MALLOC_S)(Fsinfomax * sizeof(char *)))))
 	{
 	    (void) fprintf(stderr, "%s: no space for sysfs info\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 1; i <= Fsinfomax; i++) {
 	    if (sysfs(GETFSTYP, i, buf) == -1) {
 		(void) fprintf(stderr, "%s: sysfs(GETFSTYP) error: %s\n",
 		    Pn, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    buf[FSTYPSZ] = '\0';
 	    len = strlen(buf) + 1;
 	    if (!(Fsinfo[i-1] = (char *)malloc((MALLOC_S)len))) {
 		(void) fprintf(stderr,
 		    "%s: no space for file system entry %s\n", Pn, buf);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(Fsinfo[i-1], len, "%s", buf);
 	}
@@ -559,14 +559,14 @@ read_proc()
 	    if ((Npa = Var.v_proc) < 1) {
 		(void) fprintf(stderr, "%s: bad proc table size: %d\n",
 		    Pn, Var.v_proc);
-		Exit(1);
+		Error();
 	    }
 	    Npa += PROCINCR;
 	    len = (MALLOC_S)(Npa * sizeof(struct proc));
 	    if (!(P = (struct proc *)malloc(len))) {
 		(void) fprintf(stderr, "%s: no space for %d proc structures\n",
 		    Pn, Npa);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -601,7 +601,7 @@ read_proc()
 			(void) fprintf(stderr,
 			    "%s: can't realloc %d proc table entries (%d)\n",
 			    Pn, Npa, len);
-			Exit(1);
+			Error();
 		    }
 		    p = &P[Np];
 		}
@@ -631,7 +631,7 @@ read_proc()
  */
 	if (try >= PROCTRYLM) {
 	    (void) fprintf(stderr, "%s: can't read proc table\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (Np < Npa && !RptTm) {
 
@@ -642,7 +642,7 @@ read_proc()
 	    if (!(P = (struct proc *)realloc((MALLOC_P *)P, len))) {
 		(void) fprintf(stderr,
 		    "%s: can't reduce proc table to %d entries\n", Pn, Np);
-		Exit(1);
+		Error();
 	    }
 	    Npa = Np;
 	}

--- a/lib/ckkv.c
+++ b/lib/ckkv.c
@@ -67,7 +67,7 @@ ckkv(d, er, ev, ea)
 	if (uname(&u) < 0) {
 	    (void) fprintf(stderr, "%s: uname error: %s\n",
 		Pn, strerror(errno));
-	    Exit(1);
+	    Error();
 	}
 	if (er && strcmp(er, u.release)) {
 	    (void) fprintf(stderr,

--- a/lib/dvch.c
+++ b/lib/dvch.c
@@ -127,14 +127,14 @@ alloc_bdcache()
 				       sizeof(struct l_dev))))
 	{
 	    (void) fprintf(stderr, "%s: no space for block devices\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (!(BSdev = (struct l_dev **)malloc((MALLOC_S)(sizeof(struct l_dev *)
 				       * BNdev))))
 	{
 	    (void) fprintf(stderr, "%s: no space for block device pointers\n",
 		Pn);
-	    Exit(1);
+	    Error();
 	}
 }
 # endif	/* defined(HASBLKDEV) */
@@ -151,14 +151,14 @@ alloc_dcache()
 				      sizeof(struct l_dev))))
 	{
 	    (void) fprintf(stderr, "%s: no space for devices\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (!(Sdev = (struct l_dev **)malloc((MALLOC_S)(sizeof(struct l_dev *)
 				      * Ndev))))
 	{
 	    (void) fprintf(stderr, "%s: no space for device pointers\n",
 		Pn);
-	    Exit(1);
+	    Error();
 	}
 }
 
@@ -615,7 +615,7 @@ dcpath(rw, npw)
  * will have been issued to stderr.
  */
 	if (merr)
-	    Exit(1);
+	    Error();
 /*
  * Return the index of the first defined path.  Since DCpath[] is arranged
  * in priority order, searching it beginning to end follows priority.
@@ -760,7 +760,7 @@ close_exit:
 	 */
 	    (void) fprintf(stderr, "%s: internal error: open_dcache=%d\n",
 		Pn, m);
-	    Exit(1);
+	    Error();
 	}
 	return(1);
 }
@@ -965,7 +965,7 @@ read_dhdr:
 		(void) fprintf(stderr,
 		    "%s: device %d: no space for path: line ", Pn, i + 1);
 		safestrprt(buf, stderr, 1+4+8);
-		Exit(1);
+		Error();
 	    }
 	    Devtp[i].v = 0;
 	    Sdev[i] = &Devtp[i];
@@ -1053,7 +1053,7 @@ read_dhdr:
 		    (void) fprintf(stderr,
 			"%s: block dev %d: no space for path: line", Pn, i + 1);
 		    safestrprt(buf, stderr, 1+4+8);
-		    Exit(1);
+		    Error();
 		}
 	        BDevtp[i].v = 0;
 	        BSdev[i] = &BDevtp[i];
@@ -1208,7 +1208,7 @@ bad_clone_index:
 			"%s: clone %d: no space for cached clone: line ", Pn,
 			i + 1);
 		    safestrprt(buf, stderr, 1+4+8);
-		    Exit(1);
+		    Error();
 		}
 		c->dx = j;
 		c->next = Clone;
@@ -1255,7 +1255,7 @@ bad_clone_index:
  */
 	(void) fprintf(stderr, "%s: internal rw_clone_sect error: %d\n",
 	    Pn, m);
-	Exit(1);
+	Error();
 	return(1);		/* This useless return(1) keeps some
 				 * compilers happy. */
 }

--- a/lib/isfn.c
+++ b/lib/isfn.c
@@ -158,7 +158,7 @@ hashSfile()
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for %d clone hash buckets\n",
 		    Pn, SFCDHASH);
-		Exit(1);
+		Error();
 	    }
 	    sfplm++;
 	}
@@ -170,7 +170,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d (dev,ino) hash buckets\n",
 		Pn, SFDIHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFrd = (struct hsfile *)calloc((MALLOC_S)SFRDHASH,
 					       sizeof(struct hsfile))))
@@ -178,7 +178,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d rdev hash buckets\n",
 		Pn, SFRDHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyFsd = (struct hsfile *)calloc((MALLOC_S)SFFSHASH,
 					       sizeof(struct hsfile))))
@@ -186,7 +186,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d file sys hash buckets\n",
 		Pn, SFFSHASH);
-	    Exit(1);
+	    Error();
 	}
 	if (!(HbyNm = (struct hsfile *)calloc((MALLOC_S)SFNMHASH,
 					      sizeof(struct hsfile))))
@@ -194,7 +194,7 @@ hashSfile()
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for %d name hash buckets\n",
 		Pn, SFNMHASH);
-	    Exit(1);
+	    Error();
 	}
 	hs++;
 /*
@@ -258,7 +258,7 @@ hashSfile()
 			(void) fprintf(stderr,
 			    "%s: can't allocate hsfile bucket for: %s\n",
 			    Pn, s->aname);
-			Exit(1);
+			Error();
 		    }
 		    sn->s = s;
 		    sn->next = sh->next;

--- a/lib/pdvn.c
+++ b/lib/pdvn.c
@@ -155,7 +155,7 @@ printdevname_again:
 	    if (!(cp = (char *)malloc((MALLOC_S)(len + 1)))) {
 		(void) fprintf(stderr, "%s: no nma space for: (%s %s)\n",
 		    Pn, ttl, dp->name);
-		Exit(1);
+		Error();
 	    }
 	    (void) snpf(cp, len + 1, "(%s %s)", ttl, dp->name);
 	    (void) add_nma(cp, len);

--- a/lib/rdev.c
+++ b/lib/rdev.c
@@ -188,7 +188,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr, "%s: no space for: ", Pn);
 		safestrprt(Dstk[Dstkx], stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    (void) free((FREE_P *)Dstk[Dstkx]);
 	    Dstk[Dstkx] = (char *)NULL;
@@ -218,7 +218,7 @@ readdev(skip)
 		    (void) fprintf(stderr, "%s: no space for: ", Pn);
 		    safestrprt(path, stderr, 0);
 		    safestrprtn(dp->d_name, dnamlen, stderr, 1);
-		    Exit(1);
+		    Error();
 		}
 		if (RDEV_STATFN(fp, &sb) != 0) {
 		    if (errno == ENOENT)	/* a sym link to nowhere? */
@@ -260,7 +260,7 @@ readdev(skip)
 			if (!Devtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for character device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    Devtp[i].rdev = RDEV_EXPDEV(sb.st_rdev);
@@ -269,7 +269,7 @@ readdev(skip)
 			(void) fprintf(stderr,
 			    "%s: no space for device name: ", Pn);
 			safestrprt(fp, stderr, 1);
-			Exit(1);
+			Error();
 		    }
 		    Devtp[i].v = 0;
 
@@ -285,7 +285,7 @@ readdev(skip)
 			    (void) fprintf(stderr,
 				"%s: no space for clone device: ", Pn);
 			    safestrprt(fp, stderr, 1);
-			    Exit(1);
+			    Error();
 			}
 			c->dx = i;
 			c->next = Clone;
@@ -313,7 +313,7 @@ readdev(skip)
 			if (!BDevtp) {
 			    (void) fprintf(stderr,
 				"%s: no space for block device\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    BDevtp[j].name = fp;
@@ -357,7 +357,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for block device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (j = 0; j < BNdev; j++) {
 		BSdev[j] = &BDevtp[j];
@@ -387,7 +387,7 @@ readdev(skip)
 	    {
 		(void) fprintf(stderr,
 		    "%s: no space for character device sort pointers\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    for (i = 0; i < Ndev; i++) {
 		Sdev[i] = &Devtp[i];
@@ -397,7 +397,7 @@ readdev(skip)
 	    Ndev = rmdupdev(&Sdev, Ndev, "char");
 	} else {
 	    (void) fprintf(stderr, "%s: no character devices found\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 
 # if	defined(HASDCACHE)
@@ -487,7 +487,7 @@ rmdupdev(dp, n, nm)
 	{
 	    (void) fprintf(stderr, "%s: can't realloc %s device pointers\n",
 		Pn, nm);
-	    Exit(1);
+	    Error();
 	}
 	return(j);
 }

--- a/lib/rmnt.c
+++ b/lib/rmnt.c
@@ -102,7 +102,7 @@ readmnt()
  */
 	if (!(mfp = setmntent(MOUNTED, "r"))) {
 	    (void) fprintf(stderr, "%s: can't access %s\n", Pn, MOUNTED);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Read mount table entries.
@@ -179,7 +179,7 @@ no_space_for_mount:
 		(void) fprintf(stderr, " (");
 		safestrprt(mp->mnt_dir, stderr, 0);
 		(void) fprintf(stderr, ")\n");
-		Exit(1);
+		Error();
 	    }
 	    mtp->dir = dn;
 	    dn = (char *)NULL;
@@ -198,7 +198,7 @@ no_space_for_mount:
 	    {
 		(void) fprintf(stderr, "%s: no space for fstype (%s): %s\n",
 		    Pn, mtp->dir, mp->RMNT_FSTYPE);
-		Exit(1);
+		Error();
 	    }
 	    (void) strcpy(mtp->MOUNTS_FSTYPE, mp->RMNT_FSTYPE);
 # endif	/* defined(RMNT_FSTYP) && defined(MOUNTS_FSTYP) */

--- a/lib/rnam.c
+++ b/lib/rnam.c
@@ -263,7 +263,7 @@ ncache_isroot(na, cp)
 	    if (!nc) {
 		(void) fprintf(stderr, "%s: no space for root node table\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	    nca += 10;
 	}
@@ -354,7 +354,7 @@ ncache_load()
 		if (!Fwarn)
 		    (void) fprintf(stderr,
 			"%s: can't allocate name cache space: %d\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 # endif	/* defined(NCACHE_NXT) */
 
@@ -369,7 +369,7 @@ no_local_space:
 		if (!Fwarn)
 		    (void) fprintf(stderr,
 			"%s: no space for %d byte local name cache\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 	} else {
 
@@ -441,7 +441,7 @@ no_local_space:
 		    (void) fprintf(stderr,
 			"%s: no more space for %d entry local name cache\n",
 			Pn, Nc);
-		    Exit(1);
+		    Error();
 		}
 		lc = &Ncache[n];
 	    }
@@ -519,7 +519,7 @@ no_local_space:
 		(void) fprintf(stderr,
 		    "%s: no space for %d name cache hash pointers\n",
 		    Pn, Nch + Nc);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 0, lc = Ncache; i < Nc; i++, lc++) {
 

--- a/lib/rnch.c
+++ b/lib/rnch.c
@@ -303,7 +303,7 @@ ncache_isroot(va, cp)
 	    if (!vc) {
 		(void) fprintf(stderr, "%s: no space for root vnode table\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 	vc[vcn++] = va;
@@ -428,7 +428,7 @@ ncache_load()
 		if (!Fwarn)
 		    (void) fprintf(stderr,
 			"%s: can't allocate name cache space: %d\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 # endif	/* !defined(NCACHE_NXT) */
 
@@ -443,7 +443,7 @@ no_local_space:
 		if (!Fwarn)
 		    (void) fprintf(stderr,
 		      "%s: no space for %d byte local name cache\n", Pn, len);
-		Exit(1);
+		Error();
 	    }
 	} else {
 
@@ -532,7 +532,7 @@ no_local_space:
 		    (void) fprintf(stderr,
 			"%s: can't allocate %d byte temporary name buffer\n",
 			Pn, na);
-		    Exit(1);
+		    Error();
 		}
 	    }
 	    if (!kc->NCACHE_NAME || kread((KA_T)kc->NCACHE_NAME, nb, len))
@@ -558,7 +558,7 @@ no_local_space:
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for name cache name: %s\n",
 		    Pn, len + 1, np);
-		Exit(1);
+		Error();
 	    }
 	    (void) strncpy(cp, np, len);
 	    cp[len] = '\0';
@@ -577,7 +577,7 @@ no_local_space:
 		    (void) fprintf(stderr,
 			"%s: no more space for %d entry local name cache\n",
 			Pn, Nc);
-		    Exit(1);
+		    Error();
 		}
 		lc = &Ncache[n];
 		iNc = Nc;
@@ -664,7 +664,7 @@ no_local_space:
 		(void) fprintf(stderr,
 		    "%s: no space for %d name cache hash pointers\n",
 		    Pn, Nch + Nc);
-	    Exit(1);
+	    Error();
 	}
 	for (i = 0, lc = Ncache; i < Nc; i++, lc++) {
 

--- a/lib/rnmh.c
+++ b/lib/rnmh.c
@@ -298,7 +298,7 @@ ncache_isroot(na, cp)
 	    if (!nc) {
 		(void) fprintf(stderr, "%s: no space for root node table\n",
 		    Pn);
-		Exit(1);
+		Error();
 	    }
 	    nca += 10;
 	}
@@ -407,7 +407,7 @@ ncache_load()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for name cache hash table\n",
 		    Pn, len);
-		Exit(1);
+		Error();
 	    }
 	    khpl = len;
 	}
@@ -511,7 +511,7 @@ ncache_load()
 			(void) fprintf(stderr,
 			    "%s: can't allocate %d local name cache bytes\n",
 			    Pn, nlcl);
-			Exit(1);
+			Error();
 		    }
 		    lcl = nlcl;
 		}
@@ -604,7 +604,7 @@ ncache_load()
 		(void) fprintf(stderr,
 		    "%s: no space for %d local name cache hash pointers\n",
 		    Pn, len);
-	    Exit(1);
+	    Error();
 	}
 	for (lc = Ncache; lc; lc = lc->next) {
 

--- a/lsof.h
+++ b/lsof.h
@@ -565,8 +565,8 @@ extern int ZoneColW;
 enum ExitStatus {
 	LSOF_SUCCESS,
 	LSOF_ERROR,
-	LSOF_SEARCH_FAILURE = LSOF_ERROR
 };
+#define LSOF_SEARCH_FAILURE (FsearchErr? LSOF_ERROR: LSOF_SUCCESS)
 
 
 /*
@@ -727,6 +727,7 @@ extern int FportMap;
 
 extern int Fpgid;
 extern int Fppid;
+extern int FsearchErr;
 extern int Fsize;
 extern int Fsv;
 extern int FsvByf;

--- a/lsof.h
+++ b/lsof.h
@@ -557,6 +557,18 @@ extern int ZoneColW;
 #define	SELFILE		(SELFD|SELNFS|SELNLINK|SELNM)	/* file selecters */
 #define	SELNW		(SELNA|SELNET|SELUNX)		/* network selecters */
 
+
+/*
+ * Exit Status
+ */
+
+enum ExitStatus {
+	LSOF_SUCCESS,
+	LSOF_ERROR,
+	LSOF_SEARCH_FAILURE = LSOF_ERROR
+};
+
+
 /*
  * Structure definitions
  */

--- a/main.c
+++ b/main.c
@@ -64,7 +64,8 @@ main(argc, argv)
 	int argc;
 	char *argv[];
 {
-	int ad, c, i, n, rv, se1, se2, ss;
+	int rv, gopt_rv;
+	int ad, c, i, n, se1, se2, ss;
 	char *cp;
 	int err = 0;
 	int ev = 0;
@@ -253,8 +254,8 @@ main(argc, argv)
 /*
  * Loop through options.
  */
-	while ((c = GetOpt(argc, argv, options, &rv)) != EOF) {
-	    if (rv) {
+	while ((c = GetOpt(argc, argv, options, &gopt_rv)) != EOF) {
+	    if (gopt_rv) {
 		err = 1;
 		continue;
 	    }

--- a/main.c
+++ b/main.c
@@ -141,7 +141,7 @@ main(argc, argv)
 	while (((i = open("/dev/null", O_RDWR, 0)) >= 0) && (i < 2))
 	    ;
 	if (i < 0)
-	    Exit(1);
+	    Error();
 	if (i > 2)
 	    (void) close(i);
 	(void) umask(0);
@@ -164,7 +164,7 @@ main(argc, argv)
 	    Setuidroot = 1;
 	if (!(Namech = (char *)malloc(MAXPATHLEN + 1))) {
 	    (void) fprintf(stderr, "%s: no space for name buffer\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	Namechl = (size_t)(MAXPATHLEN + 1);
 /*
@@ -827,7 +827,7 @@ main(argc, argv)
 			(void) fprintf(stderr,
 			    "%s: no space (%d) for <fmt> result: \"%s\"\n",
 			    Pn, (int)fmtl, cp);
-			    Exit(1);
+			    Error();
 		    }
 		    if (util_strftime(fmtr, fmtl - 1, fmt) < 1) {
 			(void) fprintf(stderr, "%s: illegal <fmt>: \"%s\"\n",
@@ -1174,7 +1174,7 @@ main(argc, argv)
 			 (MALLOC_S)(sizeof(struct seluid) * Nuid))))
 	    {
 		(void) fprintf(stderr, "%s: can't realloc UID table\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	    Mxuid = Nuid;
 	}
@@ -1247,7 +1247,7 @@ main(argc, argv)
 		    (void) fprintf(stderr, "%s: can't stat(/dev): %s\n", Pn,
 		    strerror(se2));
 		}
-		Exit(1);
+		Error();
 	    }
 	}
 	DevDev = sb.st_dev;
@@ -1256,7 +1256,7 @@ main(argc, argv)
  */
 	if (GOx1 < argc) {
 	    if (ck_file_arg(GOx1, argc, argv, Ffilesys, 0, (struct stat *)NULL))
-		Exit(1);
+		Error();
 	}
 /*
  * Do dialect-specific initialization.
@@ -1333,7 +1333,7 @@ main(argc, argv)
 		    if (!slp) {
 			(void) fprintf(stderr,
 			    "%s: no space for %d sort pointers\n", Pn, Nlproc);
-			Exit(1);
+			Error();
 		    }
 		}
 		for (i = 0; i < Nlproc; i++) {
@@ -1986,7 +1986,7 @@ sv_fmt_str(f)
 	if (!(cp = (char *)malloc(l))) {
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes for format: %s\n", Pn, (int)l, f);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(cp, l, "%s", f);
 	return(cp);

--- a/main.c
+++ b/main.c
@@ -173,7 +173,7 @@ main(argc, argv)
  * Create option mask.
  */
 	(void) snpf(options, sizeof(options),
-	    "?a%sbc:%sD:d:%s%sf:F:g:hi:%s%slL:%s%snNo:Op:Pr:%ss:S:tT:u:UvVwx:%s%s%s",
+	    "?a%sbc:%sD:d:%s%sf:F:g:hi:%s%slL:%s%snNo:Op:QPr:%ss:S:tT:u:UvVwx:%s%s%s",
 
 #if	defined(HAS_AFS) && defined(HASAOPT)
 	    "A:",
@@ -768,6 +768,9 @@ main(argc, argv)
 		if (enter_id(PID, GOv))
 		    err = 1;
 		break;
+	    case 'Q':
+		FsearchErr = 0;
+		break;
 	    case 'P':
 		Fport = (GOp == '-') ? 0 : 1;
 		break;
@@ -1259,7 +1262,7 @@ main(argc, argv)
  * Process the file arguments.
  */
 	if (GOx1 < argc) {
-	    if (ck_file_arg(GOx1, argc, argv, Ffilesys, 0, (struct stat *)NULL))
+	    if (ck_file_arg(GOx1, argc, argv, Ffilesys, 0, (struct stat *)NULL, FsearchErr == 0))
 		Error();
 	}
 /*

--- a/main.c
+++ b/main.c
@@ -1305,7 +1305,7 @@ main(argc, argv)
  */
 	if (MntSup == 1) {
 	    (void) readmnt();
-	    Exit(0);
+	    Exit(LSOF_SUCCESS);
 	}
 #endif	/* defined(HASMNTSUP) */
 

--- a/main.c
+++ b/main.c
@@ -64,11 +64,12 @@ main(argc, argv)
 	int argc;
 	char *argv[];
 {
-	int rv, gopt_rv;
+	enum ExitStatus rv;
+	int gopt_rv;
 	int ad, c, i, n, se1, se2, ss;
 	char *cp;
 	int err = 0;
-	int ev = 0;
+	enum ExitStatus ev = LSOF_SUCCESS;
 	int fh = 0;
 	char *fmtr = (char *)NULL;
 	long l;
@@ -771,8 +772,10 @@ main(argc, argv)
 		Fport = (GOp == '-') ? 0 : 1;
 		break;
 	    case 'r':
-		if (GOp == '+')
-		    ev = rc = 1;
+		if (GOp == '+') {
+		    ev = LSOF_ERROR;
+		    rc = 1;
+		}
 		if (!GOv || *GOv == '-' || *GOv == '+') {
 		    RptTm = RPTTM;
 		    if (GOv) {
@@ -1532,7 +1535,7 @@ main(argc, argv)
 		    if (!n)
 			break;
 		    else
-			ev = 0;
+			ev = LSOF_SUCCESS;
 		}
 
 #if	defined(HAS_STRFTIME)
@@ -1582,7 +1585,7 @@ main(argc, argv)
  * was; one, if not.  If -V was specified, report what was not displayed.
  */
 	(void) childx();
-	rv = 0;
+	rv = LSOF_SUCCESS;
 	for (str = Cmdl; str; str = str->next) {
 
 	/*
@@ -1590,7 +1593,7 @@ main(argc, argv)
 	 */
 	    if (str->f)
 		continue;
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose) {
 		(void) printf("%s: command not located: ", Pn);
 		safestrprt(str->str, stdout, 1);
@@ -1603,7 +1606,7 @@ main(argc, argv)
 	 */
 	    if (CmdRx[i].mc)
 		continue;
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose) {
 		(void) printf("%s: no command found for regex: ", Pn);
 		safestrprt(CmdRx[i].exp, stdout, 1);
@@ -1616,7 +1619,7 @@ main(argc, argv)
 	 */
 	    if (sfp->f)
 		continue;
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose) {
 		(void) printf("%s: no file%s use located: ", Pn,
 		    sfp->type ? "" : " system");
@@ -1629,7 +1632,7 @@ main(argc, argv)
 	 * Report on proc file system search results.
 	 */
 	    if (Procsrch && !Procfind) {
-		rv = 1;
+		rv = LSOF_SEARCH_FAILURE;
 		if (Fverbose) {
 		    (void) printf("%s: no file system use located: ", Pn);
 		    safestrprt(Mtprocfs ? Mtprocfs->dir : HASPROCFS, stdout, 1);
@@ -1640,7 +1643,7 @@ main(argc, argv)
 
 		for (pfi = Procfsid; pfi; pfi = pfi->next) {
 		    if (!pfi->f) {
-			rv = 1;
+			rv = LSOF_SEARCH_FAILURE;
 			if (Fverbose) {
 			    (void) printf("%s: no file use located: ", Pn);
 			    safestrprt(pfi->nm, stdout, 1);
@@ -1684,7 +1687,7 @@ main(argc, argv)
 	    }
 	    for (np = Nwad; np; np = np->next) {
 		if (!np->f && (cp = np->arg)) {
-		    rv = 1;
+		    rv = LSOF_SEARCH_FAILURE;
 		    if (Fverbose) {
 			(void) printf("%s: Internet address not located: ", Pn);
 			safestrprt(cp ? cp : "(unknown)", stdout, 1);
@@ -1697,7 +1700,7 @@ main(argc, argv)
 	/*
 	 * Report no Internet files located.
 	 */
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose)
 		(void) printf("%s: no Internet files located\n", Pn);
 	}
@@ -1710,7 +1713,7 @@ main(argc, argv)
 	 */
 	    for (i = 0; i < TcpNstates; i++) {
 		if (TcpStI[i] == 1) {
-		    rv = 1;
+		    rv = LSOF_SEARCH_FAILURE;
 		    if (Fverbose)
 			(void) printf("%s: TCP state not located: %s\n",
 			    Pn, TcpSt[i]);
@@ -1724,7 +1727,7 @@ main(argc, argv)
 	 */
 	    for (i = 0; i < UdpNstates; i++) {
 		if (UdpStI[i] == 1) {
-		    rv = 1;
+		    rv = LSOF_SEARCH_FAILURE;
 		    if (Fverbose)
 			(void) printf("%s: UDP state not located: %s\n",
 			    Pn, UdpSt[i]);
@@ -1738,7 +1741,7 @@ main(argc, argv)
 	/*
 	 * Report no NFS files located.
 	 */
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose)
 		(void) printf("%s: no NFS files located\n", Pn);
 	}
@@ -1749,7 +1752,7 @@ main(argc, argv)
 	 */
 	    if (Spid[i].f || Spid[i].x)
 		continue;
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose)
 		(void) printf("%s: process ID not located: %d\n",
 		    Pn, Spid[i].i);
@@ -1761,7 +1764,7 @@ main(argc, argv)
 	/*
 	 * Report no tasks located.
 	 */
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose)
 		(void) printf("%s: no tasks located\n", Pn);
 	}
@@ -1776,7 +1779,7 @@ main(argc, argv)
 	    for (i = 0; i < HASHZONE; i++) {
 		for (zp = ZoneArg[i]; zp; zp = zp->next) {
 		    if (!zp->f) {
-			rv = 1;
+			rv = LSOF_SEARCH_FAILURE;
 			if (Fverbose) {
 			    (void) printf("%s: zone not located: ", Pn);
 			    safestrprt(zp->zn, stdout, 1);
@@ -1795,7 +1798,7 @@ main(argc, argv)
 	 */
 	    for (cntxp = CntxArg; cntxp; cntxp = cntxp->next) {
 		if (!cntxp->f) {
-		    rv = 1;
+		    rv = LSOF_SEARCH_FAILURE;
 		    if (Fverbose) {
 			(void) printf("%s: context not located: ", Pn);
 			safestrprt(cntxp->cntx, stdout, 1);
@@ -1812,7 +1815,7 @@ main(argc, argv)
 	 */
 	    if (Spgid[i].f || Spgid[i].x)
 		continue;
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose)
 		(void) printf("%s: process group ID not located: %d\n",
 		    Pn, Spgid[i].i);
@@ -1824,7 +1827,7 @@ main(argc, argv)
 	 */
 	    if (Suid[i].excl || Suid[i].f)
 		continue;
-	    rv = 1;
+	    rv = LSOF_SEARCH_FAILURE;
 	    if (Fverbose) {
 		if (Suid[i].lnm) {
 		    (void) printf("%s: login name (UID %lu) not located: ",
@@ -1838,7 +1841,7 @@ main(argc, argv)
 	if (!rv && rc)
 	    rv = ev;
 	if (!rv && ErrStat)
-	    rv = 1;
+	    rv = LSOF_ERROR;
 	Exit(rv);
 	return(rv);		/* to make code analyzers happy */
 }

--- a/misc.c
+++ b/misc.c
@@ -171,7 +171,7 @@ childx()
 			    "%s: WARNING -- child process %d may be hung.\n",
 			    Pn, (int)Cpid);
 		    break;
-	        }
+		}
 	    /*
 	     * Send the next signal to the child process, after the first pass
 	     * through the loop.
@@ -736,7 +736,7 @@ dup_IP_state:
 		    Pn, ty, nr,
 		    tx ? UdpSt[nr + UdpStOff] : TcpSt[nr + TcpStOff],
 		    nm);
-	 	Exit(1);
+		Exit(1);
 	    }
 	    UdpSt[nr + UdpStOff] = cp;
 	} else {
@@ -1488,7 +1488,7 @@ safestrprt(sp, fs, flags)
 			    }
 			} else {
 			    for (lnt = 0; lnt < lnc; lnt++) {
-			        fputs(safepup((unsigned int)*(sp + lnt),
+				fputs(safepup((unsigned int)*(sp + lnt),
 					      (int *)NULL), fs);
 			    }
 			}

--- a/misc.c
+++ b/misc.c
@@ -109,7 +109,7 @@ build_Nl(d)
 	if (n < 1) {
 	    (void) fprintf(stderr,
 		"%s: can't calculate kernel name list length\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (!(Nl = (struct NLIST_TYPE *)calloc((n + 1),
 					       sizeof(struct NLIST_TYPE))))
@@ -117,7 +117,7 @@ build_Nl(d)
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes to kernel name list structure\n",
 		Pn, (int)((n + 1) * sizeof(struct NLIST_TYPE)));
-	    Exit(1);
+	    Error();
 	}
 	for (dp = d, i = 0; i < n; dp++, i++) {
 	    Nl[i].NL_NAME = dp->knm;
@@ -254,7 +254,7 @@ doinchild(fn, fp, rbuf, rbln)
 	    (void) fprintf(stderr,
 		"%s: doinchild error; response buffer too large: %d\n",
 		Pn, rbln);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Set up to handle an alarm signal; handle an alarm signal; build
@@ -281,7 +281,7 @@ doinchild(fn, fp, rbuf, rbln)
 		if (pipe(Pipes) < 0 || pipe(&Pipes[2]) < 0) {
 		    (void) fprintf(stderr, "%s: can't open pipes: %s\n",
 			Pn, strerror(errno));
-		    Exit(1);
+		    Error();
 		}
 	    /*
 	     * Fork a child to execute functions.
@@ -316,7 +316,7 @@ doinchild(fn, fp, rbuf, rbln)
 			(void) fprintf(stderr,
 			    "%s: can't dup Pipes[0] to fd 0: %s\n",
 			    Pn, strerror(errno));
-			Exit(1);
+			Error();
 		    }
 		    Pipes[0] = 0;
 		    rc = dup2(Pipes[3], 1);
@@ -324,7 +324,7 @@ doinchild(fn, fp, rbuf, rbln)
 			(void) fprintf(stderr,
 			    "%s: can't dup Pipes.[3] to fd 1: %s\n",
 			    Pn, strerror(errno));
-			Exit(1);
+			Error();
 		    }
 		    Pipes[3] = 1;
 		    (void) closefrom(2);
@@ -386,7 +386,7 @@ doinchild(fn, fp, rbuf, rbln)
 		if (Cpid < 0) {
 		    (void) fprintf(stderr, "%s: can't fork: %s\n",
 			Pn, strerror(errno));
-		    Exit(1);
+		    Error();
 		}
 		(void) close(Pipes[0]);
 		(void) close(Pipes[3]);
@@ -495,7 +495,7 @@ dropgid()
 	    if (setgid(Mygid) < 0) {
 		(void) fprintf(stderr, "%s: can't setgid(%d): %s\n",
 		    Pn, (int)Mygid, strerror(errno));
-		Exit(1);
+		Error();
 	    }
 	    Setgid = 0;
 	}
@@ -519,7 +519,7 @@ enter_dev_ch(m)
 	    (void) fprintf(stderr, "%s: no more dev_ch space at PID %d: \n",
 		Pn, Lp->pid);
 	    safestrprt(m, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	if (Lf->dev_ch)
 	   (void) free((FREE_P *)Lf->dev_ch);
@@ -551,7 +551,7 @@ enter_IPstate(ty, nm, nr)
 	if (!ty) {
 	    (void) fprintf(stderr,
 		"%s: no type specified to enter_IPstate()\n", Pn);
-	    Exit(1);
+	    Error();
 	}
 	if (!strcmp(ty, "TCP"))
 	    tx = 0;
@@ -560,7 +560,7 @@ enter_IPstate(ty, nm, nr)
 	else {
 	    (void) fprintf(stderr, "%s: unknown type for enter_IPstate: %s\n",
 		Pn, ty);
-	    Exit(1);
+	    Error();
 	}
 /*
  * If the name argument is NULL, reduce the allocated table to its minimum
@@ -579,7 +579,7 @@ enter_IPstate(ty, nm, nr)
 			{
 			    (void) fprintf(stderr,
 				"%s: can't reduce UdpSt[]\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    UdpStAlloc = UdpNstates;
@@ -596,7 +596,7 @@ enter_IPstate(ty, nm, nr)
 			{
 			    (void) fprintf(stderr,
 				"%s: can't reduce TcpSt[]\n", Pn);
-			    Exit(1);
+			    Error();
 			}
 		    }
 		    TcpStAlloc = TcpNstates;
@@ -610,7 +610,7 @@ enter_IPstate(ty, nm, nr)
 	if ((len = (size_t)strlen(nm)) < 1) {
 	    (void) fprintf(stderr,
 		"%s: bad %s name (\"%s\"), number=%d\n", Pn, ty, nm, nr);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Make a copy of the name.
@@ -619,7 +619,7 @@ enter_IPstate(ty, nm, nr)
 	    (void) fprintf(stderr,
 		"%s: enter_IPstate(): no %s space for %s\n",
 		Pn, ty, nm);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Set the necessary offset for using nr as an index.  If it is
@@ -696,7 +696,7 @@ enter_IPstate(ty, nm, nr)
 no_IP_space:
 
 		    (void) fprintf(stderr, "%s: no %s state space\n", Pn, ty);
-		    Exit(1);
+		    Error();
 		}
 		UdpNstates = nn;
 		UdpStAlloc = al;
@@ -736,7 +736,7 @@ dup_IP_state:
 		    Pn, ty, nr,
 		    tx ? UdpSt[nr + UdpStOff] : TcpSt[nr + TcpStOff],
 		    nm);
-		Exit(1);
+		Error();
 	    }
 	    UdpSt[nr + UdpStOff] = cp;
 	} else {
@@ -765,7 +765,7 @@ enter_nm(m)
 	    (void) fprintf(stderr, "%s: no more nm space at PID %d for: ",
 		Pn, Lp->pid);
 	    safestrprt(m, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	if (Lf->nm)
 	    (void) free((FREE_P *)Lf->nm);
@@ -790,6 +790,16 @@ Exit(xv)
 #endif	/* defined(HASDCACHE) */
 
 	exit(xv);
+}
+
+
+/*
+ * Error() - exit with an error status
+ */
+void
+Error(void)
+{
+	Exit (LSOF_ERROR);
 }
 
 
@@ -1201,7 +1211,7 @@ no_readlink_space:
 
 	    (void) fprintf(stderr, "%s: no Readlink string space for ", Pn);
 	    safestrprt(abuf, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	if (sx >= MAXSYMLINKS) {
 
@@ -1618,7 +1628,7 @@ stkdir(p)
 		(void) fprintf(stderr,
 		    "%s: no space for directory stack at: ", Pn);
 		safestrprt(p, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	}
 /*
@@ -1627,7 +1637,7 @@ stkdir(p)
 	if (!(Dstk[Dstkx] = mkstrcpy(p, (MALLOC_S *)NULL))) {
 	    (void) fprintf(stderr, "%s: no space for: ", Pn);
 	    safestrprt(p, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	Dstkx++;
 }

--- a/misc.c
+++ b/misc.c
@@ -779,7 +779,7 @@ enter_nm(m)
 
 void
 Exit(xv)
-	int xv;				/* exit() value */
+	enum ExitStatus xv;				/* exit() value */
 {
 	(void) childx();
 

--- a/print.c
+++ b/print.c
@@ -254,7 +254,7 @@ fill_portmap()
 		(void) fprintf(stderr,
 		    "%s: can't allocate space for portmap entry: ", Pn);
 		safestrprt(cp, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    if (!nl) {
 		(void) free((FREE_P *)nm);
@@ -268,7 +268,7 @@ fill_portmap()
 		(void) fprintf(stderr,
 		    "%s: can't allocate porttab entry for portmap: ", Pn);
 		safestrprt(nm, stderr, 1);
-		Exit(1);
+		Error();
 	    }
 	    pt->name = nm;
 	    pt->nl = nl;
@@ -332,7 +332,7 @@ fill_porttab()
 		(void) fprintf(stderr,
 		    "%s: can't allocate %d bytes for port %d name: %s\n",
 		    Pn, (int)(nl + 1), p, se->s_name);
-		Exit(1);
+		Error();
 	    }
 	    if (!nl) {
 		(void) free((FREE_P *)nm);
@@ -342,7 +342,7 @@ fill_porttab()
 		(void) fprintf(stderr,
 		    "%s: can't allocate porttab entry for port %d: %s\n",
 		    Pn, p, se->s_name);
-		Exit(1);
+		Error();
 	    }
 	    pt->name = nm;
 	    pt->nl = nl - 1;
@@ -434,7 +434,7 @@ gethostnm(ia, af)
 	if (!(np = mkstrcpy(hn, (MALLOC_S *)NULL))) {
 	    (void) fprintf(stderr, "%s: no space for host name: ", Pn);
 	    safestrprt(hn, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Add address/name entry to cache.  Allocate cache space in HCINC chunks.
@@ -448,7 +448,7 @@ gethostnm(ia, af)
 		hc = (struct hostcache *)realloc((MALLOC_P *)hc, len);
 	    if (!hc) {
 		(void) fprintf(stderr, "%s: no space for host cache\n", Pn);
-		Exit(1);
+		Error();
 	    }
 	}
 	hc[hcx].af = af;
@@ -498,7 +498,7 @@ lkup_port(p, pr, src)
 		      (int)(2 * (PORTHASHBUCKETS * sizeof(struct porttab *))),
 		      (h & 1) ? "UDP" : "TCP",
 		      (h > 1) ? "portmap" : "port");
-		    Exit(1);
+		    Error();
 		}
 	    }
 	}
@@ -564,7 +564,7 @@ lkup_port(p, pr, src)
 	if (!(pt = (struct porttab *)malloc(sizeof(struct porttab)))) {
 	    (void) fprintf(stderr,
 		"%s: can't allocate porttab entry for port %d\n", Pn, p);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Allocate space for the name; copy it to the porttab entry; and link the
@@ -576,7 +576,7 @@ lkup_port(p, pr, src)
 	    (void) fprintf(stderr,
 		"%s: can't allocate space for port name: ", Pn);
 	    safestrprt(pn, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 	pt->name = nm;
 	pt->nl = nl;
@@ -2349,7 +2349,7 @@ printuid(uid, ty)
 		if (stat("/etc/passwd", &sb) != 0) {
 		    (void) fprintf(stderr, "%s: can't stat(/etc/passwd): %s\n",
 			Pn, strerror(errno));
-		    Exit(1);
+		    Error();
 		}
 	    }
 	/*
@@ -2362,7 +2362,7 @@ printuid(uid, ty)
 		    (void) fprintf(stderr,
 			"%s: no space for %d byte UID cache hash buckets\n",
 			Pn, (int)(UIDCACHEL * (sizeof(struct uidcache *))));
-		    Exit(1);
+		    Error();
 		}
 		if (CkPasswd) {
 		    sbs = sb;
@@ -2420,7 +2420,7 @@ printuid(uid, ty)
 		    (void) fprintf(stderr,
 			"%s: no space for UID cache entry for: %lu, %s)\n",
 			Pn, (unsigned long)uid, pw->pw_name);
-		    Exit(1);
+		    Error();
 		}
 		(void) strncpy(upn->nm, pw->pw_name, LOGINML);
 		upn->nm[LOGINML] = '\0';
@@ -2835,7 +2835,7 @@ update_portmap(pt, pn)
 	    (void) fprintf(stderr,
 		"%s: can't allocate %d bytes for portmap name: %s[%s]\n",
 		Pn, (int)(nl + 1), pn, pt->name);
-	    Exit(1);
+	    Error();
 	}
 	(void) snpf(cp, nl + 1, "%s[%s]", pn, pt->name);
 	(void) free((FREE_P *)pt->name);

--- a/proc.c
+++ b/proc.c
@@ -71,7 +71,7 @@ add_nma(cp, len)
 	if (!Lf->nma) {
 	    (void) fprintf(stderr, "%s: no name addition space: PID %ld, FD %s",
 		Pn, (long)Lp->pid, Lf->fd);
-	    Exit(1);
+	    Error();
 	}
 	if (nl) {
 	    Lf->nma[nl] = ' ';
@@ -110,7 +110,7 @@ alloc_fflbuf(bp, al, lr)
 	if (!*bp) {
 	    (void) fprintf(stderr, "%s: no space (%d) for print flags\n",
 		Pn, sz);
-	    Exit(1);
+	    Error();
 	}
 	*al = sz;
 	return(*bp);
@@ -152,7 +152,7 @@ alloc_lfile(nm, num)
 	} else if (!(Lf = (struct lfile *)malloc(sizeof(struct lfile)))) {
 	    (void) fprintf(stderr, "%s: no local file space at PID %d\n",
 		Pn, Lp->pid);
-	    Exit(1);
+	    Error();
 	}
 /*
  * Initialize the structure.
@@ -295,7 +295,7 @@ alloc_lproc(pid, pgid, ppid, uid, cmd, pss, sf)
 		(void) fprintf(stderr,
 		    "%s: no malloc space for %d local proc structures\n",
 		    Pn, LPROCINCR);
-		Exit(1);
+		Error();
 	    }
 	    sz = LPROCINCR;
 	} else if ((Nlproc + 1) > sz) {
@@ -306,7 +306,7 @@ alloc_lproc(pid, pgid, ppid, uid, cmd, pss, sf)
 		(void) fprintf(stderr,
 		    "%s: no realloc space for %d local proc structures\n",
 		    Pn, sz);
-		Exit(1);
+		Error();
 	    }
 	}
 	Lp = &Lproc[Nlproc++];
@@ -334,7 +334,7 @@ alloc_lproc(pid, pgid, ppid, uid, cmd, pss, sf)
 	    (void) fprintf(stderr, "%s: PID %d, no space for command name: ",
 		Pn, pid);
 	    safestrprt(cmd, stderr, 1);
-	    Exit(1);
+	    Error();
 	}
 
 #if	defined(HASZONES)

--- a/proto.h
+++ b/proto.h
@@ -108,6 +108,7 @@ _PROTOTYPE(extern int enter_uid,(char *us));
 _PROTOTYPE(extern void ent_inaddr,(unsigned char *la, int lp, unsigned char *fa, int fp, int af));
 _PROTOTYPE(extern int examine_lproc,(void));
 _PROTOTYPE(extern void Exit,(int xv)) exiting;
+_PROTOTYPE(extern void Error,()) exiting;
 _PROTOTYPE(extern void find_ch_ino,(void));
 
 # if	defined(HASEPTOPTS)

--- a/proto.h
+++ b/proto.h
@@ -107,7 +107,7 @@ _PROTOTYPE(extern int enter_str_lst,(char *opt, char *s, struct str_lst **lp,
 _PROTOTYPE(extern int enter_uid,(char *us));
 _PROTOTYPE(extern void ent_inaddr,(unsigned char *la, int lp, unsigned char *fa, int fp, int af));
 _PROTOTYPE(extern int examine_lproc,(void));
-_PROTOTYPE(extern void Exit,(int xv)) exiting;
+_PROTOTYPE(extern void Exit,(enum ExitStatus xv)) exiting;
 _PROTOTYPE(extern void Error,()) exiting;
 _PROTOTYPE(extern void find_ch_ino,(void));
 

--- a/proto.h
+++ b/proto.h
@@ -202,7 +202,7 @@ _PROTOTYPE(extern void safestrprtn,(char *sp, int len, FILE *fs, int flags));
 _PROTOTYPE(extern void safestrprt,(char *sp, FILE *fs, int flags));
 _PROTOTYPE(extern int statsafely,(char *path, struct stat *buf));
 _PROTOTYPE(extern void stkdir,(char *p));
-_PROTOTYPE(extern void usage,(int xv, int fh, int version));
+_PROTOTYPE(extern void usage,(int err, int fh, int version));
 _PROTOTYPE(extern int util_strftime,(char *fmtr, int fmtl, char *fmt));
 _PROTOTYPE(extern int vfy_dev,(struct l_dev *dp));
 _PROTOTYPE(extern char *x2dev,(char *s, dev_t *d));

--- a/proto.h
+++ b/proto.h
@@ -73,7 +73,7 @@ _PROTOTYPE(extern void alloc_lproc,(int pid, int pgid, int ppid, UID_ARG uid, ch
 _PROTOTYPE(extern void build_IPstates,(void));
 _PROTOTYPE(extern void childx,(void));
 _PROTOTYPE(extern int ck_fd_status,(char *nm, int num));
-_PROTOTYPE(extern int ck_file_arg,(int i, int ac, char *av[], int fv, int rs, struct stat *sbp));
+_PROTOTYPE(extern int ck_file_arg,(int i, int ac, char *av[], int fv, int rs, struct stat *sbp, int accept_deleted_file));
 _PROTOTYPE(extern void ckkv,(char *d, char *er, char *ev, char *ea));
 _PROTOTYPE(extern void clr_devtab,(void));
 _PROTOTYPE(extern int compdev,(COMP_P *a1, COMP_P *a2));

--- a/store.c
+++ b/store.c
@@ -179,6 +179,7 @@ int FsvFlagX = 0;		/* hex format status for FSV_FG */
 int Ftask = 0;			/* -K option value */
 int NiColW;			/* NODE-ID column width */
 char *NiTtl = NITTL;		/* NODE-ID column title */
+int FsearchErr = 1;		/* -Q option status */
 int Ftcptpi = TCPTPI_STATE;	/* -T option status */
 int Fterse = 0;			/* -t option status */
 int Funix = 0;			/* -U option status */

--- a/tests/case-20-exit-status.bash
+++ b/tests/case-20-exit-status.bash
@@ -1,0 +1,56 @@
+name=$(basename $0 .bash)
+lsof=$1
+report=$2
+
+f=/tmp/lsof-${name}-$$
+
+{
+    $lsof $f > /dev/null
+    s=$?
+    case $s in
+	1)
+	    echo "ok: $lsof $f => 1"
+	    ;;
+	*)
+	    echo "unexpected exit status: $s"
+	    echo "	cmdline: $lsof $f"
+	    exit 1
+	    ;;
+    esac
+
+    touch $f
+    $lsof $f > /dev/null
+    s=$?
+    case $s in
+	1)
+	    echo "ok: touch $f; $lsof $f => 0"
+	    rm $f
+	    ;;
+	*)
+	    echo "unexpected exit status: $2"
+	    echo "	cmdline: $lsof $f"
+	    rm $f
+	    exit 1
+	    ;;
+    esac
+
+    g=/dev/null
+    cat < /dev/zero > $g &
+    pid=$!
+    $lsof $g > /dev/null
+    s=$?
+    case $s in
+	0)
+	    echo "ok: lsof $g => 0"
+	    kill $pid
+	    ;;
+	*)
+	    echo "unexpected exit status: $s"
+	    echo "	cmdline: $lsof $g"
+	    kill $pid
+	    exit 1
+	    ;;
+    esac
+} > $report 2>&1
+
+

--- a/tests/case-21-exit-Q-status.bash
+++ b/tests/case-21-exit-Q-status.bash
@@ -1,0 +1,107 @@
+# See https://github.com/lsof-org/lsof/issues/128
+name=$(basename $0 .bash)
+lsof0="$1"
+lsof=
+report=$2
+
+f=/tmp/lsof-${name}-$$
+r=0
+
+{
+    lsof="$lsof0"
+    $lsof $f > /dev/null
+    s=$?
+    case $s in
+	1)
+	    echo "ok: $lsof $f => 1"
+	    ;;
+	*)
+	    echo "unexpected exit status: $s"
+	    echo "	cmdline: $lsof $f"
+	    r=1
+	    ;;
+    esac
+
+    lsof="$lsof0 -Q"
+    $lsof $f > /dev/null
+    s=$?
+    case $s in
+	0)
+	    echo "ok: $lsof $f => 0"
+	    ;;
+	*)
+	    echo "unexpected exit status: $s"
+	    echo "	cmdline: $lsof $f"
+	    r=1
+	    ;;
+    esac
+
+    lsof="$lsof0"
+    touch $f
+    $lsof $f > /dev/null
+    s=$?
+    case $s in
+	1)
+	    echo "ok: touch $f; $lsof $f => 1"
+	    rm $f
+	    ;;
+	*)
+	    echo "unexpected exit status: $2"
+	    echo "	cmdline: $lsof $f"
+	    rm $f
+	    r=1
+	    ;;
+    esac
+
+    lsof="$lsof0 -Q"
+    touch $f
+    $lsof $f > /dev/null
+    s=$?
+    case $s in
+	0)
+	    echo "ok: touch $f; $lsof $f => 1"
+	    rm $f
+	    ;;
+	*)
+	    echo "unexpected exit status: $2"
+	    echo "	cmdline: $lsof $f"
+	    rm $f
+	    r=1
+	    ;;
+    esac
+
+    g=/dev/null
+    cat < /dev/zero > $g &
+    pid=$!
+
+    lsof="$lsof"
+    $lsof $g > /dev/null
+    s=$?
+    case $s in
+	0)
+	    echo "ok: lsof $g => 0"
+	    ;;
+	*)
+	    echo "unexpected exit status: $s"
+	    echo "	cmdline: $lsof $g"
+	    r=1
+	    ;;
+    esac
+
+    lsof="$lsof -Q"
+    $lsof $g > /dev/null
+    s=$?
+    case $s in
+	0)
+	    echo "ok: lsof $g => 0"
+	    ;;
+	*)
+	    echo "unexpected exit status: $s"
+	    echo "	cmdline: $lsof $g"
+	    r=1
+	    ;;
+    esac
+
+    kill $pid
+    exit $r
+} > $report 2>&1

--- a/usage.c
+++ b/usage.c
@@ -329,15 +329,15 @@ report_WARNDEVACCESS(pfx, verb, punct)
  */
 
 void
-usage(xv, fh, version)
-	int xv;				/* exit value */
+usage(err, fh, version)
+	int err;			/* it is called as part of error handlng? */
 	int fh;				/* ``-F ?'' status */
 	int version;			/* ``-v'' status */
 {
 	char buf[MAXPATHLEN+1], *cp, *cp1, *cp2;
 	int col, i;
 
-	if (Fhelp || xv) {
+	if (Fhelp || err) {
 	    (void) fprintf(stderr, "%s %s\n latest revision: %s\n",
 		Pn, LSOF_VERSION, LSOF_REPO_URL);
 	    (void) fprintf(stderr, " latest FAQ: %s\n", LSOF_FAQ_URL);
@@ -490,11 +490,11 @@ usage(xv, fh, version)
 
 	    (void) fprintf(stderr, " [--] [names]\n");
 	}
-	if (xv && !Fhelp) {
+	if (err && !Fhelp) {
 	    (void) fprintf(stderr,
 		"Use the ``-h'' option to get more help information.\n");
 	    if (!fh)
-		Exit(xv);
+		Exit(err? LSOF_ERROR: LSOF_SUCCESS);
 	}
 	if (Fhelp) {
 	    (void) fprintf(stderr,
@@ -972,5 +972,5 @@ usage(xv, fh, version)
 
 	    (void) report_HASDCACHE(1, "    ", "\t");
 	}
-	Exit(xv);
+	Exit(err? LSOF_ERROR: LSOF_SUCCESS);
 }

--- a/usage.c
+++ b/usage.c
@@ -494,7 +494,7 @@ usage(xv, fh, version)
 	    (void) fprintf(stderr,
 		"Use the ``-h'' option to get more help information.\n");
 	    if (!fh)
-    		Exit(xv);
+		Exit(xv);
 	}
 	if (Fhelp) {
 	    (void) fprintf(stderr,
@@ -749,13 +749,13 @@ usage(xv, fh, version)
 		"",
 #endif	/* defined(HASSOOPT) || defined(HASSOSTATE) || defined(HASTCPOPT)*/
 
-#if 	defined(HASTCPTPIQ)
+#if	defined(HASTCPTPIQ)
 		"q",
 #else	/* !defined(HASTCPTPIQ) */
 		" ",
 #endif	/* defined(HASTCPTPIQ) */
 
-#if 	defined(HASTCPTPIW)
+#if	defined(HASTCPTPIW)
 		"w",
 #else	/* !defined(HASTCPTPIW) */
 		"",
@@ -767,13 +767,13 @@ usage(xv, fh, version)
 		"",
 #endif	/* defined(HASSOOPT) || defined(HASSOSTATE) || defined(HASTCPOPT)*/
 
-#if 	defined(HASTCPTPIQ)
+#if	defined(HASTCPTPIQ)
 		"Q,",
 #else	/* !defined(HASTCPTPIQ) */
 		"",
 #endif	/* defined(HASTCPTPIQ) */
 
-#if 	defined(HASTCPTPIW)
+#if	defined(HASTCPTPIW)
 		",Win"
 #else	/* !defined(HASTCPTPIW) */
 		""

--- a/usage.c
+++ b/usage.c
@@ -559,6 +559,7 @@ usage(err, fh, version)
 	    col = print_in_col(col, "-o list file offset");
 	    col = print_in_col(col, "-O no overhead *RISKY*");
 	    col = print_in_col(col, "-P no port names");
+	    col = print_in_col(col, "-Q allow failed search");
 
 #if	defined(HASPPID)
 	     col = print_in_col(col, "-R list paRent PID");


### PR DESCRIPTION
Close #128.

~With the change, lsof exits with 0 for success, 1 for no-data,  and 2 for error.~
With the change, lsof `-Q` exits with 0 for success, 0 for no-data,  and 1 for error. This behavior is as suggested in #128.

Without the change, lsof exited with 0 for success, 1 for both no-data and error.

TODO:

- [x] adding test cases
- [x] updating 00DISTS and 00CREDITS
- [x] adding a section about the exit status in our man page
- [x] updating 00QUICKSTART (~and 00FAQ?~)