### PR TITLE
[FreeBSD] Work around conflicts with sys/systm.h

### DIFF
--- a/dialects/freebsd/dlsof.h
+++ b/dialects/freebsd/dlsof.h
@@ -315,7 +315,11 @@ int     open(const char *, int, ...);
 #define	vasprintf vasprintf_kernel_lsof
 #define	uintfptr_t	int
 #define	_SYS_LIBKERN_H_
+#define	tick_sbt 1
+#define	pause kernel_pause
 #include <sys/file.h>
+#undef	pause
+#undef	tick_sbt
 
 /*
  * Attempt to remove the circumventions.


### PR DESCRIPTION
sys/file.h includes sys/systm.h with _KERNEL defined.  Cope with the difference in lsof's environment and the normal kernel environment in two ways.  define time_sbt to be 1 so the multiplication in systm.h's pause function works.  define pause kernel_pause before we include sys/file.h so there's not a conflict with the pause in unistd.h. Undefine both of these after the include since they are unneeded later. While technically only needed for FreeBSD >= 1400067 or so, it's harmless on older verrsions and would need to be added if the change to FreeBSD's systm.h were ever merged to stable/13, so omit the versrion test.