### PR TITLE
Fix FD field description

### DIFF
--- a/lsof_fields.h
+++ b/lsof_fields.h
@@ -79,7 +79,7 @@
 
 #define	LSOF_FID_FD		'f'
 #define	LSOF_FIX_FD		5
-#define	LSOF_FNM_FD		"file descriptor (always selected)"
+#define	LSOF_FNM_FD		"file descriptor"
 
 #define	LSOF_FID_FA		'F'
 #define	LSOF_FIX_FA		6


### PR DESCRIPTION
In https://github.com/lsof-org/lsof/commit/811dc78cc6404cb39d82bf01728cfdf38f097af1 the output format was changed to not select the `f` field by default, however the field description in `lsof_fields.h`, as seen in `-F?` output still included the `(always selected)` text.