### PR TITLE
[linux] Do not hard-code fd numbers in epoll test

### DIFF
--- a/dialects/linux/tests/case-20-epoll.bash
+++ b/dialects/linux/tests/case-20-epoll.bash
@@ -8,8 +8,8 @@ if ! [ -x $TARGET ]; then
 fi
 
 $TARGET 2>> $report | {
-    read pid epfd
-    if [[ -z "$pid" || -z "$epfd" ]]; then
+    read pid epfd evfd0 evfd1
+    if [[ -z "$pid" || -z "$epfd" || -z "$evfd0" || -z "$evfd1" ]]; then
 	echo "unexpected output form target ( $TARGET )" >> $report
 	exit 1
     fi
@@ -25,7 +25,7 @@ $TARGET 2>> $report | {
 	echo done
     } >> $report
     if $lsof -p $pid -a -d $epfd |
-	    grep -q "epoll *[0-9]* *.* *${epfd}u *a_inode *[0-9]*,[0-9]* *[0-9]* *[0-9]* *\[eventpoll:5,6\]"; then
+	    grep -q "epoll *[0-9]* *.* *${epfd}u *a_inode *[0-9]*,[0-9]* *[0-9]* *[0-9]* *\[eventpoll:${evfd0},${evfd1}\]"; then
 	kill $pid
 	exit 0
     else


### PR DESCRIPTION
In case file descriptor 3 and 4 are being used already, the executable created by epoll.c exits with exit code 1, and prints the message -

	epoll_ctl<6>: Invalid argument

causing case-20-epoll.bash to FAIL.