### PR TITLE
[linux] use close_range instead of calling close repeatedly 

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5296,5 +5296,13 @@ July 14, 2018
 		submitted by @emaste
 
 
+		[linux] use close_range instead of calling close repeatedly
+		At the starting up, lsof closes its file descriptors greater
+		than 2 by calling close(2) repeatedly. As reported in #186,
+		it can take long time. Linux 5.9 introduced close_range(2).
+		The new system call can close multiple file descriptors faster.
+		@qianzhangyl reported the original issue (#186).
+
+
 The lsof-org team at GitHub
 November 25, 2020

--- a/00DIST
+++ b/00DIST
@@ -5232,6 +5232,7 @@ July 14, 2018
 		Provided by @dilinger (Andres Salomon) in #149.
 		A commit in the pull request includes work of Nicholas Bamber.
 
+
 		Drop LSOF_CCDATE across all dialects to ensure reproducible builds
 		Simplify things for reproducible builds by just getting rid of
 		the embedded date/time string. With LSOF_CCDATE gone, keeping
@@ -5274,17 +5275,21 @@ July 14, 2018
 		- fix spelling
 		Provided by @a1346054 in #163.
 
+
 		man page: fix hyphen issues
 		Properly use '-' and '\-' in the man page, ensuring that users
 		can cut & paste commandline options without issue. Original
 		patch from Raoul Gunnar Borenius <borenius@dfn.de>, and
 		submitted/expanded by @dilinger (Andres Salomon) in #168.
 
+
 		[FreeBSD] update for FreeBSD 13 & 14, and various internal changes
 		submitted by @DmitryAndric & @emaste.
 
+
 		[FreeBSD] remove various old FreeBSD versions from support
 		submitted by @emaste
+
 
 		[FreeBSD] configure: suggest variable to set if FreeBSD sys not
 		found

--- a/dialects/linux/dlsof.h
+++ b/dialects/linux/dlsof.h
@@ -71,6 +71,7 @@
 #include <linux/if_ether.h>
 #include <linux/netlink.h>
 
+#include <sys/syscall.h>
 
 /*
  * This definition is needed for the common function prototype definitions

--- a/main.c
+++ b/main.c
@@ -127,8 +127,15 @@ main(argc, argv)
 #if	defined(HAS_CLOSEFROM)
 	(void) closefrom(3);
 #else	/* !defined(HAS_CLOSEFROM) */
+#if	defined(SYS_close_range)
+	if (MaxFd > 3 && syscall(SYS_close_range, 3, MaxFd - 1, 0) == 0)
+	    goto closed;
+#endif
 	for (i = 3; i < MaxFd; i++)
 	    (void) close(i);
+#if	defined(SYS_close_range)
+  closed:
+#endif
 #endif	/* !defined(HAS_CLOSEFROM) */
 
 	while (((i = open("/dev/null", O_RDWR, 0)) >= 0) && (i < 2))


### PR DESCRIPTION
At the starting up, lsof closes its file descriptors greater
than 2 by calling close(2) repeatedly. As reported in https://github.com/lsof-org/lsof/issues/186,
it can take long time. Linux 5.9 introduced close_range(2).
The new system call can close multiple file descriptors
faster.

Close https://github.com/lsof-org/lsof/issues/186 for Linux. @qianzhangyl reported the issue.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>