### PR TITLE
dialects/linux/machine: remove sysvlegacy function

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5296,6 +5296,9 @@ July 14, 2018
 		Fix broken AR and RANLIB when cross-compiling.
 		Provided by Fabrice Fontaine in #194.
 
+		[linux] Remove sysvlegacy function.
+		Provided by Fabrice Fontaine in #195.
+
 
 The lsof-org team at GitHub
 November 25, 2020

--- a/00DIST
+++ b/00DIST
@@ -5290,11 +5290,11 @@ July 14, 2018
 		found
 		submitted by @emaste
 
-               Fix broken LSOF_CFLAGS_OVERRIDE.
-               Provided by Fabrice Fontaine in #172.
+		Fix broken LSOF_CFLAGS_OVERRIDE.
+		Provided by Fabrice Fontaine in #172.
 
-               Fix broken AR and RANLIB when cross-compiling.
-               Provided by Fabrice Fontaine in #194.
+		Fix broken AR and RANLIB when cross-compiling.
+		Provided by Fabrice Fontaine in #194.
 
 
 The lsof-org team at GitHub

--- a/dialects/linux/machine.h
+++ b/dialects/linux/machine.h
@@ -646,6 +646,6 @@
  * zeromem is a macro that uses bzero or memset.
  */
 
-#define	zeromem(a, l)	bzero(a, l)
+#define	zeromem(a, l)	memset(a, 0, l)
 
 #endif	/* !defined(LSOF_MACHINE_H) */


### PR DESCRIPTION
This patch has been added in the context of buildroot fifteen years ago: https://git.buildroot.net/buildroot/commit/package/lsof?id=c1efa9b291f0aa1453ea6359cc6638c0e75b2ca7

[Retrieved from: https://git.buildroot.net/buildroot/tree/package/lsof/0002-remove-susvlegacy-funcs.patch]

While at it also fix indentation in 00DIST

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>