### PR TITLE
[linux] obtain correct information of memory-mapped file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run:
           name: Install build tools
           command: |
-            dnf -y install git gcc make sudo nmap-ncat iproute libtirpc-devel lcov gem
+            dnf -y install git gcc make sudo nmap-ncat iproute libtirpc-devel lcov gem procps
             gem install lcoveralls
       - checkout
       - run:
@@ -40,7 +40,7 @@ jobs:
       - run:
           name: Install build tools
           command: |
-            dnf -y install git gcc make sudo nmap-ncat iproute libtirpc-devel
+            dnf -y install git gcc make sudo nmap-ncat iproute libtirpc-devel procps
       - checkout
       - run:
           name: Configure

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ dialects/linux/tests/pidfd
 dialects/linux/tests/pipe
 dialects/linux/tests/pty
 dialects/linux/tests/ux
+dialects/linux/tests/mmap

--- a/00DIST
+++ b/00DIST
@@ -5372,6 +5372,8 @@ July 14, 2018
 		Fixes issue #234.
 		Provided by Jiajie Chen in #235
 
+		[linux] obtain correct information of memory-mapped file.
+		Provided by Teng Hu in #239
 
 The lsof-org team at GitHub
 April 28, 2022

--- a/dialects/linux/tests/Makefile
+++ b/dialects/linux/tests/Makefile
@@ -7,6 +7,7 @@ HELPERS = \
 	pipe \
 	pty \
 	ux \
+	mmap \
 	\
 	open_with_flags \
 	\

--- a/dialects/linux/tests/case-20-mmap.bash
+++ b/dialects/linux/tests/case-20-mmap.bash
@@ -1,0 +1,61 @@
+#!/bin/sh
+
+lsof=$1
+report=$2
+tdir=$3
+
+cleanup()
+{
+    if [ -n "$(mount | grep "tmp\/ext4.img" | grep -v grep)" ]
+    then
+        umount /tmp/ext4.img
+    fi
+    
+    if [ -f /tmp/ext4.img ]
+    then
+        rm -f /tmp/ext4.img
+    fi
+    
+    if [ -d /tmp/TEST ]
+    then
+        rm -rf /tmp/TEST
+    fi
+    
+    pidlist=`ps aux | grep "TEST\/MMAP" | grep -v grep | awk '{print $2}'`
+    for pid in $pidlist
+    do
+        kill -9 $pid
+    done
+}
+
+# cleanup the environment
+cleanup
+
+# create a new namespace and mmap
+unshare --mount --propagation private $3/mount-and-mmap.bash $@ >> $report 2>&1
+if grep -q 'unshare failed: Operation not permitted' $report; then
+    echo "unshare is not supported on this platform" >> $report
+    exit 2
+fi
+
+# get pid of the mmap process
+pid=`ps aux | grep "TEST\/MMAP" | grep -v grep | awk '{print $2}'`
+if [ -z "$pid" ]
+then
+    echo "mmap process does not exist" >> $report
+    cleanup
+    exit 1
+fi
+
+# lsof -p pid and obtain the output
+output=`$lsof -p $pid | grep "TEST\/MMAP" | grep "stat: No such file or directory"`
+
+if [ -z "$output" ]
+then
+    cleanup
+    exit 0
+else
+    echo "unexpected output: $output" >> $report
+    cleanup
+    exit 1
+fi

--- a/dialects/linux/tests/mmap.c
+++ b/dialects/linux/tests/mmap.c
@@ -1,0 +1,33 @@
+#include <sys/stat.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define handle_error(msg) \
+	do { perror(msg); exit(EXIT_FAILURE); } while (0)
+
+int main(int argc, char *argv[])
+{
+	char *addr;
+	int fd;
+	struct stat sb;
+
+	if (argc != 2)
+		exit(EXIT_FAILURE);
+
+	fd = open(argv[1], O_RDONLY);
+	if (fd == -1)
+		handle_error("open");
+
+	if (fstat(fd, &sb) == -1)
+		handle_error("fstat");
+
+	addr = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
+	if (addr == MAP_FAILED)
+		handle_error("mmap");
+
+	pause();
+	return 0;
+}

--- a/dialects/linux/tests/mount-and-mmap.bash
+++ b/dialects/linux/tests/mount-and-mmap.bash
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+lsof=$1
+report=$2
+tdir=$3
+
+TARGET=$tdir/mmap
+if ! [ -x $TARGET ]; then
+    echo "target executable ( $TARGET ) is not found" >> $report
+    exit 1
+fi
+
+mkdir /tmp/TEST
+dd if=/dev/zero of=/tmp/ext4.img bs=40MB count=1
+mkfs.ext4 /tmp/ext4.img
+mount --make-private /tmp/ext4.img /tmp/TEST
+
+dd if=/dev/zero of=/tmp/TEST/MMAP bs=2MB count=1
+$TARGET /tmp/TEST/MMAP &


### PR DESCRIPTION
In circumstances the target process in different mount namespace
from lsof itself, applying stat(2) directly gets failed,
with error message 'stat: No such file or directory'.

Thus, fork a child process and move it into the mount namespace
of the target process before applying stat(2). In this way, correct
information can be obtained.

Signed-off-by: huteng.ht <huteng.ht@bytedance.com>
#238 