### PR TITLE
[linux] Changing the number of ipcbuckets to 4096

### DIFF
--- a/00CREDITS
+++ b/00CREDITS
@@ -564,6 +564,7 @@ provided test systems where I was able to do development work.
 	Fabrice Fontaine
 	Danny Fowler and
 	Benny "BenBE" Baumann
+	Robert Geislinger (Alienmaster)
 
 If I have omitted a contributor's name, the fault is wholly mine,
 and I apologize for the error.

--- a/00DIST
+++ b/00DIST
@@ -5343,6 +5343,9 @@ July 14, 2018
 
 
 		[linux] Avoid some easy collissions for udp/udp6 sockets when hashing
+		
+		
+		[linux] Changing the number of ipcbuckets to 4096
 
 
 The lsof-org team at GitHub

--- a/dialects/linux/dsock.c
+++ b/dialects/linux/dsock.c
@@ -62,11 +62,11 @@
 #define TCPUDPHASH(ino)	((int)((ino * 31415) >> 3) & (TcpUdp_bucks - 1))
 #define TCPUDP6HASH(ino) ((int)((ino * 31415) >> 3) & (TcpUdp6_bucks - 1))
 
-#define IPCBUCKS 128			/* IPC hash bucket count -- must be
+#define IPCBUCKS 4096			/* IPC hash bucket count -- must be
 					 * a power of two */
 
 /* If a socket is used for IPC, we store both end points for the socket
- * to the same hash backet. This makes seaching the counter part of
+ * to the same hash bucket. This makes seaching the counter part of
  * an end point easier. See get_netpeeri(). */
 #define TCPUDP_IPC_HASH(tp) ((int)(((((tp)->faddr * 0x109		\
 				      + (tp)->laddr * 0x109		\


### PR DESCRIPTION
I suggest to increase the number of ipcbckets. On an fresh installed Ubuntu VM there are over 200 sockets used.
BenBE mentioned this problem here: https://github.com/lsof-org/lsof/pull/212#issuecomment-1113964661 .

I also fixed a small typo.