### PR TITLE
Handle #145

### DIFF
--- a/Lsof.8
+++ b/Lsof.8
@@ -1,4 +1,3 @@
-.so ./version
 .TH LSOF 8 Revision-\*(VN
 \" Register )P is used neither by this file nor any groff macro.  However,
 \" some versions of nroff require it.


### PR DESCRIPTION
For handle `Compile and install the latest git master version of lsof on Ubuntu 20.04. #145`

While contrasting to other manpages, such as iptables.8.gz, arp.8.gz and so on, i figure out `.so ./version` is not necessary.
Therefore,  delete `.so ./version` in Lsof.8 may be the best way to solve this problem, which i have tested successful in ubuntu 20.04.