### PR TITLE
Drop LSOF_CCDATE in order to ensure reproducible builds

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5229,6 +5229,15 @@ July 14, 2018
 		Provided by @dilinger (Andres Salomon) in #149.
 		A commit in the pull request includes work of Nicholas Bamber.
 
+		Drop LSOF_CCDATE across all dialects to ensure reproducible builds
+		Simplify things for reproducible builds by just getting rid of
+		the embedded date/time string. With LSOF_CCDATE gone, keeping
+		SOURCE_DATE_EPOCH around doesn't make much sense, so drop that as
+		well. Folks doing reproducible builds should still override the
+		LSOF_HOST, LSOF_LOGNAME, LSOF_SYSINFO, and LSOF_USER variables (as
+		they were previously doing before SOURCE_DATE_EPOCH).
+		Provided by @dilinger (Andres Salomon) in #150.
+
 
 The lsof-org team at GitHub
 November 11, 2020

--- a/NEW/usage.c
+++ b/NEW/usage.c
@@ -710,8 +710,6 @@ usage(xv, fh, version)
 		(void) fprintf(stderr, "    configuration info: %s\n", cp);
 #endif	/* defined(LSOF_CINFO) */
 
-	    if ((cp = isnullstr(LSOF_CCDATE)))
-		(void) fprintf(stderr, "    constructed: %s\n", cp);
 	    cp = isnullstr(LSOF_HOST);
 	    if (!(cp1 = isnullstr(LSOF_LOGNAME)))
 		cp1 = isnullstr(LSOF_USER);

--- a/dialects/aix/Makefile
+++ b/dialects/aix/Makefile
@@ -84,7 +84,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/darwin/kmem/Makefile
+++ b/dialects/darwin/kmem/Makefile
@@ -88,7 +88,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define  LSOF_CINFO      "${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/darwin/libproc/Makefile
+++ b/dialects/darwin/libproc/Makefile
@@ -97,7 +97,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define  LSOF_CINFO      "${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/du/Makefile
+++ b/dialects/du/Makefile
@@ -76,7 +76,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \
 	  echo '#define	LSOF_HOST	"'`uname -n`'"' >> version.h; \

--- a/dialects/freebsd/Makefile
+++ b/dialects/freebsd/Makefile
@@ -76,7 +76,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \
 	  echo '#define	LSOF_HOST	"'`uname -n`'"' >> version.h; \

--- a/dialects/hpux/kmem/Makefile
+++ b/dialects/hpux/kmem/Makefile
@@ -78,7 +78,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/hpux/pstat/Makefile
+++ b/dialects/hpux/pstat/Makefile
@@ -75,7 +75,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/linux/Makefile
+++ b/dialects/linux/Makefile
@@ -40,17 +40,6 @@ SHELL=	/bin/sh
 
 SOURCE=	Makefile ${OTHER} ${MAN} ${HDR} ${SRC}
 
-ifneq ($(SOURCE_DATE_EPOCH),)
-	LSOF_HOST=   none
-	LSOF_LOGNAME=        none
-	LSOF_SYSINFO=        none
-	LSOF_USER=   none
-	BUILD_DATE=     $(shell date --utc --date=@$(SOURCE_DATE_EPOCH))
-	export LSOF_HOST LSOF_LOGNAME LSOF_SYSINFO LSOF_USER
-else
-	BUILD_DATE=     $(shell date)
-endif
-
 all: ${PROG}
 
 ${PROG}: ${P} ${LIB} ${OBJ}
@@ -97,7 +86,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"$(BUILD_DATE)"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/n+obsd/Makefile
+++ b/dialects/n+obsd/Makefile
@@ -81,7 +81,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \
 	  echo '#define	LSOF_HOST	"'`uname -n`'"' >> version.h; \

--- a/dialects/n+os/Makefile
+++ b/dialects/n+os/Makefile
@@ -87,7 +87,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_LDFLAGS	"${CFGL}"' >> version.h
 	@if [ "X${LSOF_LOGNAME}" = "X" ]; then \

--- a/dialects/osr/Makefile
+++ b/dialects/osr/Makefile
@@ -87,7 +87,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_LDFLAGS	"${CFGL}"' >> version.h
 	@if [ "X${LSOF_LOGNAME}" = "X" ]; then \

--- a/dialects/sun/Makefile
+++ b/dialects/sun/Makefile
@@ -75,7 +75,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/dialects/uw/Makefile
+++ b/dialects/uw/Makefile
@@ -74,7 +74,6 @@ version.h:	FRC
 	@echo '#define	LSOF_BLDCMT	"${LSOF_BLDCMT}"' > version.h;
 	@echo '#define	LSOF_CC		"${CC}"' >> version.h
 	@echo '#define	LSOF_CCV	"${CCV}"' >> version.h
-	@echo '#define	LSOF_CCDATE	"'`date`'"' >> version.h
 	@echo '#define	LSOF_CCFLAGS	"'`echo ${CFLAGS} | sed 's/\\\\(/\\(/g' | sed 's/\\\\)/\\)/g' | sed 's/"/\\\\"/g'`'"' >> version.h
 	@echo '#define	LSOF_CINFO	"${CINFO}"' >> version.h
 	@if [ "X${LSOF_HOST}" = "X" ]; then \

--- a/usage.c
+++ b/usage.c
@@ -929,8 +929,6 @@ usage(xv, fh, version)
 		(void) fprintf(stderr, "    configuration info: %s\n", cp);
 #endif	/* defined(LSOF_CINFO) */
 
-	    if ((cp = isnullstr(LSOF_CCDATE)))
-		(void) fprintf(stderr, "    constructed: %s\n", cp);
 	    cp = isnullstr(LSOF_HOST);
 	    if (!(cp1 = isnullstr(LSOF_LOGNAME)))
 		cp1 = isnullstr(LSOF_USER);


### PR DESCRIPTION
LSOF_CCDATE is used to embed the build time/date string into the lsof binary.
This string is displayed as part of 'lsof -v' output. However, having that
embedded string breaks reproducible builds - we want to ensure that subsequent
builds (using the same exact build environemnt) produce the same exact binary,
bit-for-bit.

Debian has a patch that allows overriding the variable, similar to what lsof allows
for LSOF_HOST (and others). Let me know if you'd prefer that patch. However,
I'm of the opinion that LSOF_CCDATE should just be dropped completely. We
can see the version to tell us what the corresponding source code is, and we have
file timestamps to tell us when a binary was installed. LSOF_CCDATE provides
no security, as an attacker could hardcode the older date/time string in their
malicious binary. So, this pull request just drops the variable completely.