### PR TITLE
Test on all AIX versions to solve issue #187

### DIFF
--- a/dialects/aix/dproc.c
+++ b/dialects/aix/dproc.c
@@ -313,6 +313,9 @@ ckkv(d, er, ev, ea)
 	char buf[64];
 	struct utsname u;
 
+	if (Fwarn)
+	    return;
+	
 	(void) memset((void *)&u, 0, sizeof(u));
 	(void) uname(&u);
 	(void) snpf(buf, sizeof(buf) - 1, "%s.%s.0.0", u.version, u.release);


### PR DESCRIPTION
IBM lsof was compiled on AIX 6.1, and targets are AIX 6.1, 7.1 and 7.2.
On AIX 7.1, we have "lsof: WARNING: compiled for AIX version 6.1.0.0; this is 7.1.0.0.", even if all is ok.

This test, for old AIX versions under 5.0 on lines 245 and 246,  need to be done everywhere.

I don't have compilers and so on to test that new code, but could be ok if your compiler accept it.
