### PR TITLE
cirrus-ci: update FreeBSD versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,9 +2,8 @@ task:
   freebsd_instance:
     cpu: 1
     matrix:
-      - image: freebsd-13-0-release-amd64
+      - image: freebsd-13-1-release-amd64
       - image: freebsd-12-2-release-amd64
-      - image: freebsd-11-4-release-amd64
   install_script: pkg install -y bash
   build_script:
     - ./Configure -n freebsd


### PR DESCRIPTION
- 13.1 is released, 13.0 is EOL
- 11.4 is EOL