### PR TITLE
darwin: fix build with -fno-common (Cfp redefinition)

### DIFF
--- a/dialects/darwin/kmem/dlsof.h
+++ b/dialects/darwin/kmem/dlsof.h
@@ -246,7 +246,7 @@ typedef	u_long		KA_T;
  * Global storage definitions (including their structure definitions)
  */
 
-struct file * Cfp;
+extern struct file * Cfp;
 
 extern int Kd;				/* KMEM descriptor */
 extern KA_T Kpa;


### PR DESCRIPTION
gcc-10 and llvm-11 changed the default from -fcommon to -fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    duplicate symbol '_Cfp' in: ddev.o dfile.o

`Cfp` is already explicitly defined in `dstore.c`. The change turns
header definitino into declaration.