### PR TITLE
Import NetBSD patches from pkgsrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ tests/config.*
 version.h
 autotools.h
 lockf_owner.h
+lockf.h
 lsof.man
 /site
 

--- a/Configure
+++ b/Configure
@@ -3574,6 +3574,67 @@ return(0); }
        LSOF_CFGF="$LSOF_CFGF -I`pwd`/dialects/n+obsd/include"
       fi       # }
     fi # }
+
+    # Generate lockf.h from kern/vfs_lockf.c
+    rm -f ./lockf.h
+    if test -r ${NETBSD_SYS}/kern/vfs_lockf.c	# {
+    then
+      # Find the line number of TAILQ_HEAD
+      LSOF_TMP1=`grep -n "^TAILQ_HEAD" ${NETBSD_SYS}/kern/vfs_lockf.c | sed 's/\([0-9]*\):.*$/\1/'`
+      if test "X$LSOF_TMP1" != "X"	# {
+      then
+        LSOF_TMP2=0
+        # Find the end of struct lockf
+        for i in `grep -n "};" ${NETBSD_SYS}/kern/vfs_lockf.c | sed 's/\([0-9]*\):.*/\1/'` # {
+        do
+          if test $LSOF_TMP2 -eq 0 -a $i -gt $LSOF_TMP1	# {
+          then
+            LSOF_TMP2=$i
+          fi	# }
+        done	# }
+        if test $LSOF_TMP2 -eq 0	# {
+        then
+          LSOF_TMP1=""
+        else
+          cat > ./lockf.h << LOCKF1
+/*
+* lockf_owner.h -- created by lsof configure script on
+LOCKF1
+          printf " * " >> ./lockf.h
+          date >> ./lockf.h
+          cat >> ./lockf.h << LOCKF2
+*/
+
+#if	!defined(LOCKF_H)
+#define	LOCKF_H
+
+LOCKF2
+          ed -s ${NETBSD_SYS}/kern/vfs_lockf.c >> ./lockf.h << LOCKF3
+${LSOF_TMP1},${LSOF_TMP2}p
+LOCKF3
+          if test $? -ne 0	# {
+          then
+	    LSOF_TMP1=""
+          else
+	    cat >> ./lockf.h << LOCKF4
+
+#endif	/* defined(LOCKF_H) */
+LOCKF4
+	  fi	# }
+        fi	# }
+      fi	# }
+    else
+      echo "FATAL ERROR: can't read ${NETBSD_SYS}/kern/vfs_lockf.c"
+    fi	# }
+
+    if test "X$LSOF_TMP1" != "X" -a "X$LSOF_TMP2" != "X0" # {
+    then
+      echo "lockf.h creation succeeded."
+      LSOF_CFGF="$LSOF_CFGF -DHAS_LOCKF_H"
+    else
+      echo "lockf.h creation failed (see 00FAQ)"
+    fi	# }
+
     LSOF_CFGL="$LSOF_CFGL -lkvm"
     LSOF_DIALECT_DIR=n+obsd
     ;;

--- a/Configure
+++ b/Configure
@@ -2767,6 +2767,12 @@ return(0); }
     fi	# }
 
     LSOF_CFGF="$LSOF_CFGF -DNETBSDV=$LSOF_VERS"
+
+    # For paddr_t
+    LSOF_CFGF="$LSOF_CFGF -D_KMEMUSER"
+    # For struct namecache
+    LSOF_CFGF="$LSOF_CFGF -D__NAMECACHE_PRIVATE"
+
     LSOF_TMP1="-DN_UNIXV=/netbsd"
     if test -r /dev/ksyms              # {
     then

--- a/Configure
+++ b/Configure
@@ -2628,7 +2628,7 @@ return(0); }
 	LSOF_TSTBIGF=" "
 	LSOF_VERS="1006000"
 	;;
-      1*)
+      1.*)
 	LSOF_VERS="1006000"
 	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
 	echo "!!!WARNING!!!  Configuring for NetBSD 1.6"
@@ -2649,7 +2649,7 @@ return(0); }
 	LSOF_TSTBIGF=" "
 	LSOF_VERS="2099010"
 	;;
-      2*)
+      2.*)
 	LSOF_VERS="2000000"
 	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
 	echo "!!!WARNING!!!  Configuring for NetBSD 2.0"
@@ -2662,37 +2662,116 @@ return(0); }
 	LSOF_TSTBIGF=" "
 	LSOF_VERS="3099000"
 	;;
-      3*)
+      3.*)
 	LSOF_VERS="3000000"
 	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
 	echo "!!!WARNING!!!  Configuring for NetBSD 3.0"
 	;;
+      4.0*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="4000000"
+	;;
+      4.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="4099000"
+	;;
+      4.*)
+	LSOF_VERS="4000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 4.0"
+	;;
+      5.[012]*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="5000000"
+	;;
+      5.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="5099000"
+	;;
+      5.*)
+	LSOF_VERS="5000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 5.0"
+	;;
+      6.[01]*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="6000000"
+	;;
+      6.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="6099000"
+	;;
+      6.*)
+	LSOF_VERS="6000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 6.0"
+	;;
+      7.[01]*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="7000000"
+	;;
+      7.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="7099000"
+	;;
+      7.*)
+	LSOF_VERS="7000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 7.0"
+	;;
+      8.[0123]*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="8000000"
+	;;
+      8.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="8099000"
+	;;
+      8.*)
+	LSOF_VERS="8000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 8.0"
+	;;
+      9.[0123]*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="9000000"
+	;;
+      9.99.10[45678])
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="9099104"
+	;;
+      9.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="9099000"
+	;;
+      9.*)
+	LSOF_VERS="9000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 9.0"
+	;;
+      10.99.*)
+	LSOF_TSTBIGF=" "
+	LSOF_VERS="10099000"
+	;;
+      10.*)
+	LSOF_VERS="10000000"
+	echo "!!!WARNING!!!  Unsupported NetBSD version: $LSOF_VSTR"
+	echo "!!!WARNING!!!  Configuring for NetBSD 10.0"
+	;;
       *)
 	echo "Unknown NetBSD release: $LSOF_VSTR"
-	echo Assuming NetBSD 1.6
-	LSOF_VERS="1006000"
+	echo Assuming NetBSD 10.0
+	LSOF_VERS="10000000"
 	;;
       esac	# }
     fi	# }
 
-    # Test for legal NetBSD version.
-
-    case $LSOF_VERS in	# {
-    1002000|1003000|1004000|1005000|1006000)
-      ;;
-    2000000|2099009|2099010)
-      ;;
-    3000000|3099000)
-      ;;
-    *)
-      echo "Unknown NetBSD version: $LSOF_VERS"
-      rm -f $LSOF_HLP
-      exit 1
-      ;;
-    esac	# }
     LSOF_CFGF="$LSOF_CFGF -DNETBSDV=$LSOF_VERS"
     LSOF_TMP1="-DN_UNIXV=/netbsd"
-    if test -r ${LSOF_INCLUDE}/util.h	# {
+    if test -r /dev/ksyms              # {
+    then
+      LSOF_TMP1="-DN_UNIXV=/dev/ksyms"
+    elif test -r ${LSOF_INCLUDE}/util.h        # {
     then
       grep -q getbootfile ${LSOF_INCLUDE}/util.h
       if test $? -eq 0	# {
@@ -3091,6 +3170,7 @@ return(0); }
     fi	# }
     LSOF_TMP2="sys/vnode.h"
     LSOF_NBSD_PTYFS=0
+    LSOF_NBSD_TMPFS=0
     if test -r ${LSOF_INCLUDE}/$LSOF_TMP2	# {
     then
       LSOF_TMP3="${LSOF_INCLUDE}/$LSOF_TMP2"
@@ -3168,16 +3248,29 @@ return(0); }
 	  fi	# }
 	fi	# }
       fi	# }
+      grep -q VT_TMPFS $LSOF_TMP3
+      if test $? -eq 0   # {
+      then
+       LSOF_TMP2="fs/tmpfs/tmpfs.h"
+       if test -r ${LSOF_INCLUDE}/$LSOF_TMP2   # {
+       then
+         LSOF_CFGF="$LSOF_CFGF -DHASTMPFS"
+       else
+         if test -r ${NETBSD_SYS}/$LSOF_TMP2   # {
+         then
+           if test $NETBSD_SYS != $LSOF_INCLUDE        # {
+           then
+             LSOF_CFGF="$LSOF_CFGF -DHASTMPFS"
+             LSOF_NBSD_TMPFS=1
+           fi  # }
+         fi    # }
+       fi      # }
+      fi       # }
       if test "X$NETBSD_UVM" = "X"	# {
       then
-	grep -q UVM $LSOF_TMP3
-	if test $? -ne 0	# {
+	if test -r ${LSOF_INCLUDE}/uvm	# {
 	then
-	  egrep -q "v_uvm;|v_uobj;" $LSOF_TMP3
-	  if test $? -eq 0	# {
-	  then
-	    NETBSD_UVM="Y"
-	  fi	# }
+	  NETBSD_UVM="Y"
 	fi	# }
       fi	# }
     fi	# }
@@ -3453,6 +3546,28 @@ return(0); }
 	LSOF_CFGF="$LSOF_CFGF -I`pwd`/dialects/n+obsd/include"
       fi	# }
     fi	# }
+    if test $LSOF_NBSD_TMPFS -eq 1     # {
+    then
+
+    # Make a local copy of $NETBSD_SYS/sys/fs/tmpfs/tmpfs.h.
+
+      if test ! -d dialects/n+obsd/include     # {
+      then
+       mkdir dialects/n+obsd/include
+      fi       # }
+      if test ! -d dialects/n+obsd/include/fs  # {
+      then
+       mkdir dialects/n+obsd/include/fs
+      fi       # }
+      rm -rf dialects/n+obsd/include/fs/tmpfs
+      mkdir dialects/n+obsd/include/fs/tmpfs
+      cp $NETBSD_SYS/fs/tmpfs/tmpfs.h dialects/n+obsd/include/fs/tmpfs
+      echo $LSOF_CFGF | grep /dialects/n+obsd/include > /dev/null 2>&1
+      if test $? -ne 0 # {
+      then
+       LSOF_CFGF="$LSOF_CFGF -I`pwd`/dialects/n+obsd/include"
+      fi       # }
+    fi # }
     LSOF_CFGL="$LSOF_CFGL -lkvm"
     LSOF_DIALECT_DIR=n+obsd
     ;;
@@ -5125,7 +5240,7 @@ fi	# }
 echo "" >> $LSOF_MKFC
 if test "X$LSOF_DEBUG" = "X"	# {
 then
-  LSOF_DEBUG="-O"
+  LSOF_DEBUG=""
 else
   if test "X$LSOF_DEBUG" = "XNo-O"	# {
   then

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ EXTRA_DIST += tests/00README tests/TestDB tests/CkTestDB tests/Makefile tests/Ls
 
 # Dialect neutral sources
 lsof_SOURCES = arg.c main.c misc.c node.c print.c proc.c store.c usage.c util.c \
-	lib/ckkv.c lib/dvch.c lib/fino.c lib/isfn.c lib/lkud.c lib/pdvn.c lib/prfp.c lib/ptti.c lib/rdev.c lib/rmnt.c lib/rnam.c lib/rnch.c lib/rnmh.c
+	lib/ckkv.c lib/dvch.c lib/fino.c lib/isfn.c lib/lkud.c lib/pdvn.c lib/prfp.c lib/ptti.c lib/rdev.c lib/rnmt.c lib/rmnt.c lib/rnam.c lib/rnch.c lib/rnmh.c
 lsof_SOURCES += lsof.h lsof_fields.h proto.h hash.h
 DIALECT_ROOT = $(top_srcdir)/dialects
 DIALECT_PATH = $(DIALECT_ROOT)/$(LSOF_DIALECT_DIR)

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ EXTRA_DIST += tests/00README tests/TestDB tests/CkTestDB tests/Makefile tests/Ls
 
 # Dialect neutral sources
 lsof_SOURCES = arg.c main.c misc.c node.c print.c proc.c store.c usage.c util.c \
-	lib/ptti.c lib/isfn.c lib/pdvn.c lib/lkud.c lib/rdev.c lib/dvch.c lib/ckkv.c lib/fino.c
+	lib/ckkv.c lib/dvch.c lib/fino.c lib/isfn.c lib/lkud.c lib/pdvn.c lib/prfp.c lib/ptti.c lib/rdev.c lib/rmnt.c lib/rnam.c lib/rnch.c lib/rnmh.c
 lsof_SOURCES += lsof.h lsof_fields.h proto.h hash.h
 DIALECT_ROOT = $(top_srcdir)/dialects
 DIALECT_PATH = $(DIALECT_ROOT)/$(LSOF_DIALECT_DIR)
@@ -46,6 +46,17 @@ lsof_SOURCES += dialects/freebsd/dmnt.c \
 		dialects/freebsd/dlsof.h \
 		dialects/freebsd/dproto.h \
 		dialects/freebsd/machine.h
+endif
+
+if N_OBSD
+lsof_SOURCES += dialects/n+obsd/dmnt.c \
+		dialects/n+obsd/dnode.c \
+		dialects/n+obsd/dproc.c \
+		dialects/n+obsd/dsock.c \
+		dialects/n+obsd/dstore.c \
+		dialects/n+obsd/dlsof.h \
+		dialects/n+obsd/dproto.h \
+		dialects/n+obsd/machine.h
 endif
 
 lsof_CPPFLAGS = -I$(DIALECT_PATH) -Iautotools

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ EXTRA_DIST += Lsof.8
 clean-local:
 	rm -rf lsof.man
 distclean-local:
-	rm -rf lockf_owner.h
+	rm -rf lockf_owner.h lockf.h
 
 # Testing scripts
 AM_TESTS_ENVIRONMENT = export LSOF_DIALECT_DIR=$(LSOF_DIALECT_DIR); export LSOF_DIALECT=$(LSOF_DIALECT);

--- a/autotools/autotools.h.in
+++ b/autotools/autotools.h.in
@@ -118,12 +118,17 @@
 #define HAS_V_LOCKF
 #endif
 
-// Check fdescfs v1 if needed later
+// Check fdescfs v1 on FreeBSD if needed later
 #if HAVE_FS_FDESCFS_FDESC_H
 #define HASFDESCFS 2
 #endif
 
-#if HAVE_FS_NULLFS_NULL_H
+// Check fdescfs v2 on NetBSD if needed later
+#if HAVE_MISCFS_FDESC_FDESC_H
+#define HASFDESCFS 1
+#endif
+
+#if HAVE_FS_NULLFS_NULL_H || HAVE_MISCFS_NULLFS_NULL_H
 #define HASNULLFS
 #endif
 
@@ -178,6 +183,10 @@
 
 #if HAVE_SYS_PIPE_H
 #define HAS_SYS_PIPEH
+#endif
+
+#if HAVE_STRUCT_FDESCNODE_FD_LINK
+#define HASFDLINK
 #endif
 
 #endif

--- a/autotools/autotools.h.in
+++ b/autotools/autotools.h.in
@@ -135,4 +135,29 @@
 #define HAS_KF_SOCK_SENDQ
 #endif
 
+#if HAVE_NFS_NFSPROTO_H
+#define HASNFSPROTO
+#endif
+
+#if HAVE_UVM_UVM_H
+#define UVM
+#define HAS_UVM_INCL
+#endif
+
+#if HAVE_STRUCT_STATVFS
+#define HASSTATVFS
+#endif
+
+#if HAVE_STRUCT_INODE_I_FFS1_SIZE
+#define HASI_FFS1
+#endif
+
+#if HAVE_DECL_GETBOOTFILE
+#define HASGETBOOTFILE
+#endif
+
+#if HAVE_DECL_KVM_GETPROC2
+#define HASKVMGETPROC2
+#endif
+
 #endif

--- a/autotools/autotools.h.in
+++ b/autotools/autotools.h.in
@@ -176,4 +176,8 @@
 #define HASTMPFS
 #endif
 
+#if HAVE_SYS_PIPE_H
+#define HAS_SYS_PIPEH
+#endif
+
 #endif

--- a/autotools/autotools.h.in
+++ b/autotools/autotools.h.in
@@ -160,4 +160,20 @@
 #define HASKVMGETPROC2
 #endif
 
+#if HAVE_FS_PTYFS_PTYFS_H
+#define HASPTYFS
+#endif
+
+#if HAVE_MISCFS_PROCFS_PROCFS_H
+#define HASPROCFS
+#endif
+
+#if HAVE_DECL_PFSROOT
+#define HASPROCFS_PFSROOT
+#endif
+
+#if HAVE_FS_TMPFS_TMPFS_H
+#define HASTMPFS
+#endif
+
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,47 @@ AS_CASE([${host_os}],
 
 	# Enable LTbigf test
 	LSOF_TEST_CFLAGS="$LSOF_TEST_CFLAGS -DLT_BIGF"
+], [netbsd*],  [
+	LSOF_DIALECT=netbsd
+	LSOF_DIALECT_DIR=n+obsd
+	LSOF_TGT=netbsd
+
+	case $LSOF_VSTR in
+		8.[[0123]]*)
+			LSOF_VERS="8000000"
+			;;
+		8.99.*)
+			LSOF_VERS="8099000"
+			;;
+		9.[[0123]]*)
+			LSOF_VERS="9000000"
+			;;
+		9.99.10[[45678]])
+			LSOF_VERS="9099104"
+			;;
+		9.99.*)
+			LSOF_VERS="9099000"
+			;;
+		10.99.*)
+			LSOF_VERS="10099000"
+			;;
+		10.*.*)
+			LSOF_VERS="10000000"
+			;;
+		*)
+			AC_MSG_ERROR([Unknown NetBSD release: $(uname -r)])
+			;;
+	esac
+
+	# Add NETBSDV to cflags
+	CFLAGS="$CFLAGS -DNETBSDV=$LSOF_VERS"
+
+	# Define _KMEMUSER for paddr_t and __NAMECACHE_PRIVATE for struct namecache
+	CFLAGS="$CFLAGS -D_KMEMUSER -D__NAMECACHE_PRIVATE"
+
+	# Define HASNFSVATTRP because the relevant change in kernel src is in 1997
+	# We can safely assume that n_vattr is a pointer
+	CFLAGS="$CFLAGS -DHASNFSVATTRP"
 ], [
 	AC_MSG_ERROR(["Host $host_os not supported"])
 ])
@@ -105,6 +146,7 @@ AS_CASE([${host_os}],
 AM_CONDITIONAL([LINUX], [test x$LSOF_DIALECT_DIR = xlinux])
 AM_CONDITIONAL([DARWIN_LIBPROC], [test x$LSOF_DIALECT_DIR = xdarwin/libproc])
 AM_CONDITIONAL([FREEBSD], [test x$LSOF_DIALECT_DIR = xfreebsd])
+AM_CONDITIONAL([N_OBSD], [test x$LSOF_DIALECT_DIR = xn+obsd])
 
 # Pass LSOF_DIALECT/LSOF_DIALECT_DIR to Makefile.am
 AC_SUBST([LSOF_DIALECT])
@@ -276,6 +318,26 @@ AC_CHECK_MEMBERS([struct xtcpcb.t_maxseg], [], [], [#include <sys/types.h>
 # Detect struct kinfo_file.kf_un.kf_sock.kf_sock_sendq for HAS_KF_SOCK_SENDQ
 AC_CHECK_MEMBERS([struct kinfo_file.kf_un.kf_sock.kf_sock_sendq], [], [], [#include <sys/types.h>
 	#include <sys/user.h>])
+
+# Detect nfs/nfsproto.h for HASNFSPROTO
+AC_CHECK_HEADERS([nfs/nfsproto.h])
+
+# Detect uvm/uvm.h for HAS_UVM_INCL
+AC_CHECK_HEADERS([uvm/uvm.h])
+
+# Detect struct statvfs for HASSTATVFS
+AC_CHECK_TYPES([struct statvfs], [], [], [#include <sys/statvfs.h>])
+
+# Detect struct inode.i_ffs1_size for HASI_FFS1
+AC_CHECK_MEMBERS([struct inode.i_ffs1_size], [], [], [#include <ufs/ufs/inode.h>])
+
+# Detect getbootfile function for HASGETBOOTFILE
+AC_CHECK_DECLS([getbootfile()], [
+		LDFLAGS="$LDFLAGS -lutil"
+], [], [#include <util.h>])
+
+# Detect kvm_getproc2 function for HASKVMGETPROC2
+AC_CHECK_DECLS([kvm_getproc2], [], [], [#include <kvm.h>])
 
 # Detect sizeof(dev_t) for LT_DEV64
 AC_CHECK_SIZEOF([dev_t])

--- a/configure.ac
+++ b/configure.ac
@@ -109,6 +109,11 @@ AS_CASE([${host_os}],
 		8.99.*)
 			LSOF_VERS="8099000"
 			;;
+		8.*)
+			LSOF_VERS="8000000"
+			AC_MSG_WARN([Unsupported NetBSD release: $(uname -r)])
+			AC_MSG_WARN([Configuring for NetBSD 8.0])
+			;;
 		9.[[0123]]*)
 			LSOF_VERS="9000000"
 			;;
@@ -118,11 +123,18 @@ AS_CASE([${host_os}],
 		9.99.*)
 			LSOF_VERS="9099000"
 			;;
+		9.*)
+			LSOF_VERS="9000000"
+			AC_MSG_WARN([Unsupported NetBSD release: $(uname -r)])
+			AC_MSG_WARN([Configuring for NetBSD 9.0])
+			;;
 		10.99.*)
 			LSOF_VERS="10099000"
 			;;
-		10.*.*)
+		10.*)
 			LSOF_VERS="10000000"
+			AC_MSG_WARN([Unsupported NetBSD release: $(uname -r)])
+			AC_MSG_WARN([Configuring for NetBSD 10.0])
 			;;
 		*)
 			AC_MSG_ERROR([Unknown NetBSD release: $(uname -r)])

--- a/configure.ac
+++ b/configure.ac
@@ -151,14 +151,16 @@ AS_CASE([${host_os}],
 	# We can safely assume that n_vattr is a pointer
 	CFLAGS="$CFLAGS -DHASNFSVATTRP"
 
+	# Check /dev/kmem
+	LSOF_TEST_CFLAGS="$LSOF_TEST_CFLAGS -DLT_KMEM"
+
 	# Detect NetBSD source code
-	if test -d /usr/src/sys	# {
-	then
+	AS_IF([test -d /usr/src/sys], [
 		NETBSD_SYS=/usr/src/sys
 		CFLAGS="$CFLAGS -I$NETBSD_SYS"
-	else
+	], [
 		AC_MSG_WARN([No kernel sources in /usr/src/sys])
-	fi	# }
+	])
 ], [
 	AC_MSG_ERROR(["Host $host_os not supported"])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -150,6 +150,15 @@ AS_CASE([${host_os}],
 	# Define HASNFSVATTRP because the relevant change in kernel src is in 1997
 	# We can safely assume that n_vattr is a pointer
 	CFLAGS="$CFLAGS -DHASNFSVATTRP"
+
+	# Detect NetBSD source code
+	if test -d /usr/src/sys	# {
+	then
+		NETBSD_SYS=/usr/src/sys
+		CFLAGS="$CFLAGS -I$NETBSD_SYS"
+	else
+		AC_MSG_WARN([No kernel sources in /usr/src/sys])
+	fi	# }
 ], [
 	AC_MSG_ERROR(["Host $host_os not supported"])
 ])
@@ -345,11 +354,25 @@ AC_CHECK_MEMBERS([struct inode.i_ffs1_size], [], [], [#include <ufs/ufs/inode.h>
 
 # Detect getbootfile function for HASGETBOOTFILE
 AC_CHECK_DECLS([getbootfile()], [
-		LDFLAGS="$LDFLAGS -lutil"
+	LDFLAGS="$LDFLAGS -lutil"
 ], [], [#include <util.h>])
 
 # Detect kvm_getproc2 function for HASKVMGETPROC2
 AC_CHECK_DECLS([kvm_getproc2], [], [], [#include <kvm.h>])
+
+# Detect fs/ptyfs/ptyfs.h header for HASPTYFS
+AC_CHECK_HEADERS([fs/ptyfs/ptyfs.h])
+
+# Detect fs/ptyfs/ptyfs.h header for HASPROCFS
+AC_CHECK_HEADERS([miscfs/procfs/procfs.h])
+
+# Detect PFSroot enum for HASPROCFS_PFSROOT
+AC_CHECK_DECLS([PFSroot], [], [], [#define _KERNEL
+	#include <sys/types.h>
+	#include <miscfs/procfs/procfs.h>])
+
+# Detect fs/tmpfs/tmpfs.h header for HASTMPFS
+AC_CHECK_HEADERS([fs/tmpfs/tmpfs.h])
 
 # Detect sizeof(dev_t) for LT_DEV64
 AC_CHECK_SIZEOF([dev_t])

--- a/configure.ac
+++ b/configure.ac
@@ -388,6 +388,17 @@ AS_IF([test x$LSOF_DIALECT = xnetbsd], [
 	CFLAGS="$CFLAGS -DHAS_LOCKF_H"
 ])
 
+# Detect fdescfs version for HASFDESCFS
+AC_CHECK_HEADERS([miscfs/fdesc/fdesc.h])
+
+# Detect struct fdescnode.fd_link for HASFDLINK
+AC_CHECK_MEMBERS([struct fdescnode.fd_link], [], [], [#define _KERNEL
+	#include <sys/types.h>
+	#include <miscfs/fdesc/fdesc.h>])
+
+# Detect miscfs/nullfs/null.h header for HASNULLFS
+AC_CHECK_HEADERS([miscfs/nullfs/null.h], [], [], [#include <sys/mount.h>])
+
 # Detect sizeof(dev_t) for LT_DEV64
 AC_CHECK_SIZEOF([dev_t])
 AS_IF([test "x$ac_cv_sizeof_dev_t" = x8], [

--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,68 @@ AC_CHECK_HEADERS([fs/tmpfs/tmpfs.h])
 # Detect sys/pipe.h header for HAS_SYS_PIPEH
 AC_CHECK_HEADERS([sys/pipe.h])
 
+# Copy struct lockf definition from kernel source code for HAS_LOCKF_H
+AS_IF([test x$LSOF_DIALECT = xnetbsd], [
+	# Generate lockf.h from kern/vfs_lockf.c
+	rm -f ./lockf.h
+	AS_IF([test -r ${NETBSD_SYS}/kern/vfs_lockf.c], [
+		# Find the line number of TAILQ_HEAD
+		# Note extra quoting [[]] for M4
+		LSOF_TMP1=$(grep -n "^TAILQ_HEAD" ${NETBSD_SYS}/kern/vfs_lockf.c | sed 's/\([[0-9]]*\):.*$/\1/')
+		AS_IF([test "X$LSOF_TMP1" != "X"], [
+			LSOF_TMP2=0
+			# Find the end of struct lockf
+			for i in $(grep -n "};" ${NETBSD_SYS}/kern/vfs_lockf.c | sed 's/\([[0-9]]*\):.*/\1/') # {
+			do
+				AS_IF([test $LSOF_TMP2 -eq 0 -a $i -gt $LSOF_TMP1], [
+					LSOF_TMP2=$i
+				])
+			done	# }
+
+			AS_IF([test $LSOF_TMP2 -eq 0], [
+			        # Fail
+				LSOF_TMP1=""
+			], [
+				# Generate lockf.h
+				cat > ./lockf.h << LOCKF1
+/*
+ * lockf_owner.h -- created by lsof configure script on
+LOCKF1
+				printf " * " >> ./lockf.h
+				date >> ./lockf.h
+				cat >> ./lockf.h << LOCKF2
+ */
+
+#if	!defined(LOCKF_H)
+#define	LOCKF_H
+
+LOCKF2
+				ed -s ${NETBSD_SYS}/kern/vfs_lockf.c >> ./lockf.h << LOCKF3
+${LSOF_TMP1},${LSOF_TMP2}p
+LOCKF3
+				AS_IF([test $? -ne 0], [
+				        # Fail
+					LSOF_TMP1=""
+				], [
+					cat >> ./lockf.h << LOCKF4
+
+#endif	/* defined(LOCKF_H) */
+LOCKF4
+				])
+			])
+		])
+	], [
+	    	AC_MSG_ERROR([Can't read ${NETBSD_SYS}/kern/vfs_lockf.c])
+	])
+
+	AS_IF([test "X$LSOF_TMP1" != "X" -a "X$LSOF_TMP2" != "X0"], [
+		AC_MSG_NOTICE([lockf.h creation succeeded])
+		CFLAGS="$CFLAGS -DHAS_LOCKF_H"
+	], [
+		AC_MSG_ERROR([lockf.h creation failed (see 00FAQ)])
+	])
+])
+
 # Detect sizeof(dev_t) for LT_DEV64
 AC_CHECK_SIZEOF([dev_t])
 AS_IF([test "x$ac_cv_sizeof_dev_t" = x8], [

--- a/configure.ac
+++ b/configure.ac
@@ -374,6 +374,9 @@ AC_CHECK_DECLS([PFSroot], [], [], [#define _KERNEL
 # Detect fs/tmpfs/tmpfs.h header for HASTMPFS
 AC_CHECK_HEADERS([fs/tmpfs/tmpfs.h])
 
+# Detect sys/pipe.h header for HAS_SYS_PIPEH
+AC_CHECK_HEADERS([sys/pipe.h])
+
 # Detect sizeof(dev_t) for LT_DEV64
 AC_CHECK_SIZEOF([dev_t])
 AS_IF([test "x$ac_cv_sizeof_dev_t" = x8], [

--- a/configure.ac
+++ b/configure.ac
@@ -380,63 +380,10 @@ AC_CHECK_HEADERS([sys/pipe.h])
 # Copy struct lockf definition from kernel source code for HAS_LOCKF_H
 AS_IF([test x$LSOF_DIALECT = xnetbsd], [
 	# Generate lockf.h from kern/vfs_lockf.c
-	rm -f ./lockf.h
-	AS_IF([test -r ${NETBSD_SYS}/kern/vfs_lockf.c], [
-		# Find the line number of TAILQ_HEAD
-		# Note extra quoting [[]] for M4
-		LSOF_TMP1=$(grep -n "^TAILQ_HEAD" ${NETBSD_SYS}/kern/vfs_lockf.c | sed 's/\([[0-9]]*\):.*$/\1/')
-		AS_IF([test "X$LSOF_TMP1" != "X"], [
-			LSOF_TMP2=0
-			# Find the end of struct lockf
-			for i in $(grep -n "};" ${NETBSD_SYS}/kern/vfs_lockf.c | sed 's/\([[0-9]]*\):.*/\1/') # {
-			do
-				AS_IF([test $LSOF_TMP2 -eq 0 -a $i -gt $LSOF_TMP1], [
-					LSOF_TMP2=$i
-				])
-			done	# }
+	HEADER_GENERATE([lockf.h], [${NETBSD_SYS}/kern/vfs_lockf.c], ["^TAILQ_HEAD"], ["^};"], [LOCKF_H])
 
-			AS_IF([test $LSOF_TMP2 -eq 0], [
-			        # Fail
-				LSOF_TMP1=""
-			], [
-				# Generate lockf.h
-				cat > ./lockf.h << LOCKF1
-/*
- * lockf_owner.h -- created by lsof configure script on
-LOCKF1
-				printf " * " >> ./lockf.h
-				date >> ./lockf.h
-				cat >> ./lockf.h << LOCKF2
- */
-
-#if	!defined(LOCKF_H)
-#define	LOCKF_H
-
-LOCKF2
-				ed -s ${NETBSD_SYS}/kern/vfs_lockf.c >> ./lockf.h << LOCKF3
-${LSOF_TMP1},${LSOF_TMP2}p
-LOCKF3
-				AS_IF([test $? -ne 0], [
-				        # Fail
-					LSOF_TMP1=""
-				], [
-					cat >> ./lockf.h << LOCKF4
-
-#endif	/* defined(LOCKF_H) */
-LOCKF4
-				])
-			])
-		])
-	], [
-	    	AC_MSG_ERROR([Can't read ${NETBSD_SYS}/kern/vfs_lockf.c])
-	])
-
-	AS_IF([test "X$LSOF_TMP1" != "X" -a "X$LSOF_TMP2" != "X0"], [
-		AC_MSG_NOTICE([lockf.h creation succeeded])
-		CFLAGS="$CFLAGS -DHAS_LOCKF_H"
-	], [
-		AC_MSG_ERROR([lockf.h creation failed (see 00FAQ)])
-	])
+	AC_MSG_NOTICE([lockf.h creation succeeded])
+	CFLAGS="$CFLAGS -DHAS_LOCKF_H"
 ])
 
 # Detect sizeof(dev_t) for LT_DEV64

--- a/dialects/n+obsd/dlsof.h
+++ b/dialects/n+obsd/dlsof.h
@@ -46,6 +46,9 @@
 #include <signal.h>
 #include <string.h>
 #include <unistd.h>
+#if (!defined(NETBSDV) || __NetBSD_Version__>=999001900)
+#include <sys/ptrace.h> /* pulled in by procfs.h, but needs to be pulled in before _KERNEL is defined */
+#endif
 
 # if	defined(HASGETBOOTFILE)
 #include <util.h>
@@ -95,6 +98,10 @@ struct uio;	/* dummy for function prototype in <sys/buf.h> */
 # endif	/* (defined(OPENBSDV) && OPENBSDV<3030)
 	   || (defined(NETBSDV) && __NetBSD_Version__>=106060000) */
 
+# if	defined(NETBSDV) && NETBSDV>=1003000
+#define	sockproto	NETBSD_sockproto
+# endif	/* defined(NETBSDV) && NETBSDV>=1003000 */
+
 #include <sys/mount.h>
 
 # if	(defined(OPENBSDV) && OPENBSDV>=3030) \
@@ -105,10 +112,6 @@ struct uio;	/* dummy for function prototype in <sys/buf.h> */
 
 #include <rpc/types.h>
 #include <sys/protosw.h>
-
-# if	defined(NETBSDV) && NETBSDV>=1003000
-#define	sockproto	NETBSD_sockproto
-# endif	/* defined(NETBSDV) && NETBSDV>=1003000 */
 
 #include <sys/socket.h>
 
@@ -147,6 +150,9 @@ struct uio;	/* dummy for function prototype in <sys/buf.h> */
 		   || (defined(NETBSDV) && __NetBSD_Version__<106060000) */
 
 #define	_KERNEL
+#ifndef	VFS_PROTOS
+#define	VFS_PROTOS(x)
+#endif
 struct nameidata;	/* to satisfy a function prototype in msdosfsmount.h */
 #include <msdosfs/msdosfsmount.h>
 #undef	_KERNEL
@@ -161,6 +167,7 @@ struct nameidata;	/* to satisfy a function prototype in msdosfsmount.h */
 #include <sys/socketvar.h>
 #include <sys/un.h>
 #include <sys/unpcb.h>
+#include <net/route.h>
 #include <netinet/in.h>
 #include <netinet/in_systm.h>
 #include <netinet/ip.h>
@@ -170,7 +177,6 @@ struct nameidata;	/* to satisfy a function prototype in msdosfsmount.h */
 #include <netinet6/in6_pcb.h>
 # endif	/* defined(HASIPv6) && defined(NETBSDV) && !defined(HASINRIAIPv6) */
 
-#include <net/route.h>
 #include <netinet/in_pcb.h>
 #include <netinet/ip_var.h>
 #include <netinet/tcp.h>
@@ -264,6 +270,9 @@ struct sockproto {
 
 #undef KERNEL
 #include <ufs/mfs/mfsnode.h>
+# if	defined(HASTMPFS)
+#include <fs/tmpfs/tmpfs.h>
+# endif	/* defined(HASTMPFS) */
 
 # if	defined(HASNFSPROTO)
 #include <nfs/rpcv2.h>
@@ -360,6 +369,16 @@ struct sockproto {
 #  if	defined(HASPROCFS_PFSROOT)
 #define	_KERNEL
 #  endif	/* defined(HASPROCFS_PFSROOT) */
+#if (defined(NETBSDV) && __NetBSD_Version__>=900000000)
+#include <sys/ptrace.h>
+#endif
+/* 
+ * Needed for definition of curlwp, which isn't used by this code base,
+ * but is exposed in procfs.h in an inline function declaration.
+ */
+#if (defined(NETBSDV) && __NetBSD_Version__>=999009300)
+extern struct lwp	*curlwp;
+#endif
 #include <miscfs/procfs/procfs.h>
 #  if	defined(HASPROCFS_PFSROOT)
 #undef	_KERNEL
@@ -370,7 +389,6 @@ struct sockproto {
 #define	Pregs		PFSregs
 #define	Pfile		PFSfile
 #define	Pfpregs		PFSfpregs
-#define	Pctl		PFSctl
 #define	Pstatus		PFSstatus
 #define	Pnote		PFSnote
 #define	Pnotepg		PFSnotepg
@@ -382,6 +400,9 @@ struct sockproto {
 #define	Pmap		PFSmap
 #define	Pmaps		PFSmaps
 #    endif	/* NETBSDV>=1006000 */
+#    if	NETBSDV<8099000
+#define	Pctl		PFSctl
+#    endif	/* NETBSDV<8099000 */
 #   endif	/* defined(NetBSDV) */
 #  endif	/* defined(HASPROCFS_PFSROOT) */
 #include <machine/reg.h>
@@ -489,7 +510,12 @@ extern KA_T Kpa;
 struct l_vfs {
 	KA_T addr;			/* kernel address */
 	fsid_t	fsid;			/* file system ID */
+#if defined(NETBSDV) && __NetBSD_Version__ >= 499002500
+	/* MFSNAMELEN was removed from the kernel source after 4.99.24 */
+	char type[sizeof(((struct statvfs *)NULL)->f_fstypename)];	/* type of file system */
+#else
 	char type[MFSNAMELEN];		/* type of file system */
+#endif
 	char *dir;			/* mounted directory */
 	char *fsname;			/* file system name */
 	struct l_vfs *next;		/* forward link */
@@ -565,7 +591,7 @@ struct sfile {
 #define	NCACHE_NODEADDR	nc_vp		/* node address in NCACHE */
 #define	NCACHE_PARADDR	nc_dvp		/* parent node address in NCACHE */
 
-#  if	(defined(OPENBSDV) && OPENBSDV>=2010) || (defined(NETBSDV) && NETBSDV>=1002000)
+#  if	(defined(OPENBSDV) && OPENBSDV>=2010) || (defined(NETBSDV) && NETBSDV>=1002000 && __NetBSD_Version__ < 999005400)
 #define	NCACHE_NXT	nc_hash.le_next	/* link in NCACHE */
 #  else	/* (defined(OPENBSDV) && OPENBSDV>=2010) || (defined(NETBSDV) && NETBSDV>=1002000) */
 #   if	defined(NetBSD1_0) && NetBSD<1994101
@@ -580,5 +606,13 @@ struct sfile {
 #define	NCACHE_NODEID	nc_vpid		/* node ID in NCACHE */
 #  endif	/* defined(HASNCVPID) */
 # endif  /* defined(HASNCACHE) */
+
+#if     defined(VV_ROOT)		/* NetBSD >= 4.99.33 */
+#define VNODE_VFLAG     v_vflag
+#define NCACHE_VROOT    VV_ROOT
+#else
+#define VNODE_VFLAG     v_flag
+#define NCACHE_VROOT    VROOT
+#endif  /* VV_ROOT */
 
 #endif	/* NETBSD_LSOF_H */

--- a/dialects/n+obsd/dmnt.c
+++ b/dialects/n+obsd/dmnt.c
@@ -44,6 +44,18 @@ static char copyright[] =
 #include <sys/statvfs.h>
 #endif  /* defined(NETBSDV) && defined(HASSTATVFS) */
 
+#if defined(NETBSDV)
+#include <sys/param.h>
+
+#if __NetBSD_Version__ >= 899000100
+#define __EXPOSE_MOUNT
+#endif
+#if __NetBSD_Version__ >= 399002400
+#include <sys/types.h>
+#include <sys/mount.h>
+#endif
+#endif
+
 #include "lsof.h"
 
 
@@ -93,7 +105,12 @@ readmnt()
 	for (; n; n--, mb++) {
 	    if (mb->f_fstypename[0] == '\0')
 		continue;
+#if defined(NETBSDV) && __NetBSD_Version__ >= 499002500
+	    /* MFSNAMELEN was removed from the kernel source after 4.99.24 */
+	    mb->f_fstypename[sizeof(mb->f_fstypename) - 1] = '\0';
+#else
 	    mb->f_fstypename[MFSNAMELEN - 1] = '\0';
+#endif
 	/*
 	 * Interpolate a possible symbolic directory link.
 	 */

--- a/dialects/n+obsd/dnode.c
+++ b/dialects/n+obsd/dnode.c
@@ -38,7 +38,11 @@ static char copyright[] =
 #include "lsof.h"
 
 #if __NetBSD_Version__ > 399001800
+#ifdef HAS_LOCKF_H
+#include "lockf.h"
+#else
 #define NOLOCKF
+#endif
 #endif
 
 #if	defined(HAS_DINODE_U)

--- a/dialects/n+obsd/dnode.c
+++ b/dialects/n+obsd/dnode.c
@@ -37,6 +37,9 @@ static char copyright[] =
 
 #include "lsof.h"
 
+#if __NetBSD_Version__ > 399001800
+#define NOLOCKF
+#endif
 
 #if	defined(HAS_DINODE_U)
 #define	DINODE_U	dinode_u
@@ -193,12 +196,17 @@ process_node(va)
 	unsigned char ns;
 	unsigned char rdevs;
 	char *ep, *ty;
+#ifndef NOLOCKF
 	struct lockf lf, *lff, *lfp;
+#endif
 	struct inode i;
 	struct mfsnode m;
+#if	defined(HASTMPFS)
+	struct tmpfs_node tmp;
+#endif	/* defined(HASTMPFS) */
 	struct nfsnode n;
 	enum nodetype {NONODE, CDFSNODE, DOSNODE, EXT2NODE, FDESCNODE, INODE,
-		KERNFSNODE, MFSNODE, NFSNODE, PFSNODE, PTYFSNODE} nty;
+		KERNFSNODE, MFSNODE, NFSNODE, PFSNODE, PTYFSNODE, TMPFSNODE} nty;
 	enum vtype type;
 	struct vnode *v, vb;
 	struct l_vfs *vfs;
@@ -275,6 +283,11 @@ process_node(va)
 
 #if	defined(HASPTYFS)
 	struct ptyfsnode pt;
+#if __NetBSD_Version__ >= 499006200
+#define specinfo specnode
+#define vu_specinfo vu_specnode
+#define si_rdev sn_rdev
+#endif
 	struct specinfo si;
 #endif	/* defined(HASPTYFS) */
 
@@ -413,7 +426,7 @@ process_overlaid_node:
 	 */
 	    if (!v->v_data
 	    ||  kread((KA_T)v->v_data, (char *)&kn, sizeof(kn))) {
-		if (v->v_type != VDIR || !(v->v_flag && VROOT)) {
+		if (v->v_type != VDIR || !(v->VNODE_VFLAG && NCACHE_VROOT)) {
 		    (void) snpf(Namech, Namechl,
 			"can't read kernfs_node at: %s",
 			print_kptr((KA_T)v->v_data, (char *)NULL, 0));
@@ -448,7 +461,7 @@ process_overlaid_node:
 	 * size are fixed; otherwise, safely stat() the file to get the
 	 * inode number and size.
 	 */
-	    if (v->v_type == VDIR && (v->v_flag & VROOT)) {
+	    if (v->v_type == VDIR && (v->VNODE_VFLAG & NCACHE_VROOT)) {
 		(void) snpf(Namech, Namechl, "%s", _PATH_KERNFS);
 		ksb.st_ino = (ino_t)2;
 		ksb.st_size = DEV_BSIZE;
@@ -469,6 +482,19 @@ process_overlaid_node:
 	    }
 	    nty = MFSNODE;
 	    break;
+
+#if	defined(HASTMPFS)
+	case VT_TMPFS:
+	    if (!v->v_data
+	    ||  kread((KA_T)v->v_data, (char *)&tmp, sizeof(tmp))) {
+		(void) snpf(Namech, Namechl, "can't read tmpfs_node at: %s",
+		    print_kptr((KA_T)v->v_data, (char *)NULL, 0));
+		enter_nm(Namech);
+		return;
+	    }
+	    nty = TMPFSNODE;
+	    break;
+#endif	/* defined(HASTMPFS) */
 
 #if	defined(HASMSDOSFS)
 	case VT_MSDOSFS:
@@ -618,6 +644,7 @@ process_overlaid_node:
 
 	    }
 
+#ifndef NOLOCKF
 	    if ((lff = i.i_lockf)) {
 
 	    /*
@@ -666,6 +693,7 @@ process_overlaid_node:
 		    break;
 		} while ((lfp = lf.lf_next) && lfp != lff);
 	    }
+#endif
 	    break;
 	default:
 	    if (v->v_type == VBAD || v->v_type == VNON)
@@ -899,6 +927,13 @@ process_overlaid_node:
 	    break;
 #endif	/* defined(HASPTYFS) */
 
+#if	defined(HASTMPFS)
+	case TMPFSNODE:
+	    Lf->inode = (INODETYPE)tmp.tn_id;
+	    Lf->inp_ty = 1;
+	    break;
+#endif	/* defined(HASTMPFS) */
+
 	}
 
 /*
@@ -1017,6 +1052,13 @@ process_overlaid_node:
 			Lf->sz = (SZOFFTYPE)m.mfs_size;
 			Lf->sz_def = 1;
 			break;
+
+#if	defined(HASTMPFS)
+		    case TMPFSNODE:
+			Lf->sz = (SZOFFTYPE)tmp.tn_size;
+			Lf->sz_def = 1;
+			break;
+#endif	/* defined(HASTMPFS) */
 
 #if	defined(HASEXT2FS)
 		    case EXT2NODE:
@@ -1220,6 +1262,9 @@ process_overlaid_node:
 	    Lf->dev_def = Lf->rdev_def = 0;
 	    (void) snpf(Namech, Namechl, "%#x", m.mfs_baseoff);
 	    enter_dev_ch("memory");
+	} else if (nty == TMPFSNODE) {
+	    Lf->dev_def = Lf->rdev_def = 0;
+	    enter_dev_ch("memory");
 	}
 
 #if	defined(HASPROCFS)
@@ -1261,11 +1306,15 @@ process_overlaid_node:
 		(void) snpf(ep, sz, "/%d/fpregs", p.pfs_pid);
 		ty = "PFPR";
 		break;
+
+# if	defined(Pctl)
 	    case Pctl:
 		ep = endnm(&sz);
 		(void) snpf(ep, sz, "/%d/ctl", p.pfs_pid);
 		ty = "PCTL";
 		break;
+# endif	/* defined(Pctl) */
+
 	    case Pstatus:
 		ep = endnm(&sz);
 		(void) snpf(ep, sz, "/%d/status", p.pfs_pid);

--- a/dialects/n+obsd/dnode1.c
+++ b/dialects/n+obsd/dnode1.c
@@ -53,6 +53,9 @@ static char copyright[] =
 #undef	IN_LOCKED
 #undef	i_size
 #undef	IN_WANTED
+#undef  i_endoff
+#undef  i_diroff
+#undef  i_offset
 
 
 /*

--- a/dialects/n+obsd/dproc.c
+++ b/dialects/n+obsd/dproc.c
@@ -36,6 +36,33 @@ static char copyright[] =
 
 #include "lsof.h"
 
+#if __NetBSD_Version__ >= 499006200
+  /*
+   * In NetBSD-4.99.62, struct fdfile was added, struct filedesc::fd_ofiles
+   * changed type from struct file ** to struct fdfile **, and
+   * fd_ofileflags disappeared from struct filedesc, being
+   * replaced by fields in struct fdfile.
+   */
+# define HAVE_STRUCT_FDFILE 1
+# define FILESTRUCT struct fdfile
+#else
+# undef HAVE_STRUCT_FDFILE
+# define FILESTRUCT struct file
+#endif
+#if __NetBSD_Version__ >= 599001400
+  /*
+   * Between NetBSD-5.99.13 and 5.99.14, struct fdtab was added, and
+   * struct filedesc::fd_ofiles and fd_nfiles were replaced by
+   * struct filedesc::fd_dt (a pointer to struct fdtab).
+   */
+# define HAVE_STRUCT_FDTAB 1
+# define NFILES(fd,dt) ((dt).dt_nfiles)
+# define OFILES(fd,dt) ((fd).fd_dt->dt_ff)
+#else
+# undef HAVE_STRUCT_FDTAB
+# define NFILES(fd,dt) ((fd).fd_nfiles)
+# define OFILES(fd,dt) ((fd).fd_ofiles)
+#endif
 
 _PROTOTYPE(static void enter_vn_text,(KA_T va, int *n));
 _PROTOTYPE(static void get_kernel_access,(void));
@@ -151,7 +178,7 @@ gather_proc_info()
 	struct filedesc fd;
 	int i, nf;
 	MALLOC_S nb;
-	static struct file **ofb = NULL;
+	static FILESTRUCT **ofb = NULL;
 	static int ofbb = 0;
 	short pss, sf;
 	int px;
@@ -177,6 +204,10 @@ gather_proc_info()
 #else	/* !defined(HASKVMGETPROC2) */
 	struct kinfo_proc *p;
 #endif	/* defined(HASKVMGETPROC2) */
+
+#if	HAVE_STRUCT_FDTAB
+	struct fdtab dt;
+#endif	/* HAVE_STRUCT_FDTAB */
 
 /*
  * Read the process table.
@@ -217,7 +248,14 @@ gather_proc_info()
 	    if (!p->P_FD
 	    ||  kread((KA_T)p->P_FD, (char *)&fd, sizeof(fd)))
 		continue;
-	    if (!fd.fd_refcnt || fd.fd_lastfile > fd.fd_nfiles)
+	    if (!fd.fd_refcnt)
+		continue;
+#if	HAVE_STRUCT_FDTAB
+	    if (!fd.fd_dt
+	    ||  kread((KA_T)fd.fd_dt, (char *)&dt, sizeof(dt)))
+		continue;
+#endif	/* ! HAVE_STRUCT_FDTAB */
+	    if (fd.fd_lastfile > NFILES(fd,dt))
 		continue;
 
 #if	defined(HASCWDINFO)
@@ -277,14 +315,14 @@ gather_proc_info()
 	/*
 	 * Read open file structure pointers.
 	 */
-	    if (!fd.fd_ofiles || (nf = fd.fd_nfiles) <= 0)
+	    if (!OFILES(fd,dt) || (nf = NFILES(fd,dt)) <= 0)
 		continue;
-	    nb = (MALLOC_S)(sizeof(struct file *) * nf);
+	    nb = (MALLOC_S)(sizeof(FILESTRUCT *) * nf);
 	    if (nb > ofbb) {
 		if (!ofb)
-		    ofb = (struct file **)malloc(nb);
+		    ofb = (FILESTRUCT **)malloc(nb);
 		else
-		    ofb = (struct file **)realloc((MALLOC_P *)ofb, nb);
+		    ofb = (FILESTRUCT **)realloc((MALLOC_P *)ofb, nb);
 		if (!ofb) {
 		    (void) fprintf(stderr, "%s: PID %d, no file * space\n",
 			Pn, p->P_PID);
@@ -292,7 +330,7 @@ gather_proc_info()
 		}
 		ofbb = nb;
 	    }
-	    if (kread((KA_T)fd.fd_ofiles, (char *)ofb, nb))
+	    if (kread((KA_T)OFILES(fd,dt), (char *)ofb, nb))
 		continue;
 
 #if	defined(HASFSTRUCT)
@@ -310,8 +348,10 @@ gather_proc_info()
 		    }
 		    pofb = nb;
 		}
+#if	! HAVE_STRUCT_FDFILE
 		if (!fd.fd_ofileflags || kread((KA_T)fd.fd_ofileflags, pof, nb))
 		    zeromem(pof, nb);
+#endif	/* ! HAVE_STRUCT_FDFILE */
 	    }
 #endif	/* defined(HASFSTRUCT) */
 
@@ -320,8 +360,20 @@ gather_proc_info()
 	 */
 	    for (i = 0; i < nf; i++) {
 		if (ofb[i]) {
+#if	HAVE_STRUCT_FDFILE
+		    struct fdfile fdf;
+		    if (kread((KA_T)ofb[i], (char *)&fdf, sizeof(fdf)))
+			continue;
+		    Cfp = fdf.ff_file;
+		    if (Cfp == NULL)
+			continue;
+		    if (pof)
+			pof[i] = fdf.ff_exclose;
+#else	/* ! HAVE_STRUCT_FDFILE */
+		    Cfp = ofb[i];
+#endif	/* ! HAVE_STRUCT_FDFILE */
 		    alloc_lfile(NULL, i);
-		    process_file((KA_T)(Cfp = ofb[i]));
+		    process_file((KA_T)Cfp);
 		    if (Lf->sf) {
 
 #if	defined(HASFSTRUCT)

--- a/dialects/n+obsd/dstore.c
+++ b/dialects/n+obsd/dstore.c
@@ -47,7 +47,9 @@ struct file *Cfp;		/* current file's file struct pointer */
  */
 
 struct drive_Nl Drive_Nl[] = {
-
+#if (defined(NETBSDV) && NETBSDV>=9099000)
+	{ "rootvnode",	"rootvnode",	},
+#endif
 #if	(defined(OPENBSDV) && OPENBSDV>=2010) || (defined(NETBSDV) && NETBSDV>=1002000)
 	{ X_NCACHE,	"_nchashtbl",	},
 	{ X_NCSIZE,	"_nchash"	},
@@ -118,6 +120,8 @@ struct pff_tab Pof_tab[] = {
 
 # if	defined(UF_EXCLOSE)
 	{ (long)UF_EXCLOSE,	POF_CLOEXEC	},
+# else
+	{ (long)1,		POF_CLOEXEC	},
 # endif	/* defined(UF_EXCLOSE) */
 
 # if	defined(UF_MAPPED)

--- a/dialects/n+obsd/machine.h
+++ b/dialects/n+obsd/machine.h
@@ -41,6 +41,10 @@
 
 #include <sys/types.h>
 #include <sys/param.h>
+#include <stdbool.h>
+#if __NetBSD_Version__ >= 499006200
+#define HASCWDINFO
+#endif
 
 
 /*
@@ -576,7 +580,9 @@
 /* #define	USE_LIB_READMNT			1	   rmnt.c */
 /* #define	USE_LIB_REGEX			1	   regex.c */
 
-# if	(defined(OPENBSDV) && OPENBSDV>=2010) || (defined(NETBSDV) && NETBSDV>=1002000)
+# if (defined(NETBSDV) && NETBSDV>=9099000)
+#define	USE_LIB_RNMT				1	/* rnmt.c */
+# elif	(defined(OPENBSDV) && OPENBSDV>=2010) || (defined(NETBSDV) && NETBSDV>=1002000)
 #define	USE_LIB_RNMH				1	/* rnmh.c */
 # else	/* (defined(OPENBSDV) && OPENBSDV<2010) && (defined(NETBSDV) && NETBSDV<1002000) */
 #define	USE_LIB_RNAM				1	/* rnam.c */

--- a/dialects/n+obsd/machine.h
+++ b/dialects/n+obsd/machine.h
@@ -38,6 +38,10 @@
 #if	!defined(LSOF_MACHINE_H)
 #define	LSOF_MACHINE_H	1
 
+#ifdef AUTOTOOLS
+#include "autotools.h"
+#endif
+
 
 #include <sys/types.h>
 #include <sys/param.h>

--- a/lib/Makefile.skel
+++ b/lib/Makefile.skel
@@ -13,10 +13,10 @@ INCL=	${DINC} -I..
 HDR=	../lsof.h ../proto.h ../dlsof.h ../dproto.h ../machine.h
 
 SRC=	ckkv.c cvfs.c dvch.c fino.c isfn.c lkud.c pdvn.c prfp.c \
-	ptti.c rdev.c regex.c rmnt.c rnam.c rnch.c rnmh.c snpf.c
+	ptti.c rdev.c regex.c rmnt.c rnam.c rnch.c rnmh.c rnmt.c snpf.c
 
 OBJ=	ckkv.o cvfs.o dvch.o fino.o isfn.o lkud.o pdvn.o prfp.o \
-	ptti.o rdev.o regex.o rmnt.o rnam.o rnch.o rnmh.o snpf.o
+	ptti.o rdev.o regex.o rmnt.o rnam.o rnch.o rnmh.o rnmt.o snpf.o
 
 all:	${LIB}
 
@@ -58,5 +58,7 @@ rnam.o: ${HDR} rnam.c
 rnch.o: ${HDR} rnch.c
 
 rnmh.o: ${HDR} rnmh.c
+
+rnmt.o: ${HDR} rnmt.c
 
 snpf.o: ${HDR} snpf.c

--- a/lib/prfp.c
+++ b/lib/prfp.c
@@ -30,7 +30,7 @@
  */
 
 
-#include "../machine.h"
+#include "machine.h"
 
 #if	defined(USE_LIB_PROCESS_FILE)
 

--- a/lib/rmnt.c
+++ b/lib/rmnt.c
@@ -30,7 +30,7 @@
  */
 
 
-#include "../machine.h"
+#include "machine.h"
 
 #if	defined(USE_LIB_READMNT)
 

--- a/lib/rnam.c
+++ b/lib/rnam.c
@@ -30,7 +30,7 @@
  */
 
 
-#include "../machine.h"
+#include "machine.h"
 
 #if	defined(HASNCACHE) && defined(USE_LIB_RNAM)
 

--- a/lib/rnch.c
+++ b/lib/rnch.c
@@ -30,7 +30,7 @@
  */
 
 
-#include "../machine.h"
+#include "machine.h"
 
 #if	defined(HASNCACHE) && defined(USE_LIB_RNCH)
 

--- a/lib/rnmh.c
+++ b/lib/rnmh.c
@@ -31,7 +31,7 @@
  */
 
 
-#include "../machine.h"
+#include "machine.h"
 
 #if	defined(HASNCACHE) && defined(USE_LIB_RNMH)
 

--- a/lib/rnmt.c
+++ b/lib/rnmt.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2022  Tobias Nygren <tnn@NetBSD.org>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+*/
+
+#include "machine.h"
+
+#if defined(HASNCACHE) && defined(USE_LIB_RNMT)
+#include <sys/rbtree.h>
+#include <sys/vnode_impl.h>
+#include <err.h>
+
+#include "../lsof.h"
+
+/*
+ * rnmt.c - read NetBSD=>10-style red-black tree kernel name cache
+ */
+
+static int lnc_compare_nodes(void *, const void *, const void *);
+static int lnc_compare_key(void *, const void *, const void *);
+
+static rb_tree_t lnc_rbtree;
+
+/* local name cache entry */
+struct lnc {
+	struct rb_node lnc_tree;	/* red-black tree */
+	KA_T lnc_vp;			/* vnode address */
+	const struct lnc *lnc_plnc;	/* parent lnc address */
+	int lnc_nlen;			/* name length */
+	char lnc_name[NCHNAMLEN + 1];	/* name */
+};
+
+static const rb_tree_ops_t lnc_rbtree_ops = {
+	.rbto_compare_nodes = lnc_compare_nodes,
+	.rbto_compare_key = lnc_compare_key,
+	.rbto_node_offset = offsetof(struct lnc, lnc_tree),
+	.rbto_context = NULL
+};
+
+static int
+lnc_compare_nodes(void *context, const void *node1, const void *node2)
+{
+	const struct lnc *lnc1 = node1;
+	const struct lnc *lnc2 = node2;
+
+	if (lnc1->lnc_vp < lnc2->lnc_vp) {
+		return -1;
+	}
+	if (lnc1->lnc_vp > lnc2->lnc_vp) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static int
+lnc_compare_key(void *context, const void *node, const void *key)
+{
+	const struct lnc *lnc = node;
+	const KA_T vp = (KA_T)key;
+
+	if (lnc->lnc_vp < vp) {
+		return -1;
+	}
+	if (lnc->lnc_vp > vp) {
+		return 1;
+	}
+
+	return 0;
+}
+
+static struct lnc *
+ncache_enter_local(KA_T vp, const struct lnc *plnc, const struct namecache *nc)
+{
+	struct lnc *lnc;
+
+	lnc = malloc(sizeof(*lnc));
+	if (!lnc) {
+		errx(1, "can't allocate local name cache entry\n");
+	}
+	lnc->lnc_vp = vp;
+	lnc->lnc_plnc = plnc;
+	lnc->lnc_nlen = nc->nc_nlen;
+	memcpy(lnc->lnc_name, nc->nc_name, lnc->lnc_nlen);
+	lnc->lnc_name[lnc->lnc_nlen] = 0;
+
+	rb_tree_insert_node(&lnc_rbtree, lnc);
+
+	return lnc;
+}
+
+static int
+sanity_check_vnode_impl(const struct vnode_impl *vi)
+{
+	if (vi->vi_vnode.v_type >= VBAD)
+		return -1;
+
+	return 0;
+}
+
+static int
+sanity_check_namecache(const struct namecache *nc)
+{
+	if (nc->nc_vp == NULL)
+		return -1;
+
+	if (nc->nc_nlen > NCHNAMLEN)
+		return -1;
+
+	if (nc->nc_nlen == 1 && nc->nc_name[0] == '.')
+		return -1;
+
+	if (nc->nc_nlen == 2 && nc->nc_name[0] == '.' && nc->nc_name[1] == '.')
+		return -1;
+
+	return 0;
+}
+
+static void
+ncache_walk(KA_T ncp, const struct lnc *plnc)
+{
+	struct l_nch *lc;
+	static struct vnode_impl vi;
+	static struct namecache nc;
+	struct lnc *lnc;
+	KA_T vp;
+	KA_T left, right;
+
+	if (kread(ncp, (char *)&nc, sizeof(nc))) {
+		return;
+	}
+	vp = (KA_T)nc.nc_vp;
+	if (kread(vp, (char *)&vi, sizeof(vi))) {
+		vi.vi_vnode.v_type = VBAD;
+	}
+	left = (KA_T)nc.nc_tree.rb_nodes[0];
+	right = (KA_T)nc.nc_tree.rb_nodes[1];
+	if (sanity_check_vnode_impl(&vi) == 0 && sanity_check_namecache(&nc) == 0) {
+		lnc = ncache_enter_local(vp, plnc, &nc);
+		if (vi.vi_vnode.v_type == VDIR && vi.vi_nc_tree.rbt_root != NULL) {
+			ncache_walk((KA_T)vi.vi_nc_tree.rbt_root, lnc);
+		}
+	}
+	if (left)
+		ncache_walk(left, plnc);
+	if (right)
+		ncache_walk(right, plnc);
+}
+
+void
+ncache_load()
+{
+	KA_T rootvnode_addr;
+	struct vnode_impl vi;
+
+	rootvnode_addr = (KA_T)0;
+	if (get_Nl_value("rootvnode", (struct drive_Nl *)NULL, &rootvnode_addr) < 0
+	    || !rootvnode_addr
+	    || kread((KA_T)rootvnode_addr, (char *)&rootvnode_addr, sizeof(rootvnode_addr))
+	    || kread((KA_T)rootvnode_addr, (char *)&vi, sizeof(vi))) {
+		errx(1, "can't read rootvnode\n");
+	}
+
+	rb_tree_init(&lnc_rbtree, &lnc_rbtree_ops);
+	ncache_walk((KA_T)vi.vi_nc_tree.rbt_root, 0);
+}
+
+static void
+build_path(char **buf, size_t *remaining, const struct lnc *lnc)
+{
+	size_t len;
+
+	if (lnc == NULL)
+		return;
+
+	build_path(buf, remaining, lnc->lnc_plnc);
+	if (remaining == 0) {
+		return;
+	}
+	if (lnc->lnc_plnc != NULL) {
+		**buf = '/';
+		(*buf)++;
+		remaining--;
+	}
+	len = lnc->lnc_nlen;
+	if (*remaining < len)
+		len = *remaining;
+	memcpy(*buf, lnc->lnc_name, len);
+	*remaining -= len;
+	*buf += len;
+}
+
+char *
+ncache_lookup(char *buf, int blen, int *fp)
+{
+	const struct lnc *lnc;
+	char *p;
+	size_t remaining;
+
+	*fp = 0;
+	lnc = rb_tree_find_node(&lnc_rbtree, (void*)Lf->na);
+	if (lnc != NULL) {
+		p = buf;
+		remaining = blen;
+		build_path(&p, &remaining, lnc);
+		if (remaining == 0) {
+			buf[blen - 1] = 0;
+		} else {
+			*p = 0;
+		}
+		*fp = 1;
+		return buf;
+	}
+
+	return NULL;
+}
+#endif

--- a/m4/header.m4
+++ b/m4/header.m4
@@ -52,12 +52,12 @@ AC_DEFUN([HEADER_GENERATE], [
 			], [
 				cat > $1 << EOF
 /*
-* $1.h -- created by lsof configure script on
+ * $1 -- created by lsof configure script on
 EOF
 				printf " * " >> $1
 				date >> $1
 				cat >> $1 << EOF
-*/
+ */
 
 #if	!defined($5)
 #define	$5

--- a/usage.c
+++ b/usage.c
@@ -984,6 +984,9 @@ usage(err, fh, version)
 #ifdef HASNULLFS
 		"nullfs",
 #endif
+#ifdef HAS_SYS_PIPEH
+		"pipe",
+#endif
 #ifdef HASPROCFS
 		"procfs",
 #endif

--- a/usage.c
+++ b/usage.c
@@ -993,6 +993,9 @@ usage(err, fh, version)
 #ifdef HASPTYEPT
 		"ptyept",
 #endif
+#ifdef HASPTYFS
+		"ptyfs",
+#endif
 #if !defined(HASNORPC_H)
 		"rpc",
 #endif
@@ -1011,7 +1014,7 @@ usage(err, fh, version)
 #ifdef HASTASKS
 		"tasks",
 #endif
-#ifdef HAS_TMPFS
+#if defined(HAS_TMPFS) || defined(HASTMPFS)
 		"tmpfs",
 #endif
 #ifdef HAS_XTCPCB_TMAXSEG


### PR DESCRIPTION
I merged patches from http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/sysutils/lsof/patches/ for #219. I have tested on NetBSD 9.3. Progress:

 - [x] Apply upstream patches
 - [x] Initial autotools migration
 - [x] Bring back lock status by copying `struct lockf` from kernel source