### PR TITLE
darwin: fix global variable definition in dlsof.h

### DIFF
--- a/dialects/darwin/libproc/dlsof.h
+++ b/dialects/darwin/libproc/dlsof.h
@@ -94,7 +94,7 @@ typedef	uintptr_t	KA_T;
  * Global storage definitions (including their structure definitions)
  */
 
-struct file *Cfp;
+extern struct file *Cfp;
 
 struct mounts {
         char *dir;              	/* directory (mounted on) */


### PR DESCRIPTION
Defining global variables in headers is error prone and can break
builds with -fno-common flag enabled:

    duplicate symbol '_Cfp' in:
    ddev.o
    dfile.o

The issue is fixed in libproc backend in the same way as pr #221.