### PR TITLE
cirrus-ci: update for FreeBSD 13.0 and 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,29 +1,13 @@
-# freebsd13_task:
-#   freebsd_instance:
-#     image: freebsd-13-0-current-amd64-v20200604
-#   timeout_in: 120m
-#   install_script: pkg install -y git bash
-#   script:
-#     - ./Configure -n freebsd
-#     - make
-#     - bash ./check.bash freebsd
-
-# freebsd12_task:
-#   freebsd_instance:
-#     image: freebsd-12-1-release-amd64
-#   timeout_in: 120m
-#   install_script: pkg install -y git bash
-#   script:
-#     - ./Configure -n freebsd
-#     - make
-#     - bash ./check.bash freebsd
-
-# freebsd11_task:
-#   freebsd_instance:
-#     image: freebsd-11-3-release-amd64
-#   timeout_in: 120m
-#   install_script: pkg install -y git bash
-#   script:
-#     - ./Configure -n freebsd
-#     - make
-#     - bash ./check.bash freebsd
+task:
+  freebsd_instance:
+    cpu: 1
+    matrix:
+      - image: freebsd-13-0-release-amd64
+      - image: freebsd-12-2-release-amd64
+      - image: freebsd-11-4-release-amd64
+  install_script: pkg install -y bash
+  build_script:
+    - ./Configure -n freebsd
+    - make
+  test_script:
+    - bash ./check.bash freebsd

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ part of them. The current status of maintenance is as follows:
 
 <dl>
 <dt>freebsd</dt>
-<dd>partially maintained, but testing on Cirrus CI is temporary disabled</dd>
+<dd>partially maintained and tested on Cirrus CI</dd>
 <dt>linux</dt>
 <dd>fully maintained, and tested on Travis CI</dd>
 <dt>darwin</dt>


### PR DESCRIPTION
Also:
- remove git from the list of packages to install (we do not need it,
  the clone is already done for us by Cirrus-CI)
- remove the timeout override as the build and test will complete within
  Cirrus-CI's default
- request only 1 CPU as we do not take advantage of parallelism so there
  is no reason to have a spare idle vCPU around
- rename the main script to "build" and split a test script out so that
  we can more easily differentiate build failures from test failures
- keep a FreeBSD 11 image for now (even though EOL) until tests pass
  consistently on supported releases

11.4:
```
STARTING TEST ( dialect neutral )
=============================================================================
case-00-hello ... ok
case-01-version ... ok
case-13-classic ... failed
case-14-classic-opt ... ok
case-20-fd-only-inclusion ... ok
case-20-handle-missing-files ... ok
case-20-offset-field ... ok
case-20-repeat-count ... ok
STARTING TEST ( freebsd specific )
=============================================================================
case-00-freebsd-hello ... ok
TEST SUMMARY
=============================================================================
successful: 8
skipped: 0
failed: 1
1 of 9 case is failed

/tmp/case-13-classic-13425.report
-----------------------------------------------------------------------------
"LTbasic ... OK" is not found in the output
"LTnlink ... OK" is not found in the output
"LTsock ... OK" is not found in the output
"LTszoff ... OK" is not found in the output
"LTunix ... OK" is not found in the output
output
.............................................................................
`cat config.cc`  -I. -I.. `cat config.cflags` -c LTlib.c  -o LTlib.o
`cat config.cc`  -I. -I.. `cat config.cflags` LTbasic.c  LTlib.o `cat config.xobj` -o LTbasic
`cat config.cc`  -I. -I.. `cat config.cflags` LTnlink.c  LTlib.o `cat config.xobj` -o LTnlink
`cat config.cc`  -I. -I.. `cat config.cflags` LTsock.c  LTlib.o `cat config.xobj` -o LTsock `cat config.ldflags`
`cat config.cc`  -I. -I.. `cat config.cflags` LTszoff.c  LTlib.o `cat config.xobj` -o LTszoff
`cat config.cc`  -I. -I.. `cat config.cflags` LTunix.c  LTlib.o `cat config.xobj` -o LTunix `cat config.ldflags`
Basic test:
LTbasic ... ERROR!!!  open lsof executable wasn't found.
            *** Error code 1
Stop.
```

12.2:
```
STARTING TEST ( dialect neutral )
=============================================================================
case-00-hello ... ok
case-01-version ... ok
case-13-classic ... failed
case-14-classic-opt ... ok
case-20-fd-only-inclusion ... ok
case-20-handle-missing-files ... ok
case-20-offset-field ... ok
case-20-repeat-count ... ok
STARTING TEST ( freebsd specific )
=============================================================================
case-00-freebsd-hello ... ok
TEST SUMMARY
=============================================================================
successful: 8
skipped: 0
failed: 1
1 of 9 case is failed
/tmp/case-13-classic-16886.report
-----------------------------------------------------------------------------
"LTbasic ... OK" is not found in the output
"LTnlink ... OK" is not found in the output
"LTsock ... OK" is not found in the output
"LTszoff ... OK" is not found in the output
"LTunix ... OK" is not found in the output
output
.............................................................................
`cat config.cc`  -I. -I.. `cat config.cflags` -c LTlib.c  -o LTlib.o
`cat config.cc`  -I. -I.. `cat config.cflags` LTbasic.c  LTlib.o `cat config.xobj` -o LTbasic
`cat config.cc`  -I. -I.. `cat config.cflags` LTnlink.c  LTlib.o `cat config.xobj` -o LTnlink
`cat config.cc`  -I. -I.. `cat config.cflags` LTsock.c  LTlib.o `cat config.xobj` -o LTsock `cat config.ldflags`
`cat config.cc`  -I. -I.. `cat config.cflags` LTszoff.c  LTlib.o `cat config.xobj` -o LTszoff
`cat config.cc`  -I. -I.. `cat config.cflags` LTunix.c  LTlib.o `cat config.xobj` -o LTunix `cat config.ldflags`
Basic test:
LTbasic ... ERROR!!!  open lsof executable wasn't found.
            *** Error code 1
Stop.
```

13.0:
```
STARTING TEST ( dialect neutral )
=============================================================================
case-00-hello ... ok
case-01-version ... ok
case-13-classic ... failed
case-14-classic-opt ... failed
case-20-fd-only-inclusion ... ok
case-20-handle-missing-files ... ok
case-20-offset-field ... ok
case-20-repeat-count ... ok
STARTING TEST ( freebsd specific )
=============================================================================
case-00-freebsd-hello ... ok
TEST SUMMARY
=============================================================================
successful: 7
skipped: 0
failed: 2
2 of 9 cases are failed
/tmp/case-13-classic-12791.report
-----------------------------------------------------------------------------
"LTbasic ... OK" is not found in the output
"LTnlink ... OK" is not found in the output
"LTsock ... OK" is not found in the output
"LTszoff ... OK" is not found in the output
"LTunix ... OK" is not found in the output
output
.............................................................................
`cat config.cc`  -I. -I.. `cat config.cflags` -c LTlib.c  -o LTlib.o
`cat config.cc`  -I. -I.. `cat config.cflags` LTbasic.c  LTlib.o `cat config.xobj` -o LTbasic
`cat config.cc`  -I. -I.. `cat config.cflags` LTnlink.c  LTlib.o `cat config.xobj` -o LTnlink
`cat config.cc`  -I. -I.. `cat config.cflags` LTsock.c  LTlib.o `cat config.xobj` -o LTsock `cat config.ldflags`
`cat config.cc`  -I. -I.. `cat config.cflags` LTszoff.c  LTlib.o `cat config.xobj` -o LTszoff
`cat config.cc`  -I. -I.. `cat config.cflags` LTunix.c  LTlib.o `cat config.xobj` -o LTunix `cat config.ldflags`
Basic test:
LTbasic ... ERROR!!!  open lsof executable wasn't found.
            ERROR!!!  lsof process wasn't found.
            *** Error code 1
Stop.
make: stopped in /tmp/cirrus-ci-build/tests
/tmp/case-14-classic-opt-12791.report
-----------------------------------------------------------------------------
"LTdnlc ... .*/tests found: 100.00%" is not found in the output
"LTlock ... OK" is not found in the output
output
.............................................................................
`cat config.cc`  -I. -I.. `cat config.cflags` LTbigf.c  LTlib.o `cat config.xobj` -o LTbigf
`cat config.cc`  -I. -I.. `cat config.cflags` LTdnlc.c  LTlib.o `cat config.xobj` -o LTdnlc
`cat config.cc`  -I. -I.. `cat config.cflags` LTlock.c  LTlib.o `cat config.xobj` -o LTlock
`cat config.cc`  -I. -I.. `cat config.cflags` LTnfs.c  LTlib.o `cat config.xobj` -o LTnfs
Optional tests:
LTbigf ... OK
LTdnlc ... /tmp/cirrus-ci-build/tests found: 0.00%
           ERROR!!!  the find rate was too low.
           Hint: since the find rate is zero, it may be that this file
           system does not fully participate in kernel DNLC processing
           -- e.g., NFS file systems often do not, /tmp file systems
           sometimes do not, Solaris loopback file systems do not.
           As a work-around rebuild and test lsof on a file system that
           fully participates in kernel DNLC processing.
           See 00FAQ and 00TEST for more information.
*** Error code 1
Stop.
make: stopped in /tmp/cirrus-ci-build/tests
```