### PR TITLE
FreeBSD isofs fixes and msdosfs support

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5246,5 +5246,8 @@ July 14, 2018
 		again. Fix the header inclusion order. Also add the new way of finding
 		dev_t on more recent FreeBSD versions.
 
+
+		[FreeBSD] add support for msdosfs on FreeBSD
+
 The lsof-org team at GitHub
 November 11, 2020

--- a/00DIST
+++ b/00DIST
@@ -5239,5 +5239,12 @@ July 14, 2018
 		Provided by @dilinger (Andres Salomon) in #150.
 
 
+		[FreeBSD] get the ISO9660 filesystem working again
+
+		The ISO9660 filesystem broke starting with FreeBSD 7 due to the header
+		location changing. Fix the header search path to get it to be detected
+		again. Fix the header inclusion order. Also add the new way of finding
+		dev_t on more recent FreeBSD versions.
+
 The lsof-org team at GitHub
 November 11, 2020

--- a/Configure
+++ b/Configure
@@ -2011,6 +2011,11 @@ FBSD_MINOR3
 	  then
 	    LSOF_CFGF="$LSOF_CFGF -DHASFUSEFS"
 	  fi	# }
+	# Do msdosfs test.
+	  if test -r ${FREEBSD_SYS}/fs/msdosfs/denode.h # {
+	  then
+	    LSOF_CFGF="$LSOF_CFGF -DHASMSDOSFS"
+	  fi    # }
 	# Do ZFS test.  Try for the newer OpenSolaris files first -- i.e.,
 	# the ones in ${FREEBSD_SYS}/cddl/contrib/opensolaris.  If that fails,
 	# try for the older ones in ${FREEBSD}/contrib/opensolaris.

--- a/Configure
+++ b/Configure
@@ -2303,15 +2303,24 @@ LOCKF_OWNER4
     fi	# }
     if test -r ${FREEBSD_SYS}/isofs/cd9660/cd9660_node.h	# {
     then
+      ISOFS_DIR="${FREEBSD_SYS}/isofs/cd9660"
+    else
+      if test -r ${FREEBSD_SYS}/fs/cd9660/cd9660_node.h		# {
+      then
+        ISOFS_DIR="${FREEBSD_SYS}/fs/cd9660"
+      fi	# }
+    fi	# }
+    if test "X$ISOFS_DIR" != "X"				# {
+    then
       rm -f cd9660_node.h
-      grep -q "^#ifdef [_]*KERNEL" ${FREEBSD_SYS}/isofs/cd9660/cd9660_node.h
+      grep -q "^#ifdef [_]*KERNEL" ${ISOFS_DIR}/cd9660_node.h
       if test $? -eq 0	# {
       then
-	ln -s ${FREEBSD_SYS}/isofs/cd9660/cd9660_node.h cd9660_node.h
+	ln -s ${ISOFS_DIR}/cd9660_node.h cd9660_node.h
       else
 	sed -e '/^ \* Prototypes for ISOFS vnode operations/,$c\
 	\ The ISOFS prototypes were removed by Configure. */' \
-	< ${FREEBSD_SYS}/isofs/cd9660/cd9660_node.h > cd9660_node.h
+	< ${ISOFS_DIR}/cd9660_node.h > cd9660_node.h
 	echo "" >> cd9660_node.h
       fi	# }
       LSOF_CFGF="$LSOF_CFGF -DHAS9660FS"

--- a/dialects/freebsd/dnode1.c
+++ b/dialects/freebsd/dnode1.c
@@ -176,3 +176,80 @@ read_fuse_node(v, d, dd, ino, nl, sz)
 	return(0);
 }
 #endif	/* defined(HASFUSEFS) */
+
+
+#if     defined(HASMSDOSFS)
+#include <fs/msdosfs/bpb.h>
+#include <fs/msdosfs/direntry.h>
+#include <fs/msdosfs/denode.h>
+#include <fs/msdosfs/fat.h>
+#define _KERNEL
+#include <fs/msdosfs/msdosfsmount.h>
+#undef _KERNEL
+/*
+ * read_msdosfs_node() -- read msdos file system denode
+ */
+
+int
+read_msdos_node(v, d, dd, ino, nl, sz)
+	struct vnode *v;		/* containing vnode */
+	dev_t *d;			/* returned device number */
+	int *dd;			/* returned device-defined flag */
+	INODETYPE *ino;			/* returned inode number */
+	long *nl;			/* returned number of links */
+	SZOFFTYPE *sz;			/* returned size */
+{
+	struct denode dep;		/* MSDOSFS node */
+	struct msdosfsmount pmp;
+	struct cdev udev;
+	typedef __uint64_t uoff_t;
+	uint64_t fileid;
+	u_long dirsperblk;
+
+	if (!v->v_data
+	||  kread((KA_T)v->v_data, (char *)&dep, sizeof(dep)))
+	    return(1);
+	if (!dep.de_pmp || kread((KA_T)dep.de_pmp, (char *)&pmp, sizeof(pmp)))
+	    return(1);
+
+#  if   defined(HAS_NO_SI_UDEV)
+#   if  defined(HAS_CONF_MINOR) || defined(HAS_CDEV2PRIV)
+	*d = Dev2Udev((KA_T)pmp.pm_dev);
+#   else	/* !defined(HAS_CONF_MINOR) && !defined(HAS_CDEV2PRIV) */
+	if (!pmp.pm_dev || kread((KA_T)pmp.pm_dev, (char *)&udev, sizeof(udev)))
+	    return(1);
+	*d = Dev2Udev(&udev);
+#   endif	/* defined(HAS_CONF_MINOR) || defined(HAS_CDEV2PRIV) */
+#   else	/* !defined(HAS_NO_SI_UDEV) */
+	if (!pmp.pm_dev || kread((KA_T)pmp.pm_dev, (char *)&udev, sizeof(udev)))
+	    return(1);
+	*d = udev.si_udev;
+#  endif	/* defined(HAS_NO_SI_UDEV) */
+
+
+	dirsperblk = pmp.pm_BytesPerSec / sizeof(struct direntry);
+	/*
+	 * The following computation of the fileid must be the same as that
+	 * used in msdosfs_readdir() to compute d_fileno. If not, pwd
+	 * doesn't work.
+	 */
+	if (dep.de_Attributes & ATTR_DIRECTORY) {
+		fileid = (uint64_t)cntobn(&pmp, dep.de_StartCluster) *
+		    dirsperblk;
+		if (dep.de_StartCluster == MSDOSFSROOT)
+			fileid = 1;
+	} else {
+		fileid = (uint64_t)cntobn(&pmp, dep.de_dirclust) *
+		    dirsperblk;
+		if (dep.de_dirclust == MSDOSFSROOT)
+			fileid = (uint64_t)roottobn(&pmp, 0) * dirsperblk;
+		fileid += (uoff_t)dep.de_diroffset / sizeof(struct direntry);
+	}
+
+	*dd = 1;
+	*ino = (INODETYPE)fileid;
+	*nl = 1;
+	*sz = dep.de_FileSize;
+	return(0);
+}
+#endif  /* defined(HASMSDOSFS) */

--- a/dialects/freebsd/dnode1.c
+++ b/dialects/freebsd/dnode1.c
@@ -54,13 +54,13 @@ static char copyright[] =
 #define	dev_t	void *
 #  endif	/* FREEBSDV>=4000 && defined(__alpha__) */
 
-#include "cd9660_node.h"
-
 # if	defined(HAS_NO_ISO_DEV)
 #define	_KERNEL
 #include <isofs/cd9660/iso.h>
 #undef	_KERNEL
 # endif	/* defined(HAS_NO_ISO_DEV) */
+
+#include "cd9660_node.h"
 
 #  if	FREEBSDV>=4000 && defined(__alpha__)
 #undef	dev_t
@@ -121,7 +121,11 @@ read_iso_node(v, d, dd, ino, nl, sz)
 	{
 
 # if	defined(HAS_NO_SI_UDEV)
+#   if	defined(HAS_CONF_MINOR) || defined(HAS_CDEV2PRIV)
+	    *d = Dev2Udev((KA_T)im.im_dev);
+#   else	/* !defined(HAS_CONF_MINOR) && !defined(HAS_CDEV2PRIV) */
 	    *d = Dev2Udev(&udev);
+#   endif	/* defined(HAS_CONF_MINOR) || defined(HAS_CDEV2PRIV) */
 # else	/* !defined(HAS_NO_SI_UDEV) */
 	    *d = udev.si_udev;
 # endif	/* defined(HAS_NO_SI_UDEV) */
@@ -144,6 +148,7 @@ read_iso_node(v, d, dd, ino, nl, sz)
 
 
 #if	defined(HASFUSEFS)
+#undef VTOI
 #include <fs/fuse/fuse_node.h>
 /*
  * read_fuse_node() -- read FUSE file system fuse_node

--- a/dialects/freebsd/dproto.h
+++ b/dialects/freebsd/dproto.h
@@ -72,3 +72,7 @@ _PROTOTYPE(extern int read_fuse_node,(struct vnode *v, dev_t *d, int *dd, INODET
 #if	defined(HAS9660FS)
 _PROTOTYPE(extern int read_iso_node,(struct vnode *v, dev_t *d, int *dd, INODETYPE *ino, long *nl, SZOFFTYPE *sz));
 #endif	/* defined(HAS9660FS) */
+
+#if	defined(HASMSDOSFS)
+_PROTOTYPE(extern int read_msdos_node,(struct vnode *v, dev_t *d, int *dd, INODETYPE *ino, long *nl, SZOFFTYPE *sz));
+#endif	/* defined(HASMSDOSFS) */


### PR DESCRIPTION
Fixes for the ISO9660 filesystem. Adds support for msdosfs.