### PR TITLE
lib/Makefile.skel: fix AR and RANLIB when cross-compiling

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5293,6 +5293,9 @@ July 14, 2018
                Fix broken LSOF_CFLAGS_OVERRIDE.
                Provided by Fabrice Fontaine in #172.
 
+               Fix broken AR and RANLIB when cross-compiling.
+               Provided by Fabrice Fontaine in #194.
+
 
 The lsof-org team at GitHub
 November 25, 2020

--- a/lib/Makefile.skel
+++ b/lib/Makefile.skel
@@ -21,8 +21,8 @@ OBJ=	ckkv.o cvfs.o dvch.o fino.o isfn.o lkud.o pdvn.o prfp.o \
 all:	${LIB}
 
 ${LIB}:	${OBJ}
-	${AR}
-	${RANLIB}
+	${AR} cr ${LIB} ${OBJ}
+	${RANLIB} ${LIB}
 
 clean:	FRC
 	rm -f ${LIB} ${OBJ} errs Makefile.bak a.out core


### PR DESCRIPTION
This patch has been added in the context of buildroot sixteen years ago, here is an extract of
https://git.buildroot.net/buildroot/commit/package/lsof?id=aca398bb7fa956dc44e1442969c4a2a425780997:

> compile against the cross toolchain, not the host

[Retrieved from: https://git.buildroot.net/buildroot/tree/package/lsof/0001-makefile.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>