### PR TITLE
Revert "lib/Makefile.skel: fix AR and RANLIB when cross-compiling"

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5298,8 +5298,6 @@ July 14, 2018
 		Fix broken LSOF_CFLAGS_OVERRIDE.
 		Provided by Fabrice Fontaine in #172.
 
-		Fix broken AR and RANLIB when cross-compiling.
-		Provided by Fabrice Fontaine in #194.
 
 		[linux] Remove sysvlegacy function.
 		Provided by Fabrice Fontaine in #195.

--- a/lib/Makefile.skel
+++ b/lib/Makefile.skel
@@ -21,8 +21,8 @@ OBJ=	ckkv.o cvfs.o dvch.o fino.o isfn.o lkud.o pdvn.o prfp.o \
 all:	${LIB}
 
 ${LIB}:	${OBJ}
-	${AR} cr ${LIB} ${OBJ}
-	${RANLIB} ${LIB}
+	${AR}
+	${RANLIB}
 
 clean:	FRC
 	rm -f ${LIB} ${OBJ} errs Makefile.bak a.out core


### PR DESCRIPTION
This reverts commit e3e81bbe865d61b738cbd6fd4b973d33508db5a9. (#194)

Grisha Levit (@schrodinger) reported the build error with introducing
the commit.

Close #197.

Signed-off-by: Masatake YAMATO <yamato@redhat.com>