### PR TITLE
arg: Remove unnecessary initialization assignments

### DIFF
--- a/arg.c
+++ b/arg.c
@@ -993,7 +993,7 @@ enter_dir(d, descend)
 	char *av[2];
 	dev_t ddev;
 	DIR *dfp;
-	char *dn = (char *)NULL;
+	char *dn;
 	MALLOC_S dnl, dnamlen;
 	struct DIRTYPE *dp;
 	int en, sl;

--- a/dialects/uw/dsock.c
+++ b/dialects/uw/dsock.c
@@ -1104,7 +1104,7 @@ find_unix_sockaddr_un(ka)
 	    char *ch = (char *)NULL;
 	    int ct, pct;
 	    struct strioctl ioc;
-	    int sock = -1;
+	    int sock;
 
 	    if (alct < 0)
 		return((struct sockaddr_un *)NULL);


### PR DESCRIPTION
The dn pointer variable will be assigned before use. It does not need to initialize the assignment.


Signed-off-by: Li kunyu <kunyu@nfschina.com>