### PR TITLE
freebsd: net/raw_cb.h no longer exists

### DIFF
--- a/dialects/freebsd/dlsof.h
+++ b/dialects/freebsd/dlsof.h
@@ -183,7 +183,6 @@ int     getmntinfo(struct statfs **, int);
 #undef	_KVM_VNODE
 # endif	/* defined(HAS_KVM_VNODE) */
 
-#include <net/raw_cb.h>
 #include <sys/domain.h>
 #define	pmap	RPC_pmap
 #include <rpc/rpc.h>


### PR DESCRIPTION
As of f63cb32c1988561136fabdcc54d16cd200b666d9 (in FreeBSD/src) the net/raw_cb.h
header no longer exists. It was removed as part of the retirement of
4.4BSD raw sockets.

Happily this header is not actually required for lsof, so we can just
not include it to fix the ports build.

See also: https://reviews.freebsd.org/D36240
Sponsored by:   Rubicon Communications, LLC ("Netgate")