### PR TITLE
Describe fd number truncation in output

### DIFF
--- a/Lsof.8
+++ b/Lsof.8
@@ -2584,7 +2584,9 @@ See the
 section for more information on the lock information character.
 .IP
 The FD column contents constitutes a single field for parsing in
-post\-processing scripts.
+post\-processing scripts. FD numbers larger than 9999 are abbreviated
+to a '*' followed by the last three digits. E.g., 10001 appears as
+'*001'
 .TP
 TYPE
 is the type of the node associated with the file \- e.g., GDIR, GREG,


### PR DESCRIPTION
I had to go read the source code to figure out what the FD's listed with leading * represented...