### PR TITLE
Adjust alignment of buffer passed to stat()

### DIFF
--- a/00CREDITS
+++ b/00CREDITS
@@ -554,8 +554,9 @@ provided test systems where I was able to do development work.
 	@albert-github
 	Tobias Geerinckx-Rice
 	Andres Salomon
-	Nicholas Bamber and
-	Grisha Levit
+	Nicholas Bamber
+	Grisha Levit and
+	@10ne1 (github account)
 
 If I have omitted a contributor's name, the fault is wholly mine,
 and I apologize for the error.

--- a/00DIST
+++ b/00DIST
@@ -5246,5 +5246,12 @@ July 14, 2018
 		Provided by @algorythmic (Grisha Levit) in #158.
 
 
+		Adjust alignment of buffer passed to stat().
+		The original code passes char[] buffer to stat(). This can be cause
+		a SIGBUS. #160 reported an actual crash on armv7a + glibc-2.33 platform.
+		See also https://sourceware.org/bugzilla/show_bug.cgi?id=27993.
+		Reported by @10ne1 in #160.
+
+
 The lsof-org team at GitHub
 November 11, 2020

--- a/misc.c
+++ b/misc.c
@@ -293,7 +293,15 @@ doinchild(fn, fp, rbuf, rbln)
 		 */
 
 		    int r_al, r_rbln;
-		    char r_arg[MAXPATHLEN+1], r_rbuf[MAXPATHLEN+1];
+		    char r_arg[MAXPATHLEN+1];
+		    union {
+			    char r_rbuf[MAXPATHLEN+1];
+			    /*
+			     * This field is only for adjusting the alignment of r_rbuf that
+			     * can be used as an argument for stat().
+			     */
+			    struct stat _;
+		    } r;
 		    int (*r_fn)();
 		/*
 		 * Close sufficient open file descriptors except Pipes[0] and
@@ -358,16 +366,16 @@ doinchild(fn, fp, rbuf, rbln)
 			||  read(Pipes[0], r_arg, r_al) != r_al
 			||  read(Pipes[0], (char *)&r_rbln, sizeof(r_rbln))
 			    != (int)sizeof(r_rbln)
-			||  r_rbln < 1 || r_rbln > (int)sizeof(r_rbuf))
+			||  r_rbln < 1 || r_rbln > (int)sizeof(r.r_rbuf))
 			    break;
-			zeromem (r_rbuf, r_rbln);
-			rv = r_fn(r_arg, r_rbuf, r_rbln);
+			zeromem (r.r_rbuf, r_rbln);
+			rv = r_fn(r_arg, r.r_rbuf, r_rbln);
 			en = errno;
 			if (write(Pipes[3], (char *)&rv, sizeof(rv))
 			    != sizeof(rv)
 			||  write(Pipes[3], (char *)&en, sizeof(en))
 			    != sizeof(en)
-			||  write(Pipes[3], r_rbuf, r_rbln) != r_rbln)
+			||  write(Pipes[3], r.r_rbuf, r_rbln) != r_rbln)
 			    break;
 		    }
 		    (void) _exit(0);


### PR DESCRIPTION
Close #160.

The original code passes char[] buffer to stat().
This can be cause a SIGBUS.

#160 reported an actual crash on armv7a + glibc-2.33 platform.
See also https://sourceware.org/bugzilla/show_bug.cgi?id=27993.

The issue is reported by @10ne1.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>