### PR TITLE
[darwin] fix: remove /usr/include prefix from include

### DIFF
--- a/00DIST
+++ b/00DIST
@@ -5367,6 +5367,11 @@ July 14, 2018
 		it is set.
 		Provided by Danilo Spinella in #217
 
+		[darwin] remove /usr/include prefix from include for Darwin 19+
+		The /usr/include path is missing since macOS Catalina.
+		Fixes issue #234.
+		Provided by Jiajie Chen in #235
+
 
 The lsof-org team at GitHub
 April 28, 2022

--- a/Configure
+++ b/Configure
@@ -892,13 +892,31 @@ case $LSOF_TGT in	# {
       12.*)			# Mac OS X 10.8 (Mountain Lion)
  	LSOF_VERS=1200
  	;;
-      13.*)			# Next Mac OS X
+      13.*)			# Mac OS X 10.9 (Mavericks)
 	LSOF_VERS=1300
+	;;
+      14.*)			# Mac OS X 10.10 (Yosemite)
+	LSOF_VERS=1400
+	;;
+      15.*)			# Mac OS X 10.11 (El Capitan)
+	LSOF_VERS=1500
+	;;
+      16.*)			# macOS 10.12 (Sierra)
+	LSOF_VERS=1600
+	;;
+      17.*)			# macOS 10.13 (High Sierra)
+	LSOF_VERS=1700
+	;;
+      18.*)			# macOS 10.14 (Mojave)
+	LSOF_VERS=1800
+	;;
+      19.*)			# macOS 10.15 (Catalina)
+	LSOF_VERS=1900
 	;;
       *)
 	echo Unknown Darwin release: `uname -r`
-	echo Assuming Darwin 12.0
-	LSOF_VERS=1200
+	echo Assuming Darwin 19.0
+	LSOF_VERS=1900
 	;;
       esac	# }
     fi	# }
@@ -937,9 +955,11 @@ case $LSOF_TGT in	# {
 	LSOF_CFGF="$LSOF_CFGF -DNEEDS_MACH_PORT_T"
       fi	# }
       ;;
-    1300)
+    1300|1400|1500|1600|1700|1800|1900)
       LSOF_CFGF="$LSOF_CFGF -DHASIPv6"
       LSOF_TMP1=""
+      LSOF_UNSUP=""
+      LSOF_TSTBIGF=" "			# enable LTbigf test
       ;;
     *)
       echo "Unsupported Darwin version: $LSOF_VERS"

--- a/dialects/darwin/kmem/dlsof.h
+++ b/dialects/darwin/kmem/dlsof.h
@@ -165,11 +165,12 @@ struct nameidata { int dummy; };	/* to satisfy function  prototypes */
 #undef	TRUE
 #undef	FALSE
 
-# if	DARWINV<800
+# if	DARWINV<800 || DARWINV>=1900
+// macOS Catalina and later removed /usr/include
 #include <sys/sysctl.h>
-# else	/* DARWINV>=800 */
+# else	/* DARWINV>=800 && DARWINV<1900 */
 #include "/usr/include/sys/sysctl.h"
-# endif	/* DARWINV<800 */
+# endif	/* DARWINV<800 || DARWINV<1900 */
 
 # if	DARWINV<800
 #define	KERNEL

--- a/dialects/darwin/kmem/machine.h
+++ b/dialects/darwin/kmem/machine.h
@@ -42,7 +42,10 @@
 #include <sys/types.h>
 #include <sys/param.h>
 
-# if	DARWINV>=800
+# if	DARWINV>=1900
+// macOS Catalina and later removed /usr/include
+#include "string.h"
+# elif	DARWINV>=800
 #include "/usr/include/string.h"
 # endif	/* DARWINV>=800 */
 

--- a/dialects/darwin/libproc/machine.h
+++ b/dialects/darwin/libproc/machine.h
@@ -50,7 +50,12 @@
 # include <device/device_types.h>
 # endif	/* NEED_MACH_PORT_T */
 
+# if DARWINV>=1900
+// macOS Catalina and later removed /usr/include
+#include "string.h"
+# else
 #include "/usr/include/string.h"
+# endif /* DARWINV>=1900 */
 
 
 /*


### PR DESCRIPTION
The /usr/include path is missing on modern Darwin systems. The intention
of hardcoding the path is unknown. Fixes issue #234.