### PR TITLE
[darwin] circleci: add ci config for macOS catalina target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,24 @@ jobs:
           name: Test
           command: |
             bash ./check.bash linux
+  catalina:
+    macos:
+      xcode: 12.4.0
+    steps:
+      - checkout
+      - run:
+          name: Configure
+          command: |
+            LSOF_INCLUDE=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include ./Configure -n darwin
+      - run:
+          name: Build
+          command: |
+            make -j 2
+      - run:
+          name: Test
+          command: |
+            # TODO: blocked by issue #236
+            # bash ./check.bash darwin
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows
@@ -62,3 +80,4 @@ workflows:
     jobs:
       - fedora36
       - stream8
+      - catalina


### PR DESCRIPTION
Set LSOF_INCLUDE to search libproc.h in macOS sdk

Disable unit tests until issue #236 is fixed