### PR TITLE
Improve readability of complex adverbial clause in the manpage

### DIFF
--- a/Lsof.8
+++ b/Lsof.8
@@ -125,7 +125,7 @@ won't be listed unless the
 .B \-U
 option is also specified.
 .PP
-Normally list options that are specifically stated are ORed \- i.e.,
+Normally, list options that are specifically stated are ORed \- i.e.,
 specifying the
 .B \-i
 option without an address and the \fB\-u\fPfoo option produces a


### PR DESCRIPTION
A small change, but this paragraph trips me up every time I hit the man pages for `lsof`. Figured it warranted a PR if I'd noticed it enough times to think about fixing it.

Adding a comma after the adverb "Normally" should improve the readability a fair bit for future decades of `lsof` man page referencers.