### PR TITLE
Expose functionality as a re-usable library - Part 3

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,7 @@ EXTRA_DIST += tests/00README tests/TestDB tests/CkTestDB tests/Makefile tests/Ls
 
 # Dialect neutral sources
 lsof_SOURCES = src/arg.c src/main.c lib/node.c src/print.c src/ptti.c src/store.c src/usage.c src/util.c \
-	lib/ckkv.c lib/cvfs.c lib/dvch.c lib/fino.c lib/isfn.c lib/lkud.c lib/misc.c lib/pdvn.c lib/prfp.c lib/proc.c lib/ptti.c lib/rdev.c lib/rnmt.c lib/rmnt.c lib/rnam.c lib/rnch.c lib/rnmh.c
+	lib/ckkv.c lib/cvfs.c lib/dvch.c lib/fino.c lib/isfn.c lib/lkud.c lib/misc.c lib/pdvn.c lib/prfp.c lib/print.c lib/proc.c lib/ptti.c lib/rdev.c lib/rnmt.c lib/rmnt.c lib/rnam.c lib/rnch.c lib/rnmh.c
 lsof_SOURCES += lib/common.h include/lsof_fields.h lib/proto.h lib/hash.h
 include_HEADERS = include/lsof.h include/lsof_fields.h
 DIALECT_ROOT = $(top_srcdir)/lib/dialects

--- a/include/lsof.h
+++ b/include/lsof.h
@@ -1,0 +1,47 @@
+/** @file
+ * lsof.h - header file for lsof
+ */
+
+/*
+ * Copyright 1994 Purdue Research Foundation, West Lafayette, Indiana
+ * 47907.  All rights reserved.
+ *
+ * Written by Victor A. Abell
+ *
+ * This software is not subject to any license of the American Telephone
+ * and Telegraph Company or the Regents of the University of California.
+ *
+ * Permission is granted to anyone to use this software for any purpose on
+ * any computer system, and to alter it and redistribute it freely, subject
+ * to the following restrictions:
+ *
+ * 1. Neither the authors nor Purdue University are responsible for any
+ *    consequences of the use of this software.
+ *
+ * 2. The origin of this software must not be misrepresented, either by
+ *    explicit claim or by omission.  Credit to the authors and Purdue
+ *    University must appear in documentation and sources.
+ *
+ * 3. Altered versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 4. This notice may not be removed or altered.
+ */
+
+/*
+ * $Id: lsof.h,v 1.70 2018/03/26 21:50:45 abe Exp $
+ */
+
+#if !defined(LSOF_H)
+#    define LSOF_H 1
+
+/** File access mode */
+enum lsof_file_access_mode {
+    LSOF_FILE_ACCESS_NONE = 0,  /**< None */
+    LSOF_FILE_ACCESS_READ = 1,  /**< Read */
+    LSOF_FILE_ACCESS_WRITE = 2, /**< Write */
+    LSOF_FILE_ACCESS_READ_WRITE =
+        LSOF_FILE_ACCESS_READ | LSOF_FILE_ACCESS_WRITE, /**< Read and write */
+};
+
+#endif

--- a/lib/common.h
+++ b/lib/common.h
@@ -32,8 +32,9 @@
  * $Id: lsof.h,v 1.70 2018/03/26 21:50:45 abe Exp $
  */
 
-#if !defined(LSOF_H)
-#    define LSOF_H 1
+#include "lsof.h"
+#if !defined(COMMON_H)
+#    define COMMON_H 1
 
 #    if defined(AUTOTOOLS)
 #        include "autotools.h"
@@ -795,7 +796,7 @@ extern char *InodeFmt_x;
 extern int LastPid;
 
 struct lfile {
-    char access;
+    enum lsof_file_access_mode access;
     char lock;
     unsigned char dev_def;   /* device number definition status */
     unsigned char inp_ty;    /* inode/iproto type

--- a/lib/dialects/aix/dnode.c
+++ b/lib/dialects/aix/dnode.c
@@ -879,72 +879,61 @@ void process_node(va) KA_T va; /* vnode kernel space address */
     /*
      * Obtain the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
-
+    switch (Ntype) {
 #if defined(HAS_AFS)
-        case N_AFS:
-            Lf->sz = (SZOFFTYPE)an.size;
-            Lf->sz_def = 1;
-            break;
+    case N_AFS:
+        Lf->sz = (SZOFFTYPE)an.size;
+        Lf->sz_def = 1;
+        break;
 #endif /* defined(HAS_AFS) */
 
 #if AIXV >= 3200
-        case N_FIFO:
-            Lf->sz = (SZOFFTYPE)f.ff_size;
-            Lf->sz_def = 1;
-            break;
+    case N_FIFO:
+        Lf->sz = (SZOFFTYPE)f.ff_size;
+        Lf->sz_def = 1;
+        break;
 #endif /* AIXV>=3200 */
 
 #if defined(HAS_NFS)
-        case N_NFS:
-            if (nfss) {
-                Lf->sz = (SZOFFTYPE)nfs_attr.va_size;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_NFS:
+        if (nfss) {
+            Lf->sz = (SZOFFTYPE)nfs_attr.va_size;
+            Lf->sz_def = 1;
+        }
+        break;
 #endif /* defined(HAS_NFS) */
 
 #if defined(HAS_SANFS)
-        case N_SANFS:
-            if (sans) {
+    case N_SANFS:
+        if (sans) {
 
-                /*
-                 * DEBUG: this code is insufficient.  It can't be completed
-                 * until IBM makes the SANFS header files available in
-                 * /usr/include.
-                 */
-                /* Lf->sz = (SZOFFTYPE)???	DEBUG */
-                Lf->sz_def = 1;
-            }
-            break;
+            /*
+             * DEBUG: this code is insufficient.  It can't be completed
+             * until IBM makes the SANFS header files available in
+             * /usr/include.
+             */
+            /* Lf->sz = (SZOFFTYPE)???	DEBUG */
+            Lf->sz_def = 1;
+        }
+        break;
 #endif /* defined(HAS_SANFS) */
 
 #if AIXV >= 3200
-        case N_BLK:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_CHR:
-        case N_MPC:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_BLK:
+        break;
+    case N_CHR:
+    case N_MPC:
+        break;
 #endif /* AIXV>=3200 */
 
-        case N_REGLR:
-            if (type == VREG || type == VDIR) {
-                if (ins) {
-                    Lf->sz = (SZOFFTYPE)i.size;
-                    Lf->sz_def = i.size_def;
-                }
-            } else if (((type == VBLK) || (type == VCHR) || (type == VMPC)) &&
-                       !Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_REGLR:
+        if (type == VREG || type == VDIR) {
+            if (ins) {
+                Lf->sz = (SZOFFTYPE)i.size;
+                Lf->sz_def = i.size_def;
+            }
         }
+        break;
     }
     /*
      * Record link count.
@@ -1181,13 +1170,10 @@ void process_shmt(sa) KA_T sa; /* shared memory transport node struct
     }
     enter_dev_ch(print_kptr(sa, (char *)NULL, 0));
     /*
-     * If offset display has been requested or if buffer size less free bytes is
-     * negative, enable offset display.  Otherwise set the  file size as buffer
-     * size less free bytes.
+     * If buffer size is less than free bytes, enable offset display. Otherwise
+     * set the file size as buffer size less free bytes.
      */
-    if (Foffset || mn.free > mn.sz)
-        Lf->off_def = 1;
-    else {
+    if (mn.free <= mn.sz) {
         Lf->sz = (SZOFFTYPE)(mn.sz - mn.free);
         Lf->sz_def = 1;
     }

--- a/lib/dialects/aix/dnode.c
+++ b/lib/dialects/aix/dnode.c
@@ -938,57 +938,55 @@ void process_node(va) KA_T va; /* vnode kernel space address */
     /*
      * Record link count.
      */
-    if (Fnlink) {
-        switch (Ntype) {
+    switch (Ntype) {
 
 #if defined(HAS_AFS)
-        case N_AFS:
-            Lf->nlink = an.nlink;
-            Lf->nlink_def = an.nlink_st;
-            break;
+    case N_AFS:
+        Lf->nlink = an.nlink;
+        Lf->nlink_def = an.nlink_st;
+        break;
 #endif /* defined(HAS_AFS) */
 
 #if defined(HAS_NFS)
-        case N_NFS:
-            if (nfss) {
-                Lf->nlink = (long)nfs_attr.va_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
+    case N_NFS:
+        if (nfss) {
+            Lf->nlink = (long)nfs_attr.va_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
 #endif /* defined(HAS_NFS) */
 
 #if defined(HAS_SANFS)
-        case N_SANFS:
-            if (sans) {
+    case N_SANFS:
+        if (sans) {
 
-                /*
-                 * DEBUG: this code is insufficient.  It can't be completed
-                 * until IBM makes the SANFS header files available in
-                 * /usr/include.
-                 */
-                /* Lf->nlink = (long)???	DEBUG */
-                Lf->nlink_def = 1;
-            }
-            break;
+            /*
+             * DEBUG: this code is insufficient.  It can't be completed
+             * until IBM makes the SANFS header files available in
+             * /usr/include.
+             */
+            /* Lf->nlink = (long)???	DEBUG */
+            Lf->nlink_def = 1;
+        }
+        break;
 #endif /* defined(HAS_SANFS) */
 
 #if AIXV >= 3200
-        case N_BLK:
-        case N_CHR:
-        case N_FIFO:
-        case N_MPC:
+    case N_BLK:
+    case N_CHR:
+    case N_FIFO:
+    case N_MPC:
 #endif /* AIXV>=3200 */
 
-        case N_REGLR:
-            if (ins) {
-                Lf->nlink = (long)i.nlink;
-                Lf->nlink_def = i.nlink_def;
-            }
-            break;
+    case N_REGLR:
+        if (ins) {
+            Lf->nlink = (long)i.nlink;
+            Lf->nlink_def = i.nlink_def;
         }
-        if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
+        break;
     }
+    if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
 
 #if defined(HAS_NFS)
     /*

--- a/lib/dialects/aix/dproc.c
+++ b/lib/dialects/aix/dproc.c
@@ -1363,7 +1363,7 @@ static void process_text(pid) pid_t pid; /* process PID */
          */
         (void)snpf(fd, sizeof(fd), "L%02d", i++);
         alloc_lfile(fd, -1);
-        Lf->dev_def = Lf->inp_ty = Lf->nlink_def = Lf->sz_def = 1;
+        Lf->dev_def = Lf->inp_ty = Lf->nlink_def = 1;
         Lf->dev = sb.st_dev;
         Lf->inode = (INODETYPE)sb.st_ino;
         (void)snpf(Lf->type, sizeof(Lf->type), "VREG");
@@ -1380,6 +1380,7 @@ static void process_text(pid) pid_t pid; /* process PID */
                 nm = sp->nm;
                 Lf->nlink = sp->nlink;
                 Lf->sz = sp->sz;
+                Lf->sz_def = 1;
                 break;
             }
         }
@@ -1392,6 +1393,7 @@ static void process_text(pid) pid_t pid; /* process PID */
             nm = pp;
             Lf->nlink_def = sb.st_nlink;
             Lf->sz = sb.st_size;
+            Lf->sz_def = 1;
         }
         /*
          * Do selection tests: NFS; link count; file name; and file system.

--- a/lib/dialects/aix/dproc.c
+++ b/lib/dialects/aix/dproc.c
@@ -722,12 +722,11 @@ void gather_proc_info() {
                 if (Lf->sf) {
 
 #if defined(HASFSTRUCT)
-                    if (Fsv & FSV_FG)
 
 #    if AIXV < 4300
-                        Lf->pof = (long)(Up->u_ufd[i].flags & 0x7f);
+                    Lf->pof = (long)(Up->u_ufd[i].flags & 0x7f);
 #    else  /* AIXV>=4300 */
-                        Lf->pof = (long)(fds->pi_ufd[i].flags & 0x7f);
+                    Lf->pof = (long)(fds->pi_ufd[i].flags & 0x7f);
 #    endif /* AIXV<4300 */
 #endif     /* defined(HASFSTRUCT) */
 

--- a/lib/dialects/aix/dsock.c
+++ b/lib/dialects/aix/dsock.c
@@ -101,9 +101,9 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
     /*
      * Save size information.
      */
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
     else
         Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);

--- a/lib/dialects/aix/dsock.c
+++ b/lib/dialects/aix/dsock.c
@@ -101,16 +101,13 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
     /*
      * Save size information.
      */
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
-        else
-            Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
+    else
+        Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
+    Lf->sz_def = 1;
 
 #if defined(HASTCPTPIQ)
     Lf->lts.rq = s.so_rcv.sb_cc;
@@ -304,8 +301,6 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
             enter_dev_ch(print_kptr((KA_T)(s.so_pcb), (char *)NULL, 0));
         else
             (void)snpf(Namech, Namechl, "no protocol control block");
-        if (!Fsize)
-            Lf->off_def = 1;
         break;
         /*
          * Process a Unix domain socket.

--- a/lib/dialects/darwin/dfile.c
+++ b/lib/dialects/darwin/dfile.c
@@ -163,12 +163,10 @@ void enter_vnode_info(
     /*
      * Save link count, as requested.
      */
-    if (Fnlink) {
-        Lf->nlink = vip->vip_vi.vi_stat.vst_nlink;
-        Lf->nlink_def = 1;
-        if (Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
-    }
+    Lf->nlink = vip->vip_vi.vi_stat.vst_nlink;
+    Lf->nlink_def = 1;
+    if (Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * If a device number is defined, locate file system and save its identity.
      */

--- a/lib/dialects/darwin/dfile.c
+++ b/lib/dialects/darwin/dfile.c
@@ -64,8 +64,7 @@ void enter_file_info(
      * Save the offset / size
      */
     Lf->off = (SZOFFTYPE)pfi->fi_offset;
-    if (Foffset)
-        Lf->off_def = 1;
+    Lf->off_def = 1;
     /*
      * Save file structure information as requested.
      */
@@ -190,7 +189,6 @@ void enter_vnode_info(
     switch (Ntype) {
     case N_CHR:
     case N_FIFO:
-        Lf->off_def = 1;
         break;
     default:
         Lf->sz = (SZOFFTYPE)vip->vip_vi.vi_stat.vst_size;
@@ -399,12 +397,8 @@ static void process_pipe_common(pi) struct pipe_fdinfo *pi;
     /*
      * Enable offset or size reporting.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        Lf->sz = (SZOFFTYPE)pi->pipeinfo.pipe_stat.vst_blksize;
-        Lf->sz_def = 1;
-    }
+    Lf->sz = (SZOFFTYPE)pi->pipeinfo.pipe_stat.vst_blksize;
+    Lf->sz_def = 1;
     /*
      * If there is a peer handle, enter it in as NAME column information.
      */
@@ -514,12 +508,6 @@ int32_t fd;                         /* FD */
         (void)snpf(Namech, Namechl, "%s", ps.pseminfo.psem_name);
         enter_nm(Namech);
     }
-    /*
-     * Unless file size has been specifically requested, enable the printing of
-     * file offset.
-     */
-    if (!Fsize)
-        Lf->off_def = 1;
 }
 
 /*
@@ -550,12 +538,8 @@ static void process_pshm_common(ps) struct pshm_fdinfo *ps;
     /*
      * Enable offset or size reporting.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        Lf->sz = (SZOFFTYPE)ps->pshminfo.pshm_stat.vst_size;
-        Lf->sz_def = 1;
-    }
+    Lf->sz = (SZOFFTYPE)ps->pshminfo.pshm_stat.vst_size;
+    Lf->sz_def = 1;
 }
 
 void process_pshm(pid, fd) int pid; /* PID */

--- a/lib/dialects/darwin/dfile.c
+++ b/lib/dialects/darwin/dfile.c
@@ -68,16 +68,14 @@ void enter_file_info(
     /*
      * Save file structure information as requested.
      */
-    if (Fsv & FSV_FG) {
-        Lf->ffg = (long)pfi->fi_openflags;
-        Lf->fsv |= FSV_FG;
+    Lf->ffg = (long)pfi->fi_openflags;
+    Lf->fsv |= FSV_FG;
 
 #if defined(PROC_FP_GUARDED)
-        if (pfi->fi_status & PROC_FP_GUARDED) {
-            Lf->guardflags = pfi->fi_guardflags;
-        }
-#endif /* defined(PROC_FP_GUARDED) */
+    if (pfi->fi_status & PROC_FP_GUARDED) {
+        Lf->guardflags = pfi->fi_guardflags;
     }
+#endif /* defined(PROC_FP_GUARDED) */
     Lf->pof = (long)pfi->fi_status;
 }
 

--- a/lib/dialects/darwin/dfile.c
+++ b/lib/dialects/darwin/dfile.c
@@ -55,11 +55,11 @@ void enter_file_info(
      */
     f = pfi->fi_openflags & (FREAD | FWRITE);
     if (f == FREAD)
-        Lf->access = 'r';
+        Lf->access = LSOF_FILE_ACCESS_READ;
     else if (f == FWRITE)
-        Lf->access = 'w';
+        Lf->access = LSOF_FILE_ACCESS_WRITE;
     else if (f == (FREAD | FWRITE))
-        Lf->access = 'u';
+        Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
     /*
      * Save the offset / size
      */

--- a/lib/dialects/darwin/dsock.c
+++ b/lib/dialects/darwin/dsock.c
@@ -68,9 +68,9 @@ static void process_socket_common(si) struct socket_fdinfo *si;
     /*
      * Enable size or offset display.
      */
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)si->psi.soi_rcv.sbi_cc;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)si->psi.soi_snd.sbi_cc;
     else
         Lf->sz = (SZOFFTYPE)(si->psi.soi_rcv.sbi_cc + si->psi.soi_snd.sbi_cc);

--- a/lib/dialects/darwin/dsock.c
+++ b/lib/dialects/darwin/dsock.c
@@ -68,17 +68,13 @@ static void process_socket_common(si) struct socket_fdinfo *si;
     /*
      * Enable size or offset display.
      */
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)si->psi.soi_rcv.sbi_cc;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)si->psi.soi_snd.sbi_cc;
-        else
-            Lf->sz =
-                (SZOFFTYPE)(si->psi.soi_rcv.sbi_cc + si->psi.soi_snd.sbi_cc);
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)si->psi.soi_rcv.sbi_cc;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)si->psi.soi_snd.sbi_cc;
+    else
+        Lf->sz = (SZOFFTYPE)(si->psi.soi_rcv.sbi_cc + si->psi.soi_snd.sbi_cc);
+    Lf->sz_def = 1;
 
 #if defined(HASTCPTPIQ)
     /*
@@ -336,8 +332,6 @@ static void process_socket_common(si) struct socket_fdinfo *si;
          * Process a ROUTE domain socket.
          */
         (void)snpf(Lf->type, sizeof(Lf->type), "rte");
-        if (!Fsize)
-            Lf->off_def = 1;
         break;
     case AF_NDRV:
 

--- a/lib/dialects/freebsd/dnode.c
+++ b/lib/dialects/freebsd/dnode.c
@@ -495,20 +495,18 @@ process_overlaid_node:
     /*
      * Record the link count.
      */
-    if (Fnlink) {
-        /* Read nlink from kernel if provided, otherwise call stat() */
+    /* Read nlink from kernel if provided, otherwise call stat() */
 #if defined(HAS_KF_FILE_NLINK)
-        Lf->nlink = kf->kf_un.kf_file.kf_file_nlink;
-        Lf->nlink_def = 1;
+    Lf->nlink = kf->kf_un.kf_file.kf_file_nlink;
+    Lf->nlink_def = 1;
 #else
-        if (kf->kf_path[0] && stat(kf->kf_path, &st) == 0) {
-            Lf->nlink = st.st_nlink;
-            Lf->nlink_def = 1;
-        }
-#endif
-        if (Lf->nlink_def && Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
+    if (kf->kf_path[0] && stat(kf->kf_path, &st) == 0) {
+        Lf->nlink = st.st_nlink;
+        Lf->nlink_def = 1;
     }
+#endif
+    if (Lf->nlink_def && Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * Record an NFS file selection.
      */

--- a/lib/dialects/freebsd/dnode.c
+++ b/lib/dialects/freebsd/dnode.c
@@ -466,48 +466,38 @@ process_overlaid_node:
     /*
      * Obtain the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
-        case N_FIFO:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_PROC:
-            Lf->sz = kf->kf_un.kf_file.kf_file_size;
-            Lf->sz_def = 1;
-            break;
+    switch (Ntype) {
+    case N_FIFO:
+        break;
+    case N_PROC:
+        Lf->sz = kf->kf_un.kf_file.kf_file_size;
+        Lf->sz_def = 1;
+        break;
 #if defined(HASPSEUDOFS)
-        case N_PSEU:
-            Lf->sz = 0;
-            Lf->sz_def = 1;
-            break;
+    case N_PSEU:
+        Lf->sz = 0;
+        Lf->sz_def = 1;
+        break;
 #endif /* defined(PSEUDOFS) */
-        case N_REGLR:
+    case N_REGLR:
 #if defined(HAS_TMPFS)
-        case N_TMP:
+    case N_TMP:
 #endif /* defined(HAS_TMPFS) */
-            if (kf_vtype == KF_VTYPE_VREG || kf_vtype == KF_VTYPE_VDIR) {
-                Lf->sz = kf->kf_un.kf_file.kf_file_size;
-                Lf->sz_def = 1;
-            } else if ((kf_vtype == KF_VTYPE_VCHR ||
-                        kf_vtype == KF_VTYPE_VBLK) &&
-                       !Fsize) {
-                Lf->off_def = 1;
-            }
-            break;
-        default:
+        if (kf_vtype == KF_VTYPE_VREG || kf_vtype == KF_VTYPE_VDIR) {
             Lf->sz = kf->kf_un.kf_file.kf_file_size;
             Lf->sz_def = 1;
         }
+        break;
+    default:
+        Lf->sz = kf->kf_un.kf_file.kf_file_size;
+        Lf->sz_def = 1;
     }
     /*
      * Record the link count.
      */
     if (Fnlink) {
         /* Read nlink from kernel if provided, otherwise call stat() */
-#if	defined(HAS_KF_FILE_NLINK)
+#if defined(HAS_KF_FILE_NLINK)
         Lf->nlink = kf->kf_un.kf_file.kf_file_nlink;
         Lf->nlink_def = 1;
 #else
@@ -675,19 +665,15 @@ void process_pipe(struct kinfo_file *kf, KA_T pa) {
     (void)snpf(dev_ch, sizeof(dev_ch), "%s",
                print_kptr(kf->kf_un.kf_pipe.kf_pipe_addr, (char *)NULL, 0));
     enter_dev_ch(dev_ch);
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
 #if __FreeBSD_version >= 1400062
-        Lf->sz = (SZOFFTYPE)kf->kf_un.kf_pipe.kf_pipe_buffer_size;
-        Lf->sz_def = 1;
+    Lf->sz = (SZOFFTYPE)kf->kf_un.kf_pipe.kf_pipe_buffer_size;
+    Lf->sz_def = 1;
 #else  /* __FreeBSD_version < 1400062 */
-        if (have_kpipe) {
-            Lf->sz = (SZOFFTYPE)p.pipe_buffer.size;
-            Lf->sz_def = 1;
-        }
-#endif /* __FreeBSD_version >= 1400062 */
+    if (have_kpipe) {
+        Lf->sz = (SZOFFTYPE)p.pipe_buffer.size;
+        Lf->sz_def = 1;
     }
+#endif /* __FreeBSD_version >= 1400062 */
     if (kf->kf_un.kf_pipe.kf_pipe_peer)
         (void)snpf(
             Namech, Namechl, "->%s",
@@ -752,7 +738,6 @@ void process_pts(struct kinfo_file *kf) {
     Lf->inode = (INODETYPE)kf->kf_un.kf_pts.kf_pts_dev;
     Lf->inp_ty = Lf->dev_def = Lf->rdev_def = 1;
     Lf->ntype = N_CHR;
-    Lf->off_def = 1;
     Lf->rdev = kf->kf_un.kf_pts.kf_pts_dev;
     DCunsafe = 1;
 }

--- a/lib/dialects/freebsd/dproc.c
+++ b/lib/dialects/freebsd/dproc.c
@@ -162,6 +162,7 @@ static void process_kinfo_file(struct kinfo_file *kf, struct xfile *xfile,
                                struct pcb_lists *pcbs,
                                struct lock_list *locks) {
     Lf->off = kf->kf_offset;
+    Lf->off_def = 1;
     if (kf->kf_ref_count) {
         if ((kf->kf_flags & (KF_FLAG_READ | KF_FLAG_WRITE)) == KF_FLAG_READ)
             Lf->access = 'r';

--- a/lib/dialects/freebsd/dproc.c
+++ b/lib/dialects/freebsd/dproc.c
@@ -165,13 +165,13 @@ static void process_kinfo_file(struct kinfo_file *kf, struct xfile *xfile,
     Lf->off_def = 1;
     if (kf->kf_ref_count) {
         if ((kf->kf_flags & (KF_FLAG_READ | KF_FLAG_WRITE)) == KF_FLAG_READ)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if ((kf->kf_flags & (KF_FLAG_READ | KF_FLAG_WRITE)) ==
                  KF_FLAG_WRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if ((kf->kf_flags & (KF_FLAG_READ | KF_FLAG_WRITE)) ==
                  (KF_FLAG_READ | KF_FLAG_WRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
     }
 
     Lf->fct = (long)kf->kf_ref_count;

--- a/lib/dialects/freebsd/dproc.c
+++ b/lib/dialects/freebsd/dproc.c
@@ -174,27 +174,19 @@ static void process_kinfo_file(struct kinfo_file *kf, struct xfile *xfile,
             Lf->access = 'u';
     }
 
-    if (Fsv & FSV_CT) {
-        Lf->fct = (long)kf->kf_ref_count;
-        Lf->fsv |= FSV_CT;
-    }
+    Lf->fct = (long)kf->kf_ref_count;
+    Lf->fsv |= FSV_CT;
     if (xfile) {
-        if (Fsv & FSV_FA) {
-            Lf->fsa = xfile->xf_file;
-            Lf->fsv |= FSV_FA;
-        }
-        if (Fsv & FSV_NI) {
-            Lf->fna = (KA_T)xfile->xf_data;
-            Lf->fsv |= FSV_NI;
-        }
+        Lf->fsa = xfile->xf_file;
+        Lf->fsv |= FSV_FA;
+        Lf->fna = (KA_T)xfile->xf_data;
+        Lf->fsv |= FSV_NI;
     }
-    if (Fsv & FSV_FG) {
-        if (xfile)
-            Lf->ffg = (long)xfile->xf_flag;
-        else
-            Lf->ffg = kf_flags_to_fflags(kf->kf_flags);
-        Lf->fsv |= FSV_FG;
-    }
+    if (xfile)
+        Lf->ffg = (long)xfile->xf_flag;
+    else
+        Lf->ffg = kf_flags_to_fflags(kf->kf_flags);
+    Lf->fsv |= FSV_FG;
 
     switch (kf->kf_type) {
     case KF_TYPE_FIFO:

--- a/lib/dialects/freebsd/dsock.c
+++ b/lib/dialects/freebsd/dsock.c
@@ -390,17 +390,14 @@ void process_socket(struct kinfo_file *kf, struct pcb_lists *pcbs) {
  * Save size information.
  */
 #if defined(HAS_KF_SOCK_SENDQ)
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_recvq;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_sendq;
-        else
-            Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_recvq +
-                     (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_sendq;
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_recvq;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_sendq;
+    else
+        Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_recvq +
+                 (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_sendq;
+    Lf->sz_def = 1;
 
 #    if defined(HASTCPTPIQ)
     Lf->lts.rq = kf->kf_un.kf_sock.kf_sock_recvq;
@@ -572,8 +569,6 @@ void process_socket(struct kinfo_file *kf, struct pcb_lists *pcbs) {
             enter_dev_ch(print_kptr((KA_T)(s->so_pcb), (char *)NULL, 0));
         else
             (void)snpf(Namech, Namechl, "no protocol control block");
-        if (!Fsize)
-            Lf->off_def = 1;
         break;
         /*
          * Process a Unix domain socket.

--- a/lib/dialects/freebsd/dsock.c
+++ b/lib/dialects/freebsd/dsock.c
@@ -390,9 +390,9 @@ void process_socket(struct kinfo_file *kf, struct pcb_lists *pcbs) {
  * Save size information.
  */
 #if defined(HAS_KF_SOCK_SENDQ)
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_recvq;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_sendq;
     else
         Lf->sz = (SZOFFTYPE)kf->kf_un.kf_sock.kf_sock_recvq +

--- a/lib/dialects/hpux/kmem/dfile.c
+++ b/lib/dialects/hpux/kmem/dfile.c
@@ -118,11 +118,11 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
          * Construct access code.
          */
         if ((flag = (f.f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
         /*
          * Process structure by its type.
          */

--- a/lib/dialects/hpux/kmem/dfile.c
+++ b/lib/dialects/hpux/kmem/dfile.c
@@ -104,22 +104,14 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         /*
          * Save file structure values.
          */
-        if (Fsv & FSV_CT) {
-            Lf->fct = (long)f.f_count;
-            Lf->fsv |= FSV_CT;
-        }
-        if (Fsv & FSV_FA) {
-            Lf->fsa = fp;
-            Lf->fsv |= FSV_FA;
-        }
-        if (Fsv & FSV_FG) {
-            Lf->ffg = (long)f.f_flag;
-            Lf->fsv |= FSV_FG;
-        }
-        if (Fsv & FSV_NI) {
-            Lf->fna = (KA_T)f.f_data;
-            Lf->fsv |= FSV_NI;
-        }
+        Lf->fct = (long)f.f_count;
+        Lf->fsv |= FSV_CT;
+        Lf->fsa = fp;
+        Lf->fsv |= FSV_FA;
+        Lf->ffg = (long)f.f_flag;
+        Lf->fsv |= FSV_FG;
+        Lf->fna = (KA_T)f.f_data;
+        Lf->fsv |= FSV_NI;
 #endif /* defined(HASFSTRUCT) */
 
         /*

--- a/lib/dialects/hpux/kmem/dfile.c
+++ b/lib/dialects/hpux/kmem/dfile.c
@@ -96,6 +96,7 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         return;
     }
     Lf->off = (SZOFFTYPE)f.f_offset;
+    Lf->off_def = 1;
 
     if (f.f_count) {
 

--- a/lib/dialects/hpux/kmem/dnode.c
+++ b/lib/dialects/hpux/kmem/dnode.c
@@ -799,7 +799,8 @@ void process_node(va) KA_T va; /* vnode kernel space address */
         }
 #    endif /* HPUXV<1000 */
 
-        if (Lf->access != 'r' && Lf->access != 'w') {
+        if (Lf->access != LSOF_FILE_ACCESS_READ &&
+            Lf->access != LSOF_FILE_ACCESS_WRITE) {
             if (fns || ins) {
                 (void)snpf(fb, sizeof(fb), "rd=%#x; wr=%#x", rp, wp);
                 (void)enter_nma(fb);
@@ -811,11 +812,13 @@ void process_node(va) KA_T va; /* vnode kernel space address */
             break;
         }
         if (fns || ins) {
-            Lf->off = (unsigned long)((Lf->access == 'r') ? rp : wp);
+            Lf->off =
+                (unsigned long)((Lf->access == LSOF_FILE_ACCESS_READ) ? rp
+                                                                      : wp);
             Lf->off_def = 1;
             (void)snpf(fb, sizeof(fb), "%s=%#x",
-                       (Lf->access == 'r') ? "rd" : "wr",
-                       (Lf->access == 'r') ? rp : wp);
+                       (Lf->access == LSOF_FILE_ACCESS_READ) ? "rd" : "wr",
+                       (Lf->access == LSOF_FILE_ACCESS_READ) ? rp : wp);
             (void)enter_nma(fb);
         }
         break;

--- a/lib/dialects/hpux/kmem/dnode.c
+++ b/lib/dialects/hpux/kmem/dnode.c
@@ -760,101 +760,94 @@ void process_node(va) KA_T va; /* vnode kernel space address */
     /*
      * Obtain the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
-
+    switch (Ntype) {
 #if defined(HAS_AFS)
-        case N_AFS:
-            Lf->sz = (SZOFFTYPE)an.size;
-            Lf->sz_def = 1;
-            break;
+    case N_AFS:
+        Lf->sz = (SZOFFTYPE)an.size;
+        Lf->sz_def = 1;
+        break;
 #endif /* defined(HAS_AFS) */
 
 #if HPUXV >= 1000
-        case N_CDFS:
-            Lf->sz = (SZOFFTYPE)c.cd_cdc.cdc_size;
+    case N_CDFS:
+        Lf->sz = (SZOFFTYPE)c.cd_cdc.cdc_size;
+        Lf->sz_def = 1;
+        break;
+    case N_PIPE:
+        if (vats) {
+            Lf->sz = (SZOFFTYPE)vat.va_size;
             Lf->sz_def = 1;
-            break;
-        case N_PIPE:
-            if (vats) {
-                Lf->sz = (SZOFFTYPE)vat.va_size;
-                Lf->sz_def = 1;
-            }
-            break;
+        }
+        break;
 #endif /* HPUXV>=1000 */
 
 #if HPUXV >= 900
-        case N_FIFO:
+    case N_FIFO:
 
 #    if HPUXV < 1000
-            if (ins) {
-                rp = i.i_frptr;
-                sz = (int)i.i_fifosize;
-                wp = i.i_fwptr;
-            } else if (rns)
-                Lf->sz = (SZOFFTYPE)r.r_nfsattr.na_size;
+        if (ins) {
+            rp = i.i_frptr;
+            sz = (int)i.i_fifosize;
+            wp = i.i_fwptr;
+        } else if (rns)
+            Lf->sz = (SZOFFTYPE)r.r_nfsattr.na_size;
 #    else  /* HPUXV>=1000 */
-            if (fns) {
-                rp = f.fn_rptr;
-                sz = f.fn_size;
-                wp = f.fn_wptr;
-            }
+        if (fns) {
+            rp = f.fn_rptr;
+            sz = f.fn_size;
+            wp = f.fn_wptr;
+        }
 #    endif /* HPUXV<1000 */
 
-            if (Fsize || (Lf->access != 'r' && Lf->access != 'w')) {
-                if (fns || ins) {
-                    (void)snpf(fb, sizeof(fb), "rd=%#x; wr=%#x", rp, wp);
-                    (void)enter_nma(fb);
-                }
-                if (fns || ins || rns) {
-                    Lf->sz = (SZOFFTYPE)sz;
-                    Lf->sz_def = 1;
-                }
-                break;
-            }
+        if (Lf->access != 'r' && Lf->access != 'w') {
             if (fns || ins) {
-                Lf->off = (unsigned long)((Lf->access == 'r') ? rp : wp);
-                (void)snpf(fb, sizeof(fb), "%s=%#x",
-                           (Lf->access == 'r') ? "rd" : "wr",
-                           (Lf->access == 'r') ? rp : wp);
+                (void)snpf(fb, sizeof(fb), "rd=%#x; wr=%#x", rp, wp);
                 (void)enter_nma(fb);
             }
-            Lf->off_def = 1;
-            break;
-#endif /* HPUXV>=900 */
-
-        case N_MVFS:
-            /* The location of the file size isn't known. */
-            break;
-        case N_NFS:
-
-#if HPUXV < 1030
-            Lf->sz = (SZOFFTYPE)r.r_nfsattr.na_size;
-#else  /* HPUXV>=1030 */
-            Lf->sz = (SZOFFTYPE)r.r_attr.va_size;
-#endif /* HPUXV<1030 */
-
-            Lf->sz_def = 1;
-            break;
-
-#if defined(HASVXFS)
-        case N_VXFS:
-            /* set in read_vxnode() */
-            break;
-#endif /* defined(HASVXFS) */
-
-        case N_SPEC:
-        case N_REGLR:
-            if ((type == VCHR || type == VBLK) && !Fsize)
-                Lf->off_def = 1;
-            else if (ins) {
-                Lf->sz = (SZOFFTYPE)i.i_size;
+            if (fns || ins || rns) {
+                Lf->sz = (SZOFFTYPE)sz;
                 Lf->sz_def = 1;
             }
             break;
         }
+        if (fns || ins) {
+            Lf->off = (unsigned long)((Lf->access == 'r') ? rp : wp);
+            Lf->off_def = 1;
+            (void)snpf(fb, sizeof(fb), "%s=%#x",
+                       (Lf->access == 'r') ? "rd" : "wr",
+                       (Lf->access == 'r') ? rp : wp);
+            (void)enter_nma(fb);
+        }
+        break;
+#endif /* HPUXV>=900 */
+
+    case N_MVFS:
+        /* The location of the file size isn't known. */
+        break;
+    case N_NFS:
+
+#if HPUXV < 1030
+        Lf->sz = (SZOFFTYPE)r.r_nfsattr.na_size;
+#else  /* HPUXV>=1030 */
+        Lf->sz = (SZOFFTYPE)r.r_attr.va_size;
+#endif /* HPUXV<1030 */
+
+        Lf->sz_def = 1;
+        break;
+
+#if defined(HASVXFS)
+    case N_VXFS:
+        /* set in read_vxnode() */
+        break;
+#endif /* defined(HASVXFS) */
+
+    case N_SPEC:
+    case N_REGLR:
+        if (!(type == VCHR || type == VBLK) && ins) {
+            Lf->sz = (SZOFFTYPE)i.i_size;
+            Lf->sz_def = 1;
+        }
+        break;
     }
     /*
      * Record link count.

--- a/lib/dialects/hpux/kmem/dnode.c
+++ b/lib/dialects/hpux/kmem/dnode.c
@@ -852,64 +852,62 @@ void process_node(va) KA_T va; /* vnode kernel space address */
     /*
      * Record link count.
      */
-    if (Fnlink) {
-        switch (Ntype) {
+    switch (Ntype) {
 
 #if defined(HAS_AFS)
-        case N_AFS:
-            Lf->nlink = an.nlink;
-            Lf->nlink_def = an.nlink_st;
-            break;
+    case N_AFS:
+        Lf->nlink = an.nlink;
+        Lf->nlink_def = an.nlink_st;
+        break;
 #endif /* defined(HAS_AFS) */
 
-        case N_MVFS:
-            /* The location of the link count isn't known. */
-            break;
-        case N_NFS:
+    case N_MVFS:
+        /* The location of the link count isn't known. */
+        break;
+    case N_NFS:
 
 #if HPUXV < 1030
-            Lf->nlink = r.r_nfsattr.na_nlink;
+        Lf->nlink = r.r_nfsattr.na_nlink;
 #else  /* HPUXV>=1030 */
-            Lf->nlink = r.r_attr.va_nlink;
+        Lf->nlink = r.r_attr.va_nlink;
 #endif /* HPUXV<1030 */
 
+        Lf->nlink_def = 1;
+        break;
+
+#if HPUXV >= 1000
+    case N_CDFS: /* no link count? */
+        break;
+#endif /* HPUXV>=1000 */
+
+    case N_FIFO:
+    case N_PIPE:
+
+#if HPUXV >= 1000
+        if (vats) {
+            Lf->nlink = (long)vat.va_nlink;
             Lf->nlink_def = 1;
-            break;
-
-#if HPUXV >= 1000
-        case N_CDFS: /* no link count? */
-            break;
+        }
 #endif /* HPUXV>=1000 */
 
-        case N_FIFO:
-        case N_PIPE:
-
-#if HPUXV >= 1000
-            if (vats) {
-                Lf->nlink = (long)vat.va_nlink;
-                Lf->nlink_def = 1;
-            }
-#endif /* HPUXV>=1000 */
-
-            break;
+        break;
 
 #if defined(HASVXFS)
-        case N_VXFS:
-            /* set in read_vxnode() */
-            break;
+    case N_VXFS:
+        /* set in read_vxnode() */
+        break;
 #endif /* defined(HASVXFS) */
 
-        case N_SPEC:
-        default:
-            if (ins) {
-                Lf->nlink = (long)i.i_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
+    case N_SPEC:
+    default:
+        if (ins) {
+            Lf->nlink = (long)i.i_nlink;
+            Lf->nlink_def = 1;
         }
-        if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
+        break;
     }
+    if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * Record an NFS file selection.
      */

--- a/lib/dialects/hpux/kmem/dnode1.c
+++ b/lib/dialects/hpux/kmem/dnode1.c
@@ -130,9 +130,7 @@ int *rdevs;        /* raw device status receiver */
     /*
      * Record size.
      */
-    if (Foffset || ((v->v_type == VCHR || v->v_type == VBLK) && !Fsize))
-        Lf->off_def = 1;
-    else {
+    if (!(v->v_type == VCHR || v->v_type == VBLK)) {
         Lf->sz = (SZOFFTYPE)i.i_size;
         Lf->sz_def = 1;
     }

--- a/lib/dialects/hpux/kmem/dnode1.c
+++ b/lib/dialects/hpux/kmem/dnode1.c
@@ -137,12 +137,10 @@ int *rdevs;        /* raw device status receiver */
     /*
      * Record link count.
      */
-    if (Fnlink) {
-        Lf->nlink = (long)i.i_nlink;
-        Lf->nlink_def = 1;
-        if (Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
-    }
+    Lf->nlink = (long)i.i_nlink;
+    Lf->nlink_def = 1;
+    if (Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     return (0);
 }
 #endif /* defined(HASVXFS) */

--- a/lib/dialects/hpux/kmem/dproc.c
+++ b/lib/dialects/hpux/kmem/dproc.c
@@ -466,8 +466,7 @@ void gather_proc_info() {
                 if (Lf->sf) {
 
 #if defined(USESPOFILE)
-                    if (Fsv & FSV_FG)
-                        Lf->pof = pof;
+                    Lf->pof = pof;
 #endif /* defined(USESPOFILE) */
 
                     link_lfile();

--- a/lib/dialects/hpux/kmem/dsock.c
+++ b/lib/dialects/hpux/kmem/dsock.c
@@ -542,16 +542,13 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
     /*
      * Save size information for HP-UX < 10.30.
      */
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
-        else
-            Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
+    else
+        Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
+    Lf->sz_def = 1;
 
 #    if defined(HASTCPTPIQ)
     Lf->lts.rq = s.so_rcv.sb_cc;
@@ -772,20 +769,17 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
         /*
          * Save size information for HP-UX 10.30 and above.
          */
-        if (Fsize) {
-            if (!s.so_rcv || kread((KA_T)s.so_rcv, (char *)&rb, sizeof(rb)))
-                rb.sb_cc = 0;
-            if (!s.so_snd || kread((KA_T)s.so_snd, (char *)&sb, sizeof(sb)))
-                sb.sb_cc = 0;
-            if (Lf->access == 'r')
-                Lf->sz = (SZOFFTYPE)rb.sb_cc;
-            else if (Lf->access == 'w')
-                Lf->sz = (SZOFFTYPE)sb.sb_cc;
-            else
-                Lf->sz = (SZOFFTYPE)(rb.sb_cc + sb.sb_cc);
-            Lf->sz_def = 1;
-        } else
-            Lf->off_def = 1;
+        if (!s.so_rcv || kread((KA_T)s.so_rcv, (char *)&rb, sizeof(rb)))
+            rb.sb_cc = 0;
+        if (!s.so_snd || kread((KA_T)s.so_snd, (char *)&sb, sizeof(sb)))
+            sb.sb_cc = 0;
+        if (Lf->access == 'r')
+            Lf->sz = (SZOFFTYPE)rb.sb_cc;
+        else if (Lf->access == 'w')
+            Lf->sz = (SZOFFTYPE)sb.sb_cc;
+        else
+            Lf->sz = (SZOFFTYPE)(rb.sb_cc + sb.sb_cc);
+        Lf->sz_def = 1;
 #endif /* HPUXV>=1030 */
 
         /*
@@ -1029,20 +1023,14 @@ enum vtype vt;                                     /* vnode type */
         Lf->lts.rqs = Lf->lts.sqs = 1;
 #        endif /* defined(HASTCPTPIQ) */
 
-        if (Fsize) {
-            if (Lf->access == 'r')
-                Lf->sz = (SZOFFTYPE)rq;
-            else if (Lf->access == 'w')
-                Lf->sz = (SZOFFTYPE)sq;
-            else
-                Lf->sz = (SZOFFTYPE)(rq + sq);
-            Lf->sz_def = 1;
-        } else
-            Lf->off_def = 1;
+        if (Lf->access == 'r')
+            Lf->sz = (SZOFFTYPE)rq;
+        else if (Lf->access == 'w')
+            Lf->sz = (SZOFFTYPE)sq;
+        else
+            Lf->sz = (SZOFFTYPE)(rq + sq);
+        Lf->sz_def = 1;
 
-#    else  /* !defined(HASTCPTPIQ) && !defined(HASTCPTPIW) */
-        if (!Fsize)
-            Lf->off_def = 1;
 #    endif /* defined(HASTCPTPIQ) || defined(HASTCPTPIW) */
 
 #    if defined(HASTCPOPT)
@@ -1123,8 +1111,6 @@ enum vtype vt;                                     /* vnode type */
         }
         (void)ent_inaddr(la, (int)ntohs(pt), (unsigned char *)NULL, -1,
                          AF_INET);
-        if (!Fsize)
-            Lf->off_def = 1;
         Lf->lts.type = 1;
         Lf->lts.state.ui = (unsigned int)ud.udp_state;
         Namech[0] = '\0';

--- a/lib/dialects/hpux/kmem/dsock.c
+++ b/lib/dialects/hpux/kmem/dsock.c
@@ -1034,52 +1034,47 @@ enum vtype vt;                                     /* vnode type */
 #    endif /* defined(HASTCPTPIQ) || defined(HASTCPTPIW) */
 
 #    if defined(HASTCPOPT)
-        if (Ftcptpi & TCPTPI_FLAGS) {
 
-            /*
-             * Save TCP options and values..
-             */
-            if (tc.tcp_naglim == (uint)1)
-                Lf->lts.topt |= TF_NODELAY;
-            Lf->lts.mss = (unsigned long)tc.tcp_mss;
-            Lf->lts.msss = (unsigned char)1;
-        }
+        /*
+         * Save TCP options and values..
+         */
+        if (tc.tcp_naglim == (uint)1)
+            Lf->lts.topt |= TF_NODELAY;
+        Lf->lts.mss = (unsigned long)tc.tcp_mss;
+        Lf->lts.msss = (unsigned char)1;
 #    endif /* defined(HASTCPOPT) */
 
 #    if defined(HASSOOPT)
-        if (Ftcptpi & TCPTPI_FLAGS) {
 
-            /*
-             * Save socket options.
-             */
-            if (tc.tcp_broadcast)
-                Lf->lts.opt |= SO_BROADCAST;
-            if (tc.tcp_so_debug)
-                Lf->lts.opt |= SO_DEBUG;
-            if (tc.tcp_dontroute)
-                Lf->lts.opt |= SO_DONTROUTE;
-            if (tc.tcp_keepalive_intrvl &&
-                (tc.tcp_keepalive_intrvl != 7200000)) {
-                Lf->lts.opt |= SO_KEEPALIVE;
-                Lf->lts.kai = (unsigned int)tc.tcp_keepalive_intrvl;
-            }
-            if (tc.tcp_lingering) {
-                Lf->lts.opt |= SO_LINGER;
-                Lf->lts.ltm = (unsigned int)tc.tcp_linger;
-            }
-            if (tc.tcp_oobinline)
-                Lf->lts.opt |= SO_OOBINLINE;
-            if (tc.tcp_reuseaddr)
-                Lf->lts.opt |= SO_REUSEADDR;
-            if (tc.tcp_reuseport)
-                Lf->lts.opt |= SO_REUSEPORT;
-            if (tc.tcp_useloopback)
-                Lf->lts.opt |= SO_USELOOPBACK;
-            Lf->lts.qlen = (unsigned int)tc.tcp_conn_ind_cnt;
-            Lf->lts.qlim = (unsigned int)tc.tcp_conn_ind_max;
-            if (Lf->lts.qlen || Lf->lts.qlim)
-                Lf->lts.qlens = Lf->lts.qlims = (unsigned char)1;
+        /*
+         * Save socket options.
+         */
+        if (tc.tcp_broadcast)
+            Lf->lts.opt |= SO_BROADCAST;
+        if (tc.tcp_so_debug)
+            Lf->lts.opt |= SO_DEBUG;
+        if (tc.tcp_dontroute)
+            Lf->lts.opt |= SO_DONTROUTE;
+        if (tc.tcp_keepalive_intrvl && (tc.tcp_keepalive_intrvl != 7200000)) {
+            Lf->lts.opt |= SO_KEEPALIVE;
+            Lf->lts.kai = (unsigned int)tc.tcp_keepalive_intrvl;
         }
+        if (tc.tcp_lingering) {
+            Lf->lts.opt |= SO_LINGER;
+            Lf->lts.ltm = (unsigned int)tc.tcp_linger;
+        }
+        if (tc.tcp_oobinline)
+            Lf->lts.opt |= SO_OOBINLINE;
+        if (tc.tcp_reuseaddr)
+            Lf->lts.opt |= SO_REUSEADDR;
+        if (tc.tcp_reuseport)
+            Lf->lts.opt |= SO_REUSEPORT;
+        if (tc.tcp_useloopback)
+            Lf->lts.opt |= SO_USELOOPBACK;
+        Lf->lts.qlen = (unsigned int)tc.tcp_conn_ind_cnt;
+        Lf->lts.qlim = (unsigned int)tc.tcp_conn_ind_max;
+        if (Lf->lts.qlen || Lf->lts.qlim)
+            Lf->lts.qlens = Lf->lts.qlims = (unsigned char)1;
 #    endif /* defined(HASSOOPT) */
 
         Namech[0] = '\0';

--- a/lib/dialects/hpux/kmem/dsock.c
+++ b/lib/dialects/hpux/kmem/dsock.c
@@ -429,11 +429,11 @@ void process_lla(la) KA_T la; /* link level CB address in kernel */
      * Determine access mode.
      */
     if ((lcb.lla_flags & LLA_FWRITE | LLA_FREAD) == LLA_FWRITE)
-        Lf->access = 'w';
+        Lf->access = LSOF_FILE_ACCESS_WRITE;
     else if ((lcb.lla_flags & LLA_FWRITE | LLA_FREAD) == LLA_FREAD)
-        Lf->access = 'r';
+        Lf->access = LSOF_FILE_ACCESS_READ;
     else if (lcb.lla_flags & LLA_FWRITE | LLA_FREAD)
-        Lf->access = 'u';
+        Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
     /*
      * Determine the open mode, if possible.
      */
@@ -542,9 +542,9 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
     /*
      * Save size information for HP-UX < 10.30.
      */
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
     else
         Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
@@ -773,9 +773,9 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
             rb.sb_cc = 0;
         if (!s.so_snd || kread((KA_T)s.so_snd, (char *)&sb, sizeof(sb)))
             sb.sb_cc = 0;
-        if (Lf->access == 'r')
+        if (Lf->access == LSOF_FILE_ACCESS_READ)
             Lf->sz = (SZOFFTYPE)rb.sb_cc;
-        else if (Lf->access == 'w')
+        else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
             Lf->sz = (SZOFFTYPE)sb.sb_cc;
         else
             Lf->sz = (SZOFFTYPE)(rb.sb_cc + sb.sb_cc);
@@ -1023,9 +1023,9 @@ enum vtype vt;                                     /* vnode type */
         Lf->lts.rqs = Lf->lts.sqs = 1;
 #        endif /* defined(HASTCPTPIQ) */
 
-        if (Lf->access == 'r')
+        if (Lf->access == LSOF_FILE_ACCESS_READ)
             Lf->sz = (SZOFFTYPE)rq;
-        else if (Lf->access == 'w')
+        else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
             Lf->sz = (SZOFFTYPE)sq;
         else
             Lf->sz = (SZOFFTYPE)(rq + sq);

--- a/lib/dialects/hpux/pstat/dfile.c
+++ b/lib/dialects/hpux/pstat/dfile.c
@@ -724,19 +724,14 @@ KA_T na;                /* node address */
      * If no offset has been activated and no size saved, activate the offset or
      * save the size.
      */
-    if (!Lf->off_def && !Lf->sz_def) {
-        if (Foffset)
-            Lf->off_def = 1;
-        else {
-            switch (Ntype) {
-            case N_CHR:
-            case N_FIFO:
-                Lf->off_def = 1;
-                break;
-            default:
-                Lf->sz = (SZOFFTYPE)pd->psfd_size;
-                Lf->sz_def = 1;
-            }
+    if (!Lf->sz_def) {
+        switch (Ntype) {
+        case N_CHR:
+        case N_FIFO:
+            break;
+        default:
+            Lf->sz = (SZOFFTYPE)pd->psfd_size;
+            Lf->sz_def = 1;
         }
     }
     /*

--- a/lib/dialects/hpux/pstat/dfile.c
+++ b/lib/dialects/hpux/pstat/dfile.c
@@ -617,7 +617,7 @@ KA_T na;                /* node address */
     /*
      * Save node ID.
      */
-    if (na && (Fsv & FSV_NI)) {
+    if (na) {
         Lf->fna = na;
         Lf->fsv |= FSV_NI;
     }

--- a/lib/dialects/hpux/pstat/dfile.c
+++ b/lib/dialects/hpux/pstat/dfile.c
@@ -692,16 +692,14 @@ KA_T na;                /* node address */
     /*
      * Save link count.
      */
-    if (Fnlink) {
 
-        /*
-         * Ignore a zero link count only if the file is a FIFO.
-         */
-        if ((Lf->nlink = (long)pd->psfd_nlink) || (Ntype != N_FIFO))
-            Lf->nlink_def = 1;
-        if (Lf->nlink_def && Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
-    }
+    /*
+     * Ignore a zero link count only if the file is a FIFO.
+     */
+    if ((Lf->nlink = (long)pd->psfd_nlink) || (Ntype != N_FIFO))
+        Lf->nlink_def = 1;
+    if (Lf->nlink_def && Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * Save file system identity.
      */

--- a/lib/dialects/hpux/pstat/dproc.c
+++ b/lib/dialects/hpux/pstat/dproc.c
@@ -362,6 +362,7 @@ void gather_proc_info() {
 #else  /* !defined(_PSTAT64) */
             Lf->off = (SZOFFTYPE)f->psf_offset;
 #endif /* defined(_PSTAT64) */
+            Lf->off_def = 1;
 
             /*
              * Process the file by its type.

--- a/lib/dialects/hpux/pstat/dproc.c
+++ b/lib/dialects/hpux/pstat/dproc.c
@@ -325,11 +325,11 @@ void gather_proc_info() {
              * Construct access code.
              */
             if ((flag = (long)(f->psf_flag & ~PS_FEXCLOS)) == (long)PS_FRDONLY)
-                Lf->access = 'r';
+                Lf->access = LSOF_FILE_ACCESS_READ;
             else if (flag == (long)PS_FWRONLY)
-                Lf->access = 'w';
+                Lf->access = LSOF_FILE_ACCESS_WRITE;
             else
-                Lf->access = 'u';
+                Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
 
 #if defined(HASFSTRUCT)
             /*

--- a/lib/dialects/hpux/pstat/dproc.c
+++ b/lib/dialects/hpux/pstat/dproc.c
@@ -335,20 +335,14 @@ void gather_proc_info() {
             /*
              * Save file structure values.
              */
-            if (Fsv & FSV_CT) {
-                Lf->fct = (long)f->psf_count;
-                Lf->fsv |= FSV_CT;
-            }
-            if (Fsv & FSV_FA) {
-                ka = (((KA_T)(f->psf_hi_fileid & 0xffffffff) << 32) |
-                      (KA_T)(f->psf_lo_fileid & 0xffffffff));
-                if ((Lf->fsa = ka))
-                    Lf->fsv |= FSV_FA;
-            }
-            if (Fsv & FSV_FG) {
-                Lf->ffg = flag;
-                Lf->fsv |= FSV_FG;
-            }
+            Lf->fct = (long)f->psf_count;
+            Lf->fsv |= FSV_CT;
+            ka = (((KA_T)(f->psf_hi_fileid & 0xffffffff) << 32) |
+                  (KA_T)(f->psf_lo_fileid & 0xffffffff));
+            if ((Lf->fsa = ka))
+                Lf->fsv |= FSV_FA;
+            Lf->ffg = flag;
+            Lf->fsv |= FSV_FG;
             Lf->pof = (long)(f->psf_flag & PS_FEXCLOS);
 #endif /* defined(HASFSTRUCT) */
 

--- a/lib/dialects/hpux/pstat/dsock.c
+++ b/lib/dialects/hpux/pstat/dsock.c
@@ -1067,16 +1067,13 @@ struct pst_socket *s; /* optional socket information
     /*
      * Save size information, as requested.
      */
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)s->pst_idata;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)s->pst_odata;
-        else
-            Lf->sz = (SZOFFTYPE)(s->pst_idata + s->pst_odata);
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)s->pst_idata;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)s->pst_odata;
+    else
+        Lf->sz = (SZOFFTYPE)(s->pst_idata + s->pst_odata);
+    Lf->sz_def = 1;
 
 #if defined(HASTCPTPIQ)
     /*
@@ -1468,18 +1465,16 @@ int ckscko; /* socket file only checking
     /*
      * Enter size from stream head's structure, if requested.
      */
-    if (Fsize) {
-        if (Lf->access == 'r') {
-            Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_rbytes;
-            Lf->sz_def = 1;
-        } else if (Lf->access == 'w') {
-            Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_wbytes;
-            Lf->sz_def = 1;
-        } else if (Lf->access == 'u') {
-            Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_rbytes +
-                     (SZOFFTYPE)s[hx].val.head.pst_wbytes;
-            Lf->sz_def = 1;
-        }
+    if (Lf->access == 'r') {
+        Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_rbytes;
+        Lf->sz_def = 1;
+    } else if (Lf->access == 'w') {
+        Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_wbytes;
+        Lf->sz_def = 1;
+    } else if (Lf->access == 'u') {
+        Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_rbytes +
+                 (SZOFFTYPE)s[hx].val.head.pst_wbytes;
+        Lf->sz_def = 1;
     }
     /*
      * Get the the device number from the stream head.
@@ -1568,8 +1563,6 @@ int ckscko; /* socket file only checking
      */
     Lf->ntype = N_STREAM;
     Lf->is_stream = 1;
-    if (!Fsize || (Fsize && !Lf->sz_def))
-        Lf->off_def = 1;
     /*
      * Test for specified file.
      */

--- a/lib/dialects/hpux/pstat/dsock.c
+++ b/lib/dialects/hpux/pstat/dsock.c
@@ -1065,9 +1065,9 @@ struct pst_socket *s; /* optional socket information
     /*
      * Save size information, as requested.
      */
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)s->pst_idata;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)s->pst_odata;
     else
         Lf->sz = (SZOFFTYPE)(s->pst_idata + s->pst_odata);
@@ -1463,13 +1463,13 @@ int ckscko; /* socket file only checking
     /*
      * Enter size from stream head's structure, if requested.
      */
-    if (Lf->access == 'r') {
+    if (Lf->access == LSOF_FILE_ACCESS_READ) {
         Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_rbytes;
         Lf->sz_def = 1;
-    } else if (Lf->access == 'w') {
+    } else if (Lf->access == LSOF_FILE_ACCESS_WRITE) {
         Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_wbytes;
         Lf->sz_def = 1;
-    } else if (Lf->access == 'u') {
+    } else if (Lf->access == LSOF_FILE_ACCESS_READ_WRITE) {
         Lf->sz = (SZOFFTYPE)s[hx].val.head.pst_rbytes +
                  (SZOFFTYPE)s[hx].val.head.pst_wbytes;
         Lf->sz_def = 1;

--- a/lib/dialects/hpux/pstat/dsock.c
+++ b/lib/dialects/hpux/pstat/dsock.c
@@ -1056,11 +1056,9 @@ struct pst_socket *s; /* optional socket information
                 (KA_T)(f->psf_lo_nodeid & 0xffffffff));
 
 #if defined(HASFSTRUCT)
-    if (na && (Fsv & FSV_NI)) {
-        if (na) {
-            Lf->fna = na;
-            Lf->fsv |= FSV_NI;
-        }
+    if (na) {
+        Lf->fna = na;
+        Lf->fsv |= FSV_NI;
     }
 #endif /* defined(HASFSTRUCT) */
 
@@ -1366,7 +1364,7 @@ int ckscko; /* socket file only checking
                 (KA_T)(f->psf_lo_nodeid & 0xffffffff));
 
 #if defined(HASFSTRUCT)
-    if (na && (Fsv & FSV_NI)) {
+    if (na) {
         Lf->fna = na;
         Lf->fsv |= FSV_NI;
     }

--- a/lib/dialects/linux/dnode.c
+++ b/lib/dialects/linux/dnode.c
@@ -812,7 +812,7 @@ int ls;                             /* *l status -- i.e., SB_* values */
     /*
      * Record the link count.
      */
-    if (Fnlink && (ss & SB_NLINK)) {
+    if (ss & SB_NLINK) {
         Lf->nlink = (long)s->st_nlink;
         Lf->nlink_def = 1;
         if (Nlink && (Lf->nlink < Nlink))

--- a/lib/dialects/linux/dnode.c
+++ b/lib/dialects/linux/dnode.c
@@ -794,22 +794,19 @@ int ls;                             /* *l status -- i.e., SB_* values */
     case N_BLK:
     case N_CHR:
     case N_FIFO:
-        if (!Fsize && l && (ls & SB_SIZE) && OffType != OFFSET_UNKNOWN) {
+        if (l && (ls & SB_SIZE) && OffType != OFFSET_UNKNOWN) {
             Lf->off = (SZOFFTYPE)l->st_size;
             Lf->off_def = 1;
         }
         break;
     default:
-        if (Foffset) {
-            if (l && (ls & SB_SIZE) && OffType != OFFSET_UNKNOWN) {
-                Lf->off = (SZOFFTYPE)l->st_size;
-                Lf->off_def = 1;
-            }
-        } else if (!Foffset || Fsize) {
-            if (ss & SB_SIZE) {
-                Lf->sz = (SZOFFTYPE)s->st_size;
-                Lf->sz_def = 1;
-            }
+        if (l && (ls & SB_SIZE) && OffType != OFFSET_UNKNOWN) {
+            Lf->off = (SZOFFTYPE)l->st_size;
+            Lf->off_def = 1;
+        }
+        if (ss & SB_SIZE) {
+            Lf->sz = (SZOFFTYPE)s->st_size;
+            Lf->sz_def = 1;
         }
     }
     /*

--- a/lib/dialects/linux/dnode.c
+++ b/lib/dialects/linux/dnode.c
@@ -701,11 +701,11 @@ int ls;                             /* *l status -- i.e., SB_* values */
      */
     if (l && (ls & SB_MODE) && ((l->st_mode & S_IFMT) == S_IFLNK)) {
         if ((access = l->st_mode & (S_IRUSR | S_IWUSR)) == S_IRUSR)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (access == S_IWUSR)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
     }
     /*
      * Determine node type.

--- a/lib/dialects/linux/dproc.c
+++ b/lib/dialects/linux/dproc.c
@@ -1289,7 +1289,7 @@ char *tcmd;  /* task command, if non-NULL) */
                     ls &= ~SB_SIZE;
 
 #if !defined(HASNOFSFLAGS)
-                if ((av & FDINFO_FLAGS) && (Fsv & FSV_FG)) {
+                if (av & FDINFO_FLAGS) {
                     if (efs) {
                         lfr->ffg = (long)fi.flags;
                         lfr->fsv |= FSV_FG;

--- a/lib/dialects/linux/dproc.c
+++ b/lib/dialects/linux/dproc.c
@@ -1279,10 +1279,8 @@ char *tcmd;  /* task command, if non-NULL) */
 
                 if ((av = get_fdinfo(pathi, fdinfo_mask, &fi)) & FDINFO_POS) {
                     if (efs) {
-                        if (Foffset) {
-                            lfr->off = (SZOFFTYPE)fi.pos;
-                            lfr->off_def = 1;
-                        }
+                        lfr->off = (SZOFFTYPE)fi.pos;
+                        lfr->off_def = 1;
                     } else {
                         ls |= SB_SIZE;
                         lsb.st_size = fi.pos;

--- a/lib/dialects/linux/dsock.c
+++ b/lib/dialects/linux/dsock.c
@@ -1073,7 +1073,7 @@ static void prt_uxs(uxsin_t *p, /* peer info */
                 break;
         }
         (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim,
-                   ep->cmd, &ef->fd[i], ef->access);
+                   ep->cmd, &ef->fd[i], print_access(ef->access));
         (void)add_nma(nma, strlen(nma));
         if (mk && FeptE == 2) {
 
@@ -1235,7 +1235,7 @@ static void prt_nets_common(void *p, /* peer info */
                 break;
         }
         (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim,
-                   ep->cmd, &ef->fd[i], ef->access);
+                   ep->cmd, &ef->fd[i], print_access(ef->access));
         (void)add_nma(nma, strlen(nma));
         if (mk && FeptE == 2) {
 

--- a/lib/dialects/linux/dsock.c
+++ b/lib/dialects/linux/dsock.c
@@ -1073,7 +1073,7 @@ static void prt_uxs(uxsin_t *p, /* peer info */
                 break;
         }
         (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim,
-                   ep->cmd, &ef->fd[i], print_access(ef->access));
+                   ep->cmd, &ef->fd[i], access_to_char(ef->access));
         (void)add_nma(nma, strlen(nma));
         if (mk && FeptE == 2) {
 
@@ -1235,7 +1235,7 @@ static void prt_nets_common(void *p, /* peer info */
                 break;
         }
         (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim,
-                   ep->cmd, &ef->fd[i], print_access(ef->access));
+                   ep->cmd, &ef->fd[i], access_to_char(ef->access));
         (void)add_nma(nma, strlen(nma));
         if (mk && FeptE == 2) {
 

--- a/lib/dialects/linux/dsock.c
+++ b/lib/dialects/linux/dsock.c
@@ -3536,11 +3536,9 @@ void process_proc_sock(char *p,        /* node's readlink() path */
     /*
      * Enter offset, if possible.
      */
-    if (Foffset || !Fsize) {
-        if (l && (lss & SB_SIZE) && OffType != OFFSET_UNKNOWN) {
-            Lf->off = (SZOFFTYPE)l->st_size;
-            Lf->off_def = 1;
-        }
+    if (l && (lss & SB_SIZE) && OffType != OFFSET_UNKNOWN) {
+        Lf->off = (SZOFFTYPE)l->st_size;
+        Lf->off_def = 1;
     }
 
     /*

--- a/lib/dialects/netbsd/dnode.c
+++ b/lib/dialects/netbsd/dnode.c
@@ -905,143 +905,135 @@ process_overlaid_node:
     /*
      * Obtain the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
-
+    switch (Ntype) {
 #if defined(HAS9660FS)
-        case N_CDFS:
-            if (iso_stat) {
-                Lf->sz = (SZOFFTYPE)iso_sz;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_CDFS:
+        if (iso_stat) {
+            Lf->sz = (SZOFFTYPE)iso_sz;
+            Lf->sz_def = 1;
+        }
+        break;
 #endif /* defined(HAS9660FS) */
 
-        case N_FIFO:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_FIFO:
+        break;
 
 #if defined(HASKERNFS)
-        case N_KERN:
-            if (ksbs) {
-                Lf->sz = (SZOFFTYPE)ksb.st_size;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_KERN:
+        if (ksbs) {
+            Lf->sz = (SZOFFTYPE)ksb.st_size;
+            Lf->sz_def = 1;
+        }
+        break;
 #endif /* defined(HASKERNFS) */
 
-        case N_NFS:
-            if (nty == NFSNODE) {
-                Lf->sz = (SZOFFTYPE)NVATTR.va_size;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_NFS:
+        if (nty == NFSNODE) {
+            Lf->sz = (SZOFFTYPE)NVATTR.va_size;
+            Lf->sz_def = 1;
+        }
+        break;
 
 #if defined(HASPROCFS)
-        case N_PROC:
-            if (nty == PFSNODE) {
-                switch (p.pfs_type) {
-                case Proot:
-                case Pproc:
-                    Lf->sz = (SZOFFTYPE)DEV_BSIZE;
-                    Lf->sz_def = 1;
-                    break;
-                case Pcurproc:
-                    Lf->sz = (SZOFFTYPE)DEV_BSIZE;
-                    Lf->sz_def = 1;
-                    break;
-                case Pmem:
-                    (void)getmemsz(p.pfs_pid);
-                    break;
-                case Pregs:
-                    Lf->sz = (SZOFFTYPE)sizeof(struct reg);
-                    Lf->sz_def = 1;
-                    break;
+    case N_PROC:
+        if (nty == PFSNODE) {
+            switch (p.pfs_type) {
+            case Proot:
+            case Pproc:
+                Lf->sz = (SZOFFTYPE)DEV_BSIZE;
+                Lf->sz_def = 1;
+                break;
+            case Pcurproc:
+                Lf->sz = (SZOFFTYPE)DEV_BSIZE;
+                Lf->sz_def = 1;
+                break;
+            case Pmem:
+                (void)getmemsz(p.pfs_pid);
+                break;
+            case Pregs:
+                Lf->sz = (SZOFFTYPE)sizeof(struct reg);
+                Lf->sz_def = 1;
+                break;
 
 #    if defined(FP_QSIZE)
-                case Pfpregs:
-                    Lf->sz = (SZOFFTYPE)sizeof(struct fpreg);
-                    Lf->sz_def = 1;
-                    break;
+            case Pfpregs:
+                Lf->sz = (SZOFFTYPE)sizeof(struct fpreg);
+                Lf->sz_def = 1;
+                break;
 #    endif /* defined(FP_QSIZE) */
-                }
             }
-            break;
+        }
+        break;
 #endif /* defined(HASPROCFS) */
 
-        case N_REGLR:
-            if (type == VREG || type == VDIR) {
-                switch (nty) {
-                case INODE:
+    case N_REGLR:
+        if (type == VREG || type == VDIR) {
+            switch (nty) {
+            case INODE:
 
 #if defined(HASI_FFS)
 
-                    Lf->sz = (SZOFFTYPE)i.i_ffs_size;
-                    Lf->sz_def = 1;
-                    break;
+                Lf->sz = (SZOFFTYPE)i.i_ffs_size;
+                Lf->sz_def = 1;
+                break;
 #else /* !defined(HASI_FFS) */
 #    if defined(HASI_FFS1)
 
-                    if (ffs == 1) {
-                        if (u1s) {
-                            Lf->sz = (SZOFFTYPE)u1.di_size;
-                            Lf->sz_def = 1;
-                        }
-                    } else if (ffs == 2) {
-                        if (u2s) {
-                            Lf->sz = (SZOFFTYPE)u2.di_size;
-                            Lf->sz_def = 1;
-                        }
+                if (ffs == 1) {
+                    if (u1s) {
+                        Lf->sz = (SZOFFTYPE)u1.di_size;
+                        Lf->sz_def = 1;
                     }
-                    break;
+                } else if (ffs == 2) {
+                    if (u2s) {
+                        Lf->sz = (SZOFFTYPE)u2.di_size;
+                        Lf->sz_def = 1;
+                    }
+                }
+                break;
 #    else  /* !defined(HASI_FFS1) */
-                    Lf->sz = (SZOFFTYPE)i.i_size;
-                    Lf->sz_def = 1;
+                Lf->sz = (SZOFFTYPE)i.i_size;
+                Lf->sz_def = 1;
 #    endif /* defined(HASI_FFS1) */
 #endif     /* defined(HASI_FFS) */
 
-                    break;
+                break;
 
 #if defined(HASMSDOSFS)
-                case DOSNODE:
-                    Lf->sz = (SZOFFTYPE)d.de_FileSize;
-                    Lf->sz_def = 1;
-                    break;
+            case DOSNODE:
+                Lf->sz = (SZOFFTYPE)d.de_FileSize;
+                Lf->sz_def = 1;
+                break;
 #endif /* defined(HASMSDOSFS) */
 
-                case MFSNODE:
-                    Lf->sz = (SZOFFTYPE)m.mfs_size;
-                    Lf->sz_def = 1;
-                    break;
+            case MFSNODE:
+                Lf->sz = (SZOFFTYPE)m.mfs_size;
+                Lf->sz_def = 1;
+                break;
 
 #if defined(HASTMPFS)
-                case TMPFSNODE:
-                    Lf->sz = (SZOFFTYPE)tmp.tn_size;
-                    Lf->sz_def = 1;
-                    break;
+            case TMPFSNODE:
+                Lf->sz = (SZOFFTYPE)tmp.tn_size;
+                Lf->sz_def = 1;
+                break;
 #endif /* defined(HASTMPFS) */
 
 #if defined(HASEXT2FS)
-                case EXT2NODE:
+            case EXT2NODE:
 #    if defined(HASI_E2FS_PTR)
-                    if (edp) {
-                        Lf->sz = (SZOFFTYPE)edp->e2di_size;
-                        Lf->sz_def = 1;
-                    }
-#    else  /* !defined(HASI_E2FS_PTR) */
-                    Lf->sz = (SZOFFTYPE)i.i_e2fs_size;
+                if (edp) {
+                    Lf->sz = (SZOFFTYPE)edp->e2di_size;
                     Lf->sz_def = 1;
-#    endif /* defined(HASI_E2FS_PTR) */
-                    break;
-#endif /* defined(HASEXT2FS) */
                 }
-            } else if ((type == VCHR || type == VBLK) && !Fsize)
-                Lf->off_def = 1;
-            break;
+#    else  /* !defined(HASI_E2FS_PTR) */
+                Lf->sz = (SZOFFTYPE)i.i_e2fs_size;
+                Lf->sz_def = 1;
+#    endif /* defined(HASI_E2FS_PTR) */
+                break;
+#endif /* defined(HASEXT2FS) */
+            }
         }
+        break;
     }
     /*
      * Record the link count.
@@ -1427,12 +1419,8 @@ void process_pipe(pa) KA_T pa; /* pipe structure kernel address */
     }
     (void)snpf(Lf->type, sizeof(Lf->type), "PIPE");
     enter_dev_ch(print_kptr(pa, (char *)NULL, 0));
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        Lf->sz = (SZOFFTYPE)p.pipe_buffer.size;
-        Lf->sz_def = 1;
-    }
+    Lf->sz = (SZOFFTYPE)p.pipe_buffer.size;
+    Lf->sz_def = 1;
     if (p.pipe_peer)
         (void)snpf(Namech, Namechl, "->%s",
                    print_kptr((KA_T)p.pipe_peer, (char *)NULL, 0));

--- a/lib/dialects/netbsd/dnode.c
+++ b/lib/dialects/netbsd/dnode.c
@@ -1038,89 +1038,87 @@ process_overlaid_node:
     /*
      * Record the link count.
      */
-    if (Fnlink) {
-        switch (Ntype) {
+    switch (Ntype) {
 
 #if defined(HAS9660FS)
-        case N_CDFS:
-            if (iso_stat) {
-                Lf->nlink = iso_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
+    case N_CDFS:
+        if (iso_stat) {
+            Lf->nlink = iso_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
 #endif /* defined(HAS9660FS) */
 
 #if defined(HASKERNFS)
-        case N_KERN:
-            if (ksbs) {
-                Lf->nlink = (long)ksb.st_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
+    case N_KERN:
+        if (ksbs) {
+            Lf->nlink = (long)ksb.st_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
 #endif /* defined(HASKERNFS) */
 
-        case N_NFS:
-            if (nty == NFSNODE) {
-                Lf->nlink = (long)NVATTR.va_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
-        case N_REGLR:
-            switch (nty) {
-            case INODE:
+    case N_NFS:
+        if (nty == NFSNODE) {
+            Lf->nlink = (long)NVATTR.va_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
+    case N_REGLR:
+        switch (nty) {
+        case INODE:
 
 #if defined(HASEFFNLINK)
-                Lf->nlink = (long)i.HASEFFNLINK;
+            Lf->nlink = (long)i.HASEFFNLINK;
 #else /* !defined(HASEFFNLINK) */
 #    if defined(HASI_FFS)
-                Lf->nlink = (long)i.i_ffs_nlink;
+            Lf->nlink = (long)i.i_ffs_nlink;
 #    else /* !defined(HASI_FFS) */
 #        if defined(HASI_FFS1)
-                if (ffs == 1) {
-                    if (u1s)
-                        Lf->nlink = (long)u1.di_nlink;
-                } else if (ffs == 2) {
-                    if (u2s)
-                        Lf->nlink = (long)u2.di_nlink;
-                }
+            if (ffs == 1) {
+                if (u1s)
+                    Lf->nlink = (long)u1.di_nlink;
+            } else if (ffs == 2) {
+                if (u2s)
+                    Lf->nlink = (long)u2.di_nlink;
+            }
 #        else  /* !defined(HASI_FFS1) */
 
-                Lf->nlink = (long)i.i_nlink;
+            Lf->nlink = (long)i.i_nlink;
 #        endif /* defined(HASI_FFS1) */
 #    endif     /* defined(HASI_FFS) */
 #endif         /* defined(HASEFFNLINK) */
 
-                Lf->nlink_def = 1;
-                break;
+            Lf->nlink_def = 1;
+            break;
 
 #if defined(HASMSDOSFS)
-            case DOSNODE:
-                Lf->nlink = (long)d.de_refcnt;
-                Lf->nlink_def = 1;
-                break;
+        case DOSNODE:
+            Lf->nlink = (long)d.de_refcnt;
+            Lf->nlink_def = 1;
+            break;
 #endif /* defined(HASMSDOSFS) */
 
 #if defined(HASEXT2FS)
-            case EXT2NODE:
+        case EXT2NODE:
 #    if defined(HASI_E2FS_PTR)
-                if (edp) {
-                    Lf->nlink = (long)edp->e2di_nlink;
-                    Lf->nlink_def = 1;
-                }
-#    else  /* !defined(HASI_E2FS_PTR) */
-                Lf->nlink = (long)i.i_e2fs_nlink;
+            if (edp) {
+                Lf->nlink = (long)edp->e2di_nlink;
                 Lf->nlink_def = 1;
+            }
+#    else  /* !defined(HASI_E2FS_PTR) */
+            Lf->nlink = (long)i.i_e2fs_nlink;
+            Lf->nlink_def = 1;
 #    endif /* defined(HASI_E2FS_PTR) */
 
-                break;
+            break;
 
 #endif /* defined(HASEXT2FS) */
-            }
-            break;
         }
-        if (Lf->nlink_def && Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
+        break;
     }
+    if (Lf->nlink_def && Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * Record an NFS file selection.
      */

--- a/lib/dialects/netbsd/dproc.c
+++ b/lib/dialects/netbsd/dproc.c
@@ -305,26 +305,24 @@ void gather_proc_info() {
             continue;
 
 #if defined(HASFSTRUCT)
-        if (Fsv & FSV_FG) {
-            nb = (MALLOC_S)(sizeof(char) * nf);
-            if (nb > pofb) {
-                if (!pof)
-                    pof = (char *)malloc(nb);
-                else
-                    pof = (char *)realloc((MALLOC_P *)pof, nb);
-                if (!pof) {
-                    (void)fprintf(stderr, "%s: PID %d, no file flag space\n",
-                                  Pn, p->P_PID);
-                    Error();
-                }
-                pofb = nb;
+        nb = (MALLOC_S)(sizeof(char) * nf);
+        if (nb > pofb) {
+            if (!pof)
+                pof = (char *)malloc(nb);
+            else
+                pof = (char *)realloc((MALLOC_P *)pof, nb);
+            if (!pof) {
+                (void)fprintf(stderr, "%s: PID %d, no file flag space\n", Pn,
+                              p->P_PID);
+                Error();
             }
-#    if !HAVE_STRUCT_FDFILE
-            if (!fd.fd_ofileflags || kread((KA_T)fd.fd_ofileflags, pof, nb))
-                zeromem(pof, nb);
-#    endif /* ! HAVE_STRUCT_FDFILE */
+            pofb = nb;
         }
-#endif /* defined(HASFSTRUCT) */
+#    if !HAVE_STRUCT_FDFILE
+        if (!fd.fd_ofileflags || kread((KA_T)fd.fd_ofileflags, pof, nb))
+            zeromem(pof, nb);
+#    endif /* ! HAVE_STRUCT_FDFILE */
+#endif     /* defined(HASFSTRUCT) */
 
         /*
          * Save information on file descriptors.
@@ -348,8 +346,7 @@ void gather_proc_info() {
                 if (Lf->sf) {
 
 #if defined(HASFSTRUCT)
-                    if (Fsv & FSV_FG)
-                        Lf->pof = (long)pof[i];
+                    Lf->pof = (long)pof[i];
 #endif /* defined(HASFSTRUCT) */
 
                     link_lfile();

--- a/lib/dialects/netbsd/dsock.c
+++ b/lib/dialects/netbsd/dsock.c
@@ -125,16 +125,13 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
     /*
      * Save size information.
      */
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
-        else
-            Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
+    else
+        Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);
+    Lf->sz_def = 1;
 
 #if defined(HASTCPTPIQ)
     Lf->lts.rq = s.so_rcv.sb_cc;
@@ -341,8 +338,6 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
             enter_dev_ch(print_kptr((KA_T)(s.so_pcb), (char *)NULL, 0));
         else
             (void)snpf(Namech, Namechl, "no protocol control block");
-        if (!Fsize)
-            Lf->off_def = 1;
         break;
         /*
          * Process a Unix domain socket.

--- a/lib/dialects/netbsd/dsock.c
+++ b/lib/dialects/netbsd/dsock.c
@@ -125,9 +125,9 @@ void process_socket(sa) KA_T sa; /* socket address in kernel */
     /*
      * Save size information.
      */
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)s.so_rcv.sb_cc;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)s.so_snd.sb_cc;
     else
         Lf->sz = (SZOFFTYPE)(s.so_rcv.sb_cc + s.so_snd.sb_cc);

--- a/lib/dialects/openbsd/dfile.c
+++ b/lib/dialects/openbsd/dfile.c
@@ -54,10 +54,6 @@ void process_kqueue_file(struct kinfo_file *file) {
         enter_dev_ch(buf);
     }
 
-    /* Fill offset */
-    Lf->off = 0;
-    Lf->off_def = 1;
-
     /*
      * Construct access code.
      */

--- a/lib/dialects/openbsd/dfile.c
+++ b/lib/dialects/openbsd/dfile.c
@@ -58,11 +58,11 @@ void process_kqueue_file(struct kinfo_file *file) {
      * Construct access code.
      */
     if ((flag = (file->f_flag & (FREAD | FWRITE))) == FREAD)
-        Lf->access = 'r';
+        Lf->access = LSOF_FILE_ACCESS_READ;
     else if (flag == FWRITE)
-        Lf->access = 'w';
+        Lf->access = LSOF_FILE_ACCESS_WRITE;
     else if (flag == (FREAD | FWRITE))
-        Lf->access = 'u';
+        Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
 
     /* Finish */
     if (Lf->sf)

--- a/lib/dialects/openbsd/dnode.c
+++ b/lib/dialects/openbsd/dnode.c
@@ -143,14 +143,12 @@ void process_vnode(struct kinfo_file *file) {
     Lf->lmi_srch = 1;
 
     /* Fill number of links */
-    if (Fnlink) {
-        Lf->nlink = file->va_nlink;
-        Lf->nlink_def = 1;
+    Lf->nlink = file->va_nlink;
+    Lf->nlink_def = 1;
 
-        /* Handle link count filter */
-        if (Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
-    }
+    /* Handle link count filter */
+    if (Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
 
     /* Handle name match, must be done late, because if_file_named checks
      * Lf->dev etc. */

--- a/lib/dialects/openbsd/dnode.c
+++ b/lib/dialects/openbsd/dnode.c
@@ -85,11 +85,11 @@ void process_vnode(struct kinfo_file *file) {
      */
     if (file->fd_fd >= 0) {
         if ((flag = (file->f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
     }
 
     /* Fill file size/offset */

--- a/lib/dialects/openbsd/dnode.c
+++ b/lib/dialects/openbsd/dnode.c
@@ -100,13 +100,10 @@ void process_vnode(struct kinfo_file *file) {
             Lf->off_def = 1;
         }
     } else {
-        if (Foffset) {
-            Lf->off = file->f_offset;
-            Lf->off_def = 1;
-        } else {
-            Lf->sz = file->va_size;
-            Lf->sz_def = 1;
-        }
+        Lf->off = file->f_offset;
+        Lf->off_def = 1;
+        Lf->sz = file->va_size;
+        Lf->sz_def = 1;
     }
 
     /* Fill inode */

--- a/lib/dialects/openbsd/dsock.c
+++ b/lib/dialects/openbsd/dsock.c
@@ -96,10 +96,6 @@ void process_socket(struct kinfo_file *file) {
         Lf->inp_ty = 2;
     }
 
-    /* Fill offset, always zero */
-    Lf->off = 0;
-    Lf->off_def = 1;
-
     if (file->so_family == AF_INET || file->so_family == AF_INET6) {
         /* Show this entry if -i */
         if (Fnet) {

--- a/lib/dialects/openbsd/dsock.c
+++ b/lib/dialects/openbsd/dsock.c
@@ -72,11 +72,11 @@ void process_socket(struct kinfo_file *file) {
      */
     if (file->fd_fd >= 0) {
         if ((flag = (file->f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
     }
 
     /* Fill iproto */

--- a/lib/dialects/osr/dfile.c
+++ b/lib/dialects/osr/dfile.c
@@ -125,22 +125,14 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         /*
          * Save file structure values.
          */
-        if (Fsv & FSV_CT) {
-            Lf->fct = (long)f.f_count;
-            Lf->fsv |= FSV_CT;
-        }
-        if (Fsv & FSV_FA) {
-            Lf->fsa = fp;
-            Lf->fsv |= FSV_FA;
-        }
-        if (Fsv & FSV_FG) {
-            Lf->ffg = (long)f.f_flag;
-            Lf->fsv |= FSV_FG;
-        }
-        if (Fsv & FSV_NI) {
-            Lf->fna = (KA_T)f.f_inode;
-            Lf->fsv |= FSV_NI;
-        }
+        Lf->fct = (long)f.f_count;
+        Lf->fsv |= FSV_CT;
+        Lf->fsa = fp;
+        Lf->fsv |= FSV_FA;
+        Lf->ffg = (long)f.f_flag;
+        Lf->fsv |= FSV_FG;
+        Lf->fna = (KA_T)f.f_inode;
+        Lf->fsv |= FSV_NI;
 #endif /* defined(HASFSTRUCT) */
 
         process_node((KA_T)f.f_inode);

--- a/lib/dialects/osr/dfile.c
+++ b/lib/dialects/osr/dfile.c
@@ -104,6 +104,7 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         return;
     }
     Lf->off = (SZOFFTYPE)f.f_offset;
+    Lf->off_def = 1;
 
     if (f.f_count) {
 

--- a/lib/dialects/osr/dfile.c
+++ b/lib/dialects/osr/dfile.c
@@ -112,11 +112,11 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
          * Construct access code.
          */
         if ((flag = (f.f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
             /*
              * Process structure.
              */

--- a/lib/dialects/osr/dnode.c
+++ b/lib/dialects/osr/dnode.c
@@ -590,12 +590,10 @@ void process_node(na) KA_T na; /* inode kernel space address */
     /*
      * Record link count.
      */
-    if (Fnlink) {
-        Lf->nlink = (long)i.i_nlink;
-        Lf->nlink_def = 1;
-        if (Nlink && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
-    }
+    Lf->nlink = (long)i.i_nlink;
+    Lf->nlink_def = 1;
+    if (Nlink && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * Format the type name.
      */

--- a/lib/dialects/osr/dnode.c
+++ b/lib/dialects/osr/dnode.c
@@ -555,48 +555,37 @@ void process_node(na) KA_T na; /* inode kernel space address */
     /*
      * Determine the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
-        case N_BLK:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_CHR:
-        case N_COM:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_FIFO:
+    switch (Ntype) {
+    case N_BLK:
+        break;
+    case N_CHR:
+    case N_COM:
+        break;
+    case N_FIFO:
 
 #if OSRV >= 500
-            if (hpps == 2) {
-                Lf->sz = (SZOFFTYPE)pi.count;
-                Lf->sz_def = 1;
-                break;
-            }
-#endif /* OSRV>=500 */
-
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_HSFS:
-
-#if defined(HAS_NFS)
-        case N_NFS:
-            Lf->sz = (SZOFFTYPE)i.i_size;
+        if (hpps == 2) {
+            Lf->sz = (SZOFFTYPE)pi.count;
             Lf->sz_def = 1;
             break;
+        }
+#endif /* OSRV>=500 */
+        break;
+    case N_HSFS:
+
+#if defined(HAS_NFS)
+    case N_NFS:
+        Lf->sz = (SZOFFTYPE)i.i_size;
+        Lf->sz_def = 1;
+        break;
 #endif /* defined(HAS_NFS) */
 
-        case N_REGLR:
-            if (type == IFREG || type == IFDIR) {
-                Lf->sz = (SZOFFTYPE)i.i_size;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_REGLR:
+        if (type == IFREG || type == IFDIR) {
+            Lf->sz = (SZOFFTYPE)i.i_size;
+            Lf->sz_def = 1;
         }
+        break;
     }
     /*
      * Record link count.

--- a/lib/dialects/osr/dproc.c
+++ b/lib/dialects/osr/dproc.c
@@ -219,37 +219,35 @@ void gather_proc_info() {
 #endif /* OSRV<42 */
 
 #if defined(HASFSTRUCT)
-        if (Fsv & FSV_FG) {
+
+        /*
+         * If u_pofile is in the u block, set its address.
+         */
+        if (nf && u->u_pofile && ((unsigned)u->u_pofile >= UVUBLK) &&
+            ((MALLOC_S)((unsigned)u->u_pofile - UVUBLK + nf) <= ual)) {
+            pof = ua + (unsigned)u->u_pofile - UVUBLK;
+        } else if (nf && u->u_pofile) {
 
             /*
-             * If u_pofile is in the u block, set its address.
+             * Allocate space for u_pofile and read it from kernel memory.
              */
-            if (nf && u->u_pofile && ((unsigned)u->u_pofile >= UVUBLK) &&
-                ((MALLOC_S)((unsigned)u->u_pofile - UVUBLK + nf) <= ual)) {
-                pof = ua + (unsigned)u->u_pofile - UVUBLK;
-            } else if (nf && u->u_pofile) {
-
-                /*
-                 * Allocate space for u_pofile and read it from kernel memory.
-                 */
-                if (nf > npofb) {
-                    if (!pofb)
-                        pofb = (char *)malloc((MALLOC_S)nf);
-                    else
-                        pofb = (char *)realloc((MALLOC_P *)pofb, (MALLOC_S)nf);
-                    if (!pofb) {
-                        (void)fprintf(stderr, "%s: no pofile space\n", Pn);
-                        Error();
-                    }
-                    npofb = nf;
-                }
-                if (kread((KA_T)u->u_pofile, pofb, nf))
-                    pof = (char *)NULL;
+            if (nf > npofb) {
+                if (!pofb)
+                    pofb = (char *)malloc((MALLOC_S)nf);
                 else
-                    pof = pofb;
-            } else
+                    pofb = (char *)realloc((MALLOC_P *)pofb, (MALLOC_S)nf);
+                if (!pofb) {
+                    (void)fprintf(stderr, "%s: no pofile space\n", Pn);
+                    Error();
+                }
+                npofb = nf;
+            }
+            if (kread((KA_T)u->u_pofile, pofb, nf))
                 pof = (char *)NULL;
-        }
+            else
+                pof = pofb;
+        } else
+            pof = (char *)NULL;
 #endif /* defined(HASFSTRUCT) */
 
         for (i = 0; i < nf; i++) {
@@ -259,7 +257,7 @@ void gather_proc_info() {
                 if (Lf->sf) {
 
 #if defined(HASFSTRUCT)
-                    if (Fsv & FSV_FG && pof)
+                    if (pof)
                         Lf->pof = (long)pof[i];
 #endif /* defined(HASFSTRUCT) */
 

--- a/lib/dialects/osr/dsock.c
+++ b/lib/dialects/osr/dsock.c
@@ -255,24 +255,17 @@ void process_socket(i) struct inode *i; /* inode pointer */
             Lf->lts.rqs = Lf->lts.sqs = 1;
 #endif /* defined(HASTCPTPIQ) */
 
-            if (Fsize) {
-                if (Lf->access == 'r')
-                    Lf->sz = (SZOFFTYPE)t.t_iqsize;
-                else if (Lf->access == 'w')
-                    Lf->sz = (SZOFFTYPE)t.t_qsize;
-                else
-                    Lf->sz = (SZOFFTYPE)(t.t_iqsize + t.t_qsize);
-                Lf->sz_def = 1;
-            } else
-                Lf->off_def = 1;
+            if (Lf->access == 'r')
+                Lf->sz = (SZOFFTYPE)t.t_iqsize;
+            else if (Lf->access == 'w')
+                Lf->sz = (SZOFFTYPE)t.t_qsize;
+            else
+                Lf->sz = (SZOFFTYPE)(t.t_iqsize + t.t_qsize);
+            Lf->sz_def = 1;
         } else if (shs) {
-            if (Fsize) {
-                Lf->sz = (SZOFFTYPE)sh.q_count;
-                Lf->sz_def = 1;
-            } else
-                Lf->off_def = 1;
-        } else
-            Lf->off_def = 1;
+            Lf->sz = (SZOFFTYPE)sh.q_count;
+            Lf->sz_def = 1;
+        }
         break;
 
 #if OSRV >= 500
@@ -284,7 +277,6 @@ void process_socket(i) struct inode *i; /* inode pointer */
          * Read Unix protocol control block and the Unix address structure.
          */
         enter_dev_ch(print_kptr(sa, (char *)NULL, 0));
-        Lf->off_def = 1;
         if (s.so_stp && !readstdata((KA_T)s.so_stp, &sd) &&
             !readsthead((KA_T)sd.sd_wrq, &sh)) {
             if (!sh.q_ptr || kread((KA_T)sh.q_ptr, (char *)&ud, sizeof(ud))) {

--- a/lib/dialects/osr/dsock.c
+++ b/lib/dialects/osr/dsock.c
@@ -255,9 +255,9 @@ void process_socket(i) struct inode *i; /* inode pointer */
             Lf->lts.rqs = Lf->lts.sqs = 1;
 #endif /* defined(HASTCPTPIQ) */
 
-            if (Lf->access == 'r')
+            if (Lf->access == LSOF_FILE_ACCESS_READ)
                 Lf->sz = (SZOFFTYPE)t.t_iqsize;
-            else if (Lf->access == 'w')
+            else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
                 Lf->sz = (SZOFFTYPE)t.t_qsize;
             else
                 Lf->sz = (SZOFFTYPE)(t.t_iqsize + t.t_qsize);

--- a/lib/dialects/sun/dfile.c
+++ b/lib/dialects/sun/dfile.c
@@ -553,6 +553,7 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         return;
     }
     Lf->off = (SZOFFTYPE)f.f_offset;
+    Lf->off_def = 1;
 
     if (f.f_count) {
 

--- a/lib/dialects/sun/dfile.c
+++ b/lib/dialects/sun/dfile.c
@@ -561,11 +561,11 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
          * Construct access code.
          */
         if ((flag = (f.f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
 
 #if defined(HASFSTRUCT)
         /*

--- a/lib/dialects/sun/dfile.c
+++ b/lib/dialects/sun/dfile.c
@@ -571,22 +571,14 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         /*
          * Save file structure values.
          */
-        if (Fsv & FSV_CT) {
-            Lf->fct = (long)f.f_count;
-            Lf->fsv |= FSV_CT;
-        }
-        if (Fsv & FSV_FA) {
-            Lf->fsa = fp;
-            Lf->fsv |= FSV_FA;
-        }
-        if (Fsv & FSV_FG) {
-            Lf->ffg = (long)f.f_flag;
-            Lf->fsv |= FSV_FG;
-        }
-        if (Fsv & FSV_NI) {
-            Lf->fna = (KA_T)f.f_vnode;
-            Lf->fsv |= FSV_NI;
-        }
+        Lf->fct = (long)f.f_count;
+        Lf->fsv |= FSV_CT;
+        Lf->fsa = fp;
+        Lf->fsv |= FSV_FA;
+        Lf->ffg = (long)f.f_flag;
+        Lf->fsv |= FSV_FG;
+        Lf->fna = (KA_T)f.f_vnode;
+        Lf->fsv |= FSV_NI;
 #endif /* defined(HASFSTRUCT) */
 
         /*

--- a/lib/dialects/sun/dnode.c
+++ b/lib/dialects/sun/dnode.c
@@ -3155,166 +3155,160 @@ void process_node(va) KA_T va; /* vnode kernel space address */
      * Record link count.
      */
 
-#if !defined(HASXOPT)
-    if (Fnlink)
-#endif /* !defined(HASXOPT) */
-
-    {
-        switch (Ntype) {
+    switch (Ntype) {
 
 #if defined(HAS_AFS)
-        case N_AFS:
-            Lf->nlink = an.nlink;
-            Lf->nlink_def = an.nlink_st;
-            break;
+    case N_AFS:
+        Lf->nlink = an.nlink;
+        Lf->nlink_def = an.nlink_st;
+        break;
 #endif /* defined(HAS_AFS) */
 
 #if solaris >= 20500
-        case N_AUTO:
-            break;
+    case N_AUTO:
+        break;
 
 #    if defined(HASCACHEFS)
-        case N_CACHE:
-            Lf->nlink = (long)cn.c_attr.va_nlink;
-            Lf->nlink_def = 1;
-            break;
+    case N_CACHE:
+        Lf->nlink = (long)cn.c_attr.va_nlink;
+        Lf->nlink_def = 1;
+        break;
 #    endif /* defined(HASCACHEFS) */
 
 #endif /* solaris>=20500 */
 
 #if solaris >= 100000
-        case N_CTFSADIR:
-        case N_CTFSBUND:
-        case N_CTFSCDIR:
-        case N_CTFSCTL:
-        case N_CTFSEVT:
-        case N_CTFSLATE:
-        case N_CTFSROOT:
-        case N_CTFSSTAT:
-        case N_CTFSSYM:
-        case N_CTFSTDIR:
-        case N_CTFSTMPL:
-            /* Method of computing CTFS link count not known. */
-            break;
+    case N_CTFSADIR:
+    case N_CTFSBUND:
+    case N_CTFSCDIR:
+    case N_CTFSCTL:
+    case N_CTFSEVT:
+    case N_CTFSLATE:
+    case N_CTFSROOT:
+    case N_CTFSSTAT:
+    case N_CTFSSYM:
+    case N_CTFSTDIR:
+    case N_CTFSTMPL:
+        /* Method of computing CTFS link count not known. */
+        break;
 #endif /* solaris>=100000 */
 
-        case N_FD:
-            Lf->nlink = (v->v_type == VDIR) ? 2 : 1;
-            Lf->nlink_def = 1;
-            break;
+    case N_FD:
+        Lf->nlink = (v->v_type == VDIR) ? 2 : 1;
+        Lf->nlink_def = 1;
+        break;
 
 #if solaris >= 20600
-        case N_SOCK: /* no link count */
-            break;
+    case N_SOCK: /* no link count */
+        break;
 #endif /* solaris>=20600 */
 
-        case N_HSFS:
-            Lf->nlink = (long)h.hs_dirent.nlink;
-            Lf->nlink_def = 1;
-            break;
-        case N_NM:
-            Lf->nlink = (long)nn.nm_vattr.va_nlink;
-            Lf->nlink_def = 1;
-            break;
+    case N_HSFS:
+        Lf->nlink = (long)h.hs_dirent.nlink;
+        Lf->nlink_def = 1;
+        break;
+    case N_NM:
+        Lf->nlink = (long)nn.nm_vattr.va_nlink;
+        Lf->nlink_def = 1;
+        break;
 
 #if solaris >= 100000
-        case N_DEV:
-            if (dvs) {
-                Lf->nlink = (long)dv.dv_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
+    case N_DEV:
+        if (dvs) {
+            Lf->nlink = (long)dv.dv_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
 #endif /* solaris>=100000 */
 
-        case N_DOOR:
-            Lf->nlink = (long)v->v_count;
-            Lf->nlink_def = 1;
-            break;
-        case N_FIFO:
-            break;
-        case N_MNT:
+    case N_DOOR:
+        Lf->nlink = (long)v->v_count;
+        Lf->nlink_def = 1;
+        break;
+    case N_FIFO:
+        break;
+    case N_MNT:
 
 #if defined(CVFS_NLKSAVE)
-            if (vfs) {
-                Lf->nlink = (long)vfs->nlink;
-                Lf->nlink_def = 1;
-            }
+        if (vfs) {
+            Lf->nlink = (long)vfs->nlink;
+            Lf->nlink_def = 1;
+        }
 #endif /* defined(CVFS_NLKSAVE) */
 
-            break;
-        case N_MVFS: /* no link count */
-            break;
-        case N_NFS:
-            Lf->nlink = (long)r.r_attr.va_nlink;
-            Lf->nlink_def = 1;
-            break;
+        break;
+    case N_MVFS: /* no link count */
+        break;
+    case N_NFS:
+        Lf->nlink = (long)r.r_attr.va_nlink;
+        Lf->nlink_def = 1;
+        break;
 
 #if solaris >= 100000
-        case N_NFS4:
-            Lf->nlink = (long)r4.r_attr.va_nlink;
-            Lf->nlink_def = 1;
-            break;
+    case N_NFS4:
+        Lf->nlink = (long)r4.r_attr.va_nlink;
+        Lf->nlink_def = 1;
+        break;
 #endif /* solaris>=100000 */
 
-        case N_PCFS:
-            break;
+    case N_PCFS:
+        break;
 
 #if defined(HASPROCFS)
-        case N_PROC:
-            break;
+    case N_PROC:
+        break;
 #endif /* defined(HASPROCFS) */
 
-        case N_REGLR:
-            if (ins) {
-                Lf->nlink = (long)i.i_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
-        case N_SAMFS:
-            break; /* No more SAM-FS information is available. */
+    case N_REGLR:
+        if (ins) {
+            Lf->nlink = (long)i.i_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
+    case N_SAMFS:
+        break; /* No more SAM-FS information is available. */
 
 #if solaris >= 110000
-        case N_SDEV:
-            if (sdns) {
-                Lf->nlink = (long)sdva.va_nlink;
-                Lf->nlink_def = 1;
-            }
-            break;
+    case N_SDEV:
+        if (sdns) {
+            Lf->nlink = (long)sdva.va_nlink;
+            Lf->nlink_def = 1;
+        }
+        break;
 #endif /* solaris>=110000 */
 
-        case N_SHARED:
-            break; /* No more sharedfs information is available. */
-        case N_STREAM:
-            break;
-        case N_TMP:
-            Lf->nlink = (long)t.tn_attr.va_nlink;
-            Lf->nlink_def = 1;
-            break;
+    case N_SHARED:
+        break; /* No more sharedfs information is available. */
+    case N_STREAM:
+        break;
+    case N_TMP:
+        Lf->nlink = (long)t.tn_attr.va_nlink;
+        Lf->nlink_def = 1;
+        break;
 
 #if defined(HASVXFS)
-        case N_VXFS:
-            Lf->nlink = vx.nl;
-            Lf->nlink_def = vx.nl_def;
-            break;
+    case N_VXFS:
+        Lf->nlink = vx.nl;
+        Lf->nlink_def = vx.nl_def;
+        break;
 #endif /* defined(HASVXFS) */
 
 #if defined(HAS_ZFS)
-        case N_ZFS:
-            if (zns) {
-                Lf->nlink = (long)MIN(zn.z_links, UINT32_MAX);
-                Lf->nlink_def = 1;
-            }
-            break;
-#endif /* defined(HAS_ZFS) */
+    case N_ZFS:
+        if (zns) {
+            Lf->nlink = (long)MIN(zn.z_links, UINT32_MAX);
+            Lf->nlink_def = 1;
         }
-        if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
+        break;
+#endif /* defined(HAS_ZFS) */
     }
+    if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
 
 #if defined(HASVXFS)
-    /*
-     * Record a VxFS file.
-     */
+        /*
+         * Record a VxFS file.
+         */
 
 #    if defined(HASVXFSDNLC)
     Lf->is_vxfs = (Ntype == N_VXFS) ? 1 : 0;

--- a/lib/dialects/sun/dnode.c
+++ b/lib/dialects/sun/dnode.c
@@ -2974,202 +2974,182 @@ void process_node(va) KA_T va; /* vnode kernel space address */
     /*
      * Obtain the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
+    switch (Ntype) {
 
 #if defined(HAS_AFS)
-        case N_AFS:
-            Lf->sz = (SZOFFTYPE)an.size;
-            Lf->sz_def = 1;
-            break;
+    case N_AFS:
+        Lf->sz = (SZOFFTYPE)an.size;
+        Lf->sz_def = 1;
+        break;
 #endif /* defined(HAS_AFS) */
 
 #if solaris >= 20500
-        case N_AUTO:
+    case N_AUTO:
 
 #    if solaris < 20600
-            Lf->sz = (SZOFFTYPE)au.an_size;
+        Lf->sz = (SZOFFTYPE)au.an_size;
 #    else  /* solaris >=20600 */
-            Lf->sz = (SZOFFTYPE)fnn.fn_size;
+        Lf->sz = (SZOFFTYPE)fnn.fn_size;
 #    endif /* solaris < 20600 */
 
-            Lf->sz_def = 1;
-            break;
+        Lf->sz_def = 1;
+        break;
 #endif /* solaris>=20500 */
 
 #if defined(HASCACHEFS)
-        case N_CACHE:
-            Lf->sz = (SZOFFTYPE)cn.c_size;
-            Lf->sz_def = 1;
-            break;
+    case N_CACHE:
+        Lf->sz = (SZOFFTYPE)cn.c_size;
+        Lf->sz_def = 1;
+        break;
 #endif /* defined(HASCACHEFS) */
 
 #if solaris >= 100000
-        case N_CTFSADIR:
-        case N_CTFSBUND:
-        case N_CTFSCDIR:
-        case N_CTFSCTL:
-        case N_CTFSEVT:
-        case N_CTFSLATE:
-        case N_CTFSROOT:
-        case N_CTFSSTAT:
-        case N_CTFSSYM:
-        case N_CTFSTDIR:
-        case N_CTFSTMPL:
-            /* Method of computing CTFS size not known. */
-            break;
+    case N_CTFSADIR:
+    case N_CTFSBUND:
+    case N_CTFSCDIR:
+    case N_CTFSCTL:
+    case N_CTFSEVT:
+    case N_CTFSLATE:
+    case N_CTFSROOT:
+    case N_CTFSSTAT:
+    case N_CTFSSYM:
+    case N_CTFSTDIR:
+    case N_CTFSTMPL:
+        /* Method of computing CTFS size not known. */
+        break;
 #endif /* solaris>=100000 */
 
-        case N_FD:
-            if (v->v_type == VDIR)
-                Lf->sz = (Unof + 2) * 16;
-            else
-                Lf->sz = (unsigned long)0;
-            Lf->sz_def = 1;
-            break;
+    case N_FD:
+        if (v->v_type == VDIR)
+            Lf->sz = (Unof + 2) * 16;
+        else
+            Lf->sz = (unsigned long)0;
+        Lf->sz_def = 1;
+        break;
 
 #if solaris >= 20600
-        case N_SOCK:
-            Lf->off_def = 1;
-            break;
+    case N_SOCK:
+        break;
 #endif /* solaris>=20600 */
 
-        case N_HSFS:
-            Lf->sz = (SZOFFTYPE)h.hs_dirent.ext_size;
-            Lf->sz_def = 1;
-            break;
-        case N_NM:
-            Lf->sz = (SZOFFTYPE)nn.nm_vattr.va_size;
-            Lf->sz_def = 1;
-            break;
+    case N_HSFS:
+        Lf->sz = (SZOFFTYPE)h.hs_dirent.ext_size;
+        Lf->sz_def = 1;
+        break;
+    case N_NM:
+        Lf->sz = (SZOFFTYPE)nn.nm_vattr.va_size;
+        Lf->sz_def = 1;
+        break;
 
 #if solaris >= 100000
-        case N_DEV:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_DEV:
+        break;
 #endif /* solaris>=100000 */
 
-        case N_DOOR:
-        case N_FIFO:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_MNT:
+    case N_DOOR:
+    case N_FIFO:
+        break;
+    case N_MNT:
 
 #if defined(CVFS_SZSAVE)
-            if (vfs) {
-                Lf->sz = (SZOFFTYPE)vfs->size;
-                Lf->sz_def = 1;
-            } else
+        if (vfs) {
+            Lf->sz = (SZOFFTYPE)vfs->size;
+            Lf->sz_def = 1;
+        } else
 #endif /* defined(CVFS_SZSAVE) */
 
-                Lf->off_def = 1;
             break;
-        case N_MVFS:
-            /* The location of file size isn't known. */
-            break;
-        case N_NFS:
-            if ((type == VCHR || type == VBLK) && !Fsize)
-                Lf->off_def = 1;
-            else {
-                Lf->sz = (SZOFFTYPE)r.r_size;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_MVFS:
+        /* The location of file size isn't known. */
+        break;
+    case N_NFS:
+        if (!(type == VCHR || type == VBLK)) {
+            Lf->sz = (SZOFFTYPE)r.r_size;
+            Lf->sz_def = 1;
+        }
+        break;
 
 #if solaris >= 100000
-        case N_NFS4:
-            if ((type == VCHR || type == VBLK) && !Fsize)
-                Lf->off_def = 1;
-            else {
-                Lf->sz = (SZOFFTYPE)r4.r_size;
-                Lf->sz_def = 1;
-            }
-            break;
+    case N_NFS4:
+        if (!(type == VCHR || type == VBLK)) {
+            Lf->sz = (SZOFFTYPE)r4.r_size;
+            Lf->sz_def = 1;
+        }
+        break;
 #endif /* solaris>=100000 */
 
-        case N_PCFS:
-            Lf->sz = (SZOFFTYPE)pc.pc_size;
-            Lf->sz_def = 1;
-            break;
+    case N_PCFS:
+        Lf->sz = (SZOFFTYPE)pc.pc_size;
+        Lf->sz_def = 1;
+        break;
 
 #if solaris >= 100000
-        case N_PORT:
-            Lf->sz = (SZOFFTYPE)pn.port_curr;
-            Lf->sz_def = 1;
-            break;
+    case N_PORT:
+        Lf->sz = (SZOFFTYPE)pn.port_curr;
+        Lf->sz_def = 1;
+        break;
 #endif /* solaris>=100000 */
 
 #if defined(HASPROCFS)
-        case N_PROC:
+    case N_PROC:
 
-            /*
-             * The proc file system size is defined when the
-             * prnode is read.
-             */
-            break;
+        /*
+         * The proc file system size is defined when the
+         * prnode is read.
+         */
+        break;
 #endif /* defined(HASPROCFS) */
 
-        case N_REGLR:
-            if (type == VREG || type == VDIR) {
-                if (ins | nns) {
-                    Lf->sz = (SZOFFTYPE)(nns ? nn.nm_vattr.va_size : i.i_size);
-                    Lf->sz_def = 1;
-                }
-            } else if ((type == VCHR || type == VBLK) && !Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_REGLR:
+        if (type == VREG || type == VDIR) {
+            if (ins | nns) {
+                Lf->sz = (SZOFFTYPE)(nns ? nn.nm_vattr.va_size : i.i_size);
+                Lf->sz_def = 1;
+            }
+        }
+        break;
 
 #if solaris >= 110000
-        case N_SDEV:
-            if (sdns) {
-                if (type == VREG || type == VDIR) {
-                    Lf->sz = (SZOFFTYPE)sdva.va_size;
-                    Lf->sz_def = 1;
-                } else if ((type == VCHR || type == VBLK) && !Fsize)
-                    Lf->off_def = 1;
+    case N_SDEV:
+        if (sdns) {
+            if (type == VREG || type == VDIR) {
+                Lf->sz = (SZOFFTYPE)sdva.va_size;
+                Lf->sz_def = 1;
             }
-            break;
+        }
+        break;
 #endif /* solaris>=110000 */
 
-        case N_SAMFS:
-            break; /* No more SAM-FS information is available. */
-        case N_SHARED:
-            break; /* No more sharedfs information is available. */
-        case N_STREAM:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_TMP:
-            Lf->sz = (SZOFFTYPE)t.tn_attr.va_size;
-            Lf->sz_def = 1;
-            break;
+    case N_SAMFS:
+        break; /* No more SAM-FS information is available. */
+    case N_SHARED:
+        break; /* No more sharedfs information is available. */
+    case N_STREAM:
+        break;
+    case N_TMP:
+        Lf->sz = (SZOFFTYPE)t.tn_attr.va_size;
+        Lf->sz_def = 1;
+        break;
 
 #if defined(HASVXFS)
-        case N_VXFS:
-            if (type == VREG || type == VDIR) {
-                Lf->sz = (SZOFFTYPE)vx.sz;
-                Lf->sz_def = vx.sz_def;
-            } else if ((type == VCHR || type == VBLK) && !Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_VXFS:
+        if (type == VREG || type == VDIR) {
+            Lf->sz = (SZOFFTYPE)vx.sz;
+            Lf->sz_def = vx.sz_def;
+        }
+        break;
 #endif /* defined(HASVXFS) */
 
 #if defined(HAS_ZFS)
-        case N_ZFS:
-            if (zns) {
-                if (type == VREG || type == VDIR) {
-                    Lf->sz = (SZOFFTYPE)zn.z_size;
-                    Lf->sz_def = 1;
-                } else if ((type == VCHR || type == VBLK) && !Fsize)
-                    Lf->off_def = 1;
+    case N_ZFS:
+        if (zns) {
+            if (type == VREG || type == VDIR) {
+                Lf->sz = (SZOFFTYPE)zn.z_size;
+                Lf->sz_def = 1;
             }
-            break;
-#endif /* defined(HAS_ZFS) */
         }
+        break;
+#endif /* defined(HAS_ZFS) */
     }
     /*
      * Record link count.

--- a/lib/dialects/sun/dproc.c
+++ b/lib/dialects/sun/dproc.c
@@ -539,8 +539,7 @@ void gather_proc_info() {
             if (Lf->sf) {
 
 #if defined(HASFSTRUCT)
-                if (Fsv & FSV_FG)
-                    Lf->pof = pofv;
+                Lf->pof = pofv;
 #endif /* defined(HASFSTRUCT) */
 
                 link_lfile();

--- a/lib/dialects/sun/dsock.c
+++ b/lib/dialects/sun/dsock.c
@@ -1866,9 +1866,9 @@ static void
     Lf->lts.rqs = Lf->lts.sqs = 1;
 #    endif /* defined(HASTCPTPIQ) */
 
-    if (Lf->access == 'r')
+    if (Lf->access == LSOF_FILE_ACCESS_READ)
         Lf->sz = (SZOFFTYPE)rq;
-    else if (Lf->access == 'w')
+    else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
         Lf->sz = (SZOFFTYPE)sq;
     else
         Lf->sz = (SZOFFTYPE)(rq + sq);

--- a/lib/dialects/sun/dsock.c
+++ b/lib/dialects/sun/dsock.c
@@ -928,32 +928,30 @@ struct sonode *so; /* pointer to socket's sonode */
             /*
              * Save UDP flags.
              */
-            if (Ftcptpi & TCPTPI_FLAGS) {
-                union {
-                    uint_t flags;
-                    uint_t udpb_debug : 1,     /* SO_DEBUG option */
-                        udpb_dontroute : 1,    /* SO_DONTROUTE option */
-                        udpb_broadcast : 1,    /* SO_BROADCAST option */
-                        udpb_reuseaddr : 1,    /* SO_REUSEADDR option */
-                        udpb_useloopback : 1,  /* SO_USELOOPBACK option */
-                        udpb_dgram_errind : 1, /* SO_DGRAM_ERRIND option */
-                        udpb_pad : 26;         /* pad to bit 31 */
-                } ucf;
+            union {
+                uint_t flags;
+                uint_t udpb_debug : 1,     /* SO_DEBUG option */
+                    udpb_dontroute : 1,    /* SO_DONTROUTE option */
+                    udpb_broadcast : 1,    /* SO_BROADCAST option */
+                    udpb_reuseaddr : 1,    /* SO_REUSEADDR option */
+                    udpb_useloopback : 1,  /* SO_USELOOPBACK option */
+                    udpb_dgram_errind : 1, /* SO_DGRAM_ERRIND option */
+                    udpb_pad : 26;         /* pad to bit 31 */
+            } ucf;
 
-                ucf.flags = uc.udp_bits;
-                if (ucf.udpb_debug)
-                    Lf->lts.opt |= SO_DEBUG;
-                if (ucf.udpb_dontroute)
-                    Lf->lts.opt |= SO_DONTROUTE;
-                if (ucf.udpb_broadcast)
-                    Lf->lts.opt |= SO_BROADCAST;
-                if (ucf.udpb_reuseaddr)
-                    Lf->lts.opt |= SO_REUSEADDR;
-                if (ucf.udpb_useloopback)
-                    Lf->lts.opt |= SO_USELOOPBACK;
-                if (ucf.udpb_dgram_errind)
-                    Lf->lts.opt |= SO_DGRAM_ERRIND;
-            }
+            ucf.flags = uc.udp_bits;
+            if (ucf.udpb_debug)
+                Lf->lts.opt |= SO_DEBUG;
+            if (ucf.udpb_dontroute)
+                Lf->lts.opt |= SO_DONTROUTE;
+            if (ucf.udpb_broadcast)
+                Lf->lts.opt |= SO_BROADCAST;
+            if (ucf.udpb_reuseaddr)
+                Lf->lts.opt |= SO_REUSEADDR;
+            if (ucf.udpb_useloopback)
+                Lf->lts.opt |= SO_USELOOPBACK;
+            if (ucf.udpb_dgram_errind)
+                Lf->lts.opt |= SO_DGRAM_ERRIND;
 #    endif /* defined(HASSOOPT) */
 
             break;
@@ -1011,20 +1009,18 @@ struct sonode *so; /* pointer to socket's sonode */
             /*
              * Save ICMP flags.
              */
-            if (Ftcptpi & TCPTPI_FLAGS) {
-                if (ic.icmp_debug.icmp_Debug)
-                    Lf->lts.opt |= SO_DEBUG;
-                if (ic.icmp_debug.icmp_dontroute)
-                    Lf->lts.opt |= SO_DONTROUTE;
-                if (ic.icmp_debug.icmp_broadcast)
-                    Lf->lts.opt |= SO_BROADCAST;
-                if (ic.icmp_debug.icmp_reuseaddr)
-                    Lf->lts.opt |= SO_REUSEADDR;
-                if (ic.icmp_debug.icmp_useloopback)
-                    Lf->lts.opt |= SO_USELOOPBACK;
-                if (ic.icmp_debug.icmp_dgram_errind)
-                    Lf->lts.opt |= SO_DGRAM_ERRIND;
-            }
+            if (ic.icmp_debug.icmp_Debug)
+                Lf->lts.opt |= SO_DEBUG;
+            if (ic.icmp_debug.icmp_dontroute)
+                Lf->lts.opt |= SO_DONTROUTE;
+            if (ic.icmp_debug.icmp_broadcast)
+                Lf->lts.opt |= SO_BROADCAST;
+            if (ic.icmp_debug.icmp_reuseaddr)
+                Lf->lts.opt |= SO_REUSEADDR;
+            if (ic.icmp_debug.icmp_useloopback)
+                Lf->lts.opt |= SO_USELOOPBACK;
+            if (ic.icmp_debug.icmp_dgram_errind)
+                Lf->lts.opt |= SO_DGRAM_ERRIND;
 #    endif /* defined(HASSOOPT) */
 
             break;
@@ -1079,18 +1075,16 @@ struct sonode *so; /* pointer to socket's sonode */
         /*
          * Save ROUTE flags.
          */
-        if (Ftcptpi & TCPTPI_FLAGS) {
-            if (rt.rts_debug.rts_Debug)
-                Lf->lts.opt |= SO_DEBUG;
-            if (rt.rts_debug.rts_dontroute)
-                Lf->lts.opt |= SO_DONTROUTE;
-            if (rt.rts_debug.rts_broadcast)
-                Lf->lts.opt |= SO_BROADCAST;
-            if (rt.rts_debug.rts_reuseaddr)
-                Lf->lts.opt |= SO_REUSEADDR;
-            if (rt.rts_debug.rts_useloopback)
-                Lf->lts.opt |= SO_USELOOPBACK;
-        }
+        if (rt.rts_debug.rts_Debug)
+            Lf->lts.opt |= SO_DEBUG;
+        if (rt.rts_debug.rts_dontroute)
+            Lf->lts.opt |= SO_DONTROUTE;
+        if (rt.rts_debug.rts_broadcast)
+            Lf->lts.opt |= SO_BROADCAST;
+        if (rt.rts_debug.rts_reuseaddr)
+            Lf->lts.opt |= SO_REUSEADDR;
+        if (rt.rts_debug.rts_useloopback)
+            Lf->lts.opt |= SO_USELOOPBACK;
 #    endif /* defined(HASSOOPT) */
 
         break;
@@ -1886,24 +1880,22 @@ static void
  * save_TCP_states() - save TCP states
  */
 
-static void
-    save_TCP_states(tc, fa, tb,
-                    xp) tcp_t *tc; /* pointer to TCP control structure */
-caddr_t *fa;                       /* flags address (may be NULL):
-                                    *   if HAS_CONN_NEW: conn_s *
-                                    *   if !CONN_HAS_NEW: tcph_t *
-                                    */
-tcpb_t *tb;                        /* pointer to TCP base structure (may
-                                    * be NULL) */
-caddr_t *xp;                       /* pointer to struct ip_xmit_attr_s if
-                                    * HAS_CONN_NEW (may be NULL) */
+static void save_TCP_states(tcp_t *tc,   /* pointer to TCP control structure */
+                            caddr_t *fa, /* flags address (may be NULL):
+                                          *   if HAS_CONN_NEW: conn_s *
+                                          *   if !CONN_HAS_NEW: tcph_t *
+                                          */
+                            tcpb_t *tb,  /* pointer to TCP base structure (may
+                                          * be NULL) */
+                            caddr_t *xp) /* pointer to struct ip_xmit_attr_s if
+                                          * HAS_CONN_NEW (may be NULL) */
 {
     if (!tc)
         return;
 
 #if defined(HASSOOPT)
 #    if defined(HAS_CONN_NEW)
-    if (Ftcptpi & TCPTPI_FLAGS && fa) {
+    if (fa) {
         struct conn_s *cs = (struct conn_s *)fa;
 
         if (cs->conn_broadcast)
@@ -1933,7 +1925,7 @@ caddr_t *xp;                       /* pointer to struct ip_xmit_attr_s if
         if (cs->conn_useloopback)
             Lf->lts.opt |= SO_USELOOPBACK;
 #    else /* !defined(HAS_CONN_NEW) */
-    if (Ftcptpi & TCPTPI_FLAGS) {
+    if (1) {
         if (tc->tcp_broadcast)
             Lf->lts.opt |= SO_BROADCAST;
         if (tc->tcp_debug)

--- a/lib/dialects/sun/dsock.c
+++ b/lib/dialects/sun/dsock.c
@@ -921,8 +921,6 @@ struct sonode *so; /* pointer to socket's sonode */
             /*
              * Save UDP state and size information.
              */
-            if (!Fsize)
-                Lf->off_def = 1;
             Lf->lts.type = 1;
             Lf->lts.state.ui = (unsigned int)uc.udp_state;
 
@@ -982,8 +980,6 @@ struct sonode *so; /* pointer to socket's sonode */
             /*
              * Save ICMP size and state information.
              */
-            if (!Fsize)
-                Lf->off_def = 1;
             Lf->lts.type = 1;
             Lf->lts.state.ui = (unsigned int)ic.icmp_state;
             /*
@@ -1067,8 +1063,6 @@ struct sonode *so; /* pointer to socket's sonode */
         /*
          * Save AF_ROUTE size and state information.
          */
-        if (!Fsize)
-            Lf->off_def = 1;
         Lf->lts.type = 1;
         Lf->lts.state.i = (int)rt.rts_state;
         /*
@@ -1521,8 +1515,6 @@ char *ty;                            /* socket type name */
 #endif     /* solaris<110000 */
 
             (void)ent_inaddr(la, (int)ntohs(p), (unsigned char *)NULL, -1, af);
-            if (!Fsize)
-                Lf->off_def = 1;
             if (ucs) {
                 Lf->lts.type = 1;
                 Lf->lts.state.ui = (unsigned int)uc.udp_state;
@@ -1880,18 +1872,13 @@ static void
     Lf->lts.rqs = Lf->lts.sqs = 1;
 #    endif /* defined(HASTCPTPIQ) */
 
-    if (Fsize) {
-        if (Lf->access == 'r')
-            Lf->sz = (SZOFFTYPE)rq;
-        else if (Lf->access == 'w')
-            Lf->sz = (SZOFFTYPE)sq;
-        else
-            Lf->sz = (SZOFFTYPE)(rq + sq);
-        Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
-#else  /* !defined(HASTCPTPIQ) && !defined(HASTCPTPIW) */
-    Lf->off_def = 1;
+    if (Lf->access == 'r')
+        Lf->sz = (SZOFFTYPE)rq;
+    else if (Lf->access == 'w')
+        Lf->sz = (SZOFFTYPE)sq;
+    else
+        Lf->sz = (SZOFFTYPE)(rq + sq);
+    Lf->sz_def = 1;
 #endif /* defined(HASTCPTPIQ) || defined(HASTCPTPIW) */
 }
 

--- a/lib/dialects/uw/dfile.c
+++ b/lib/dialects/uw/dfile.c
@@ -90,22 +90,14 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         /*
          * Save file structure values.
          */
-        if (Fsv & FSV_CT) {
-            Lf->fct = (long)f.f_count;
-            Lf->fsv |= FSV_CT;
-        }
-        if (Fsv & FSV_FA) {
-            Lf->fsa = fp;
-            Lf->fsv |= FSV_FA;
-        }
-        if (Fsv & FSV_FG) {
-            Lf->ffg = (long)f.f_flag;
-            Lf->fsv |= FSV_FG;
-        }
-        if (Fsv & FSV_NI) {
-            Lf->fna = (KA_T)f.f_vnode;
-            Lf->fsv |= FSV_NI;
-        }
+        Lf->fct = (long)f.f_count;
+        Lf->fsv |= FSV_CT;
+        Lf->fsa = fp;
+        Lf->fsv |= FSV_FA;
+        Lf->ffg = (long)f.f_flag;
+        Lf->fsv |= FSV_FG;
+        Lf->fna = (KA_T)f.f_vnode;
+        Lf->fsv |= FSV_NI;
 #endif /* defined(HASFSTRUCT) */
 
         /*

--- a/lib/dialects/uw/dfile.c
+++ b/lib/dialects/uw/dfile.c
@@ -80,11 +80,11 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
          * Construct access code.
          */
         if ((flag = (f.f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
 
 #if defined(HASFSTRUCT)
         /*

--- a/lib/dialects/uw/dnode.c
+++ b/lib/dialects/uw/dnode.c
@@ -1155,46 +1155,39 @@ get_lock_state:
     /*
      * Obtain the file size.
      */
-    if (Foffset)
-        Lf->off_def = 1;
-    else {
-        switch (Ntype) {
+    switch (Ntype) {
 
-        case N_FIFO:
-        case N_STREAM:
-            if (!Fsize)
-                Lf->off_def = 1;
-            break;
-        case N_NFS:
-            Lf->sz = (SZOFFTYPE)r.r_attr.va_size;
-            Lf->sz_def = sd;
-            break;
+    case N_FIFO:
+    case N_STREAM:
+        break;
+    case N_NFS:
+        Lf->sz = (SZOFFTYPE)r.r_attr.va_size;
+        Lf->sz_def = sd;
+        break;
 
 #if defined(HASPROCFS)
-        case N_PROC:
+    case N_PROC:
 
 #    if UNIXWAREV < 70103
-            Lf->sz = (SZOFFTYPE)i.size;
-            Lf->sz_def = sd;
+        Lf->sz = (SZOFFTYPE)i.size;
+        Lf->sz_def = sd;
 #    else  /* UNIXWAREV>=70103 */
-            Lf->sz = (SZOFFTYPE)0;
-            Lf->sz_def = 0;
+        Lf->sz = (SZOFFTYPE)0;
+        Lf->sz_def = 0;
 #    endif /* UNIXWAREV<70103 */
 
-            break;
+        break;
 #endif /* defined(HASPROCFS) */
 
-        case N_CFS:
-        case N_REGLR:
-            if ((type == VREG) || (type == VDIR)) {
-                if (!ni) {
-                    Lf->sz = (SZOFFTYPE)i.size;
-                    Lf->sz_def = (Ntype == N_CFS) ? i.size_def : sd;
-                }
-            } else if (((type == VBLK) || (type == VCHR)) && !Fsize)
-                Lf->off_def = 1;
-            break;
+    case N_CFS:
+    case N_REGLR:
+        if ((type == VREG) || (type == VDIR)) {
+            if (!ni) {
+                Lf->sz = (SZOFFTYPE)i.size;
+                Lf->sz_def = (Ntype == N_CFS) ? i.size_def : sd;
+            }
         }
+        break;
     }
     /*
      * Record link count.

--- a/lib/dialects/uw/dnode.c
+++ b/lib/dialects/uw/dnode.c
@@ -1192,32 +1192,30 @@ get_lock_state:
     /*
      * Record link count.
      */
-    if (Fnlink) {
-        switch (Ntype) {
-        case N_FIFO:
-            Lf->nlink = (long)f.fn_open;
-            Lf->nlink_def = 1;
-            break;
-        case N_NFS:
-            Lf->nlink = (long)r.r_attr.va_nlink;
-            Lf->nlink_def = 1;
-            break;
+    switch (Ntype) {
+    case N_FIFO:
+        Lf->nlink = (long)f.fn_open;
+        Lf->nlink_def = 1;
+        break;
+    case N_NFS:
+        Lf->nlink = (long)r.r_attr.va_nlink;
+        Lf->nlink_def = 1;
+        break;
 
 #if defined(HASPROCFS)
-        case N_PROC:
+    case N_PROC:
 #endif /* defined(HASPROCFS) */
 
-        case N_CFS:
-        case N_REGLR:
-            if (!ni) {
-                Lf->nlink = (long)i.nlink;
-                Lf->nlink_def = i.nlink_def;
-            }
-            break;
+    case N_CFS:
+    case N_REGLR:
+        if (!ni) {
+            Lf->nlink = (long)i.nlink;
+            Lf->nlink_def = i.nlink_def;
         }
-        if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
-            Lf->sf |= SELNLINK;
+        break;
     }
+    if (Nlink && Lf->nlink_def && (Lf->nlink < Nlink))
+        Lf->sf |= SELNLINK;
     /*
      * Record an NFS file selection.
      */

--- a/lib/dialects/uw/dproc.c
+++ b/lib/dialects/uw/dproc.c
@@ -194,8 +194,7 @@ void gather_proc_info() {
                 if (Lf->sf) {
 
 #if defined(HASFSTRUCT)
-                    if (Fsv & FSV_FG)
-                        Lf->pof = (long)f->fd_flag;
+                    Lf->pof = (long)f->fd_flag;
 #endif /* defined(HASFSTRUCT) */
 
                     link_lfile();

--- a/lib/dialects/uw/dsock.c
+++ b/lib/dialects/uw/dsock.c
@@ -838,22 +838,18 @@ struct queue *q;                     /* queue at end of stream */
      * Save size information.
      */
     if (ts) {
-        if (Fsize) {
 
 #if UNIXWAREV >= 70000
 #    define t_outqsize t_qsize
 #endif /* UNIXWAREV>=70000 */
 
-            if (Lf->access == 'r')
-                Lf->sz = (SZOFFTYPE)t.t_iqsize;
-            else if (Lf->access == 'w')
-                Lf->sz = (SZOFFTYPE)t.t_outqsize;
-            else
-                Lf->sz = (SZOFFTYPE)(t.t_iqsize + t.t_outqsize);
-            Lf->sz_def = 1;
-
-        } else
-            Lf->off_def = 1;
+        if (Lf->access == 'r')
+            Lf->sz = (SZOFFTYPE)t.t_iqsize;
+        else if (Lf->access == 'w')
+            Lf->sz = (SZOFFTYPE)t.t_outqsize;
+        else
+            Lf->sz = (SZOFFTYPE)(t.t_iqsize + t.t_outqsize);
+        Lf->sz_def = 1;
 
 #if defined(HASTCPTPIQ)
         Lf->lts.rq = (unsigned long)t.t_iqsize;
@@ -883,11 +879,10 @@ struct queue *q;                     /* queue at end of stream */
         Lf->lts.topt = (unsigned int)t.t_flags;
 #endif /* defined(HASTCPOPT) */
 
-    } else if (Fsize) {
+    } else {
         Lf->sz = (SZOFFTYPE)q->q_count;
         Lf->sz_def = 1;
-    } else
-        Lf->off_def = 1;
+    }
     enter_nm(Namech);
     return;
 }
@@ -963,8 +958,6 @@ KA_T na;         /* kernel vnode address */
     if (Funix)
         Lf->sf |= SELUNX;
     Lf->is_stream = 0;
-    if (!Fsize)
-        Lf->off_def = 1;
     enter_dev_ch(print_kptr(sa, (char *)NULL, 0));
     /*
      * Process the local address.

--- a/lib/dialects/uw/dsock.c
+++ b/lib/dialects/uw/dsock.c
@@ -843,9 +843,9 @@ struct queue *q;                     /* queue at end of stream */
 #    define t_outqsize t_qsize
 #endif /* UNIXWAREV>=70000 */
 
-        if (Lf->access == 'r')
+        if (Lf->access == LSOF_FILE_ACCESS_READ)
             Lf->sz = (SZOFFTYPE)t.t_iqsize;
-        else if (Lf->access == 'w')
+        else if (Lf->access == LSOF_FILE_ACCESS_WRITE)
             Lf->sz = (SZOFFTYPE)t.t_outqsize;
         else
             Lf->sz = (SZOFFTYPE)(t.t_iqsize + t.t_outqsize);

--- a/lib/prfp.c
+++ b/lib/prfp.c
@@ -77,11 +77,11 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
          * Construct access code.
          */
         if ((flag = (f.f_flag & (FREAD | FWRITE))) == FREAD)
-            Lf->access = 'r';
+            Lf->access = LSOF_FILE_ACCESS_READ;
         else if (flag == FWRITE)
-            Lf->access = 'w';
+            Lf->access = LSOF_FILE_ACCESS_WRITE;
         else if (flag == (FREAD | FWRITE))
-            Lf->access = 'u';
+            Lf->access = LSOF_FILE_ACCESS_READ_WRITE;
 
 #    if defined(HASFSTRUCT)
             /*

--- a/lib/prfp.c
+++ b/lib/prfp.c
@@ -89,31 +89,23 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
              */
 
 #        if !defined(HASNOFSCOUNT)
-        if (Fsv & FSV_CT) {
-            Lf->fct = (long)f.f_count;
-            Lf->fsv |= FSV_CT;
-        }
+        Lf->fct = (long)f.f_count;
+        Lf->fsv |= FSV_CT;
 #        endif /* !defined(HASNOFSCOUNT) */
 
 #        if !defined(HASNOFSADDR)
-        if (Fsv & FSV_FA) {
-            Lf->fsa = fp;
-            Lf->fsv |= FSV_FA;
-        }
+        Lf->fsa = fp;
+        Lf->fsv |= FSV_FA;
 #        endif /* !defined(HASNOFSADDR) */
 
 #        if !defined(HASNOFSFLAGS)
-        if (Fsv & FSV_FG) {
-            Lf->ffg = (long)f.f_flag;
-            Lf->fsv |= FSV_FG;
-        }
+        Lf->ffg = (long)f.f_flag;
+        Lf->fsv |= FSV_FG;
 #        endif /* !defined(HASNOFSFLAGS) */
 
 #        if !defined(HASNOFSNADDR)
-        if (Fsv & FSV_NI) {
-            Lf->fna = (KA_T)f.f_data;
-            Lf->fsv |= FSV_NI;
-        }
+        Lf->fna = (KA_T)f.f_data;
+        Lf->fsv |= FSV_NI;
 #        endif /* !defined(HASNOFSNADDR) */
 #    endif     /* defined(HASFSTRUCT) */
 

--- a/lib/prfp.c
+++ b/lib/prfp.c
@@ -70,6 +70,7 @@ void process_file(fp) KA_T fp; /* kernel file structure address */
         return;
     }
     Lf->off = (SZOFFTYPE)f.f_offset;
+    Lf->off_def = 1;
     if (f.f_count) {
 
         /*

--- a/lib/print.c
+++ b/lib/print.c
@@ -36,9 +36,9 @@
  */
 
 /*
- * print_access() - print enum lsof_file_access_mode
+ * access_to_char() - convert enum lsof_file_access_mode to char
  */
-char print_access(enum lsof_file_access_mode access) {
+char access_to_char(enum lsof_file_access_mode access) {
     switch (access) {
     default:
     case LSOF_FILE_ACCESS_NONE:

--- a/lib/print.c
+++ b/lib/print.c
@@ -1,0 +1,53 @@
+/*
+ * print.c - common print support functions for lsof
+ */
+
+/*
+ * Copyright 1994 Purdue Research Foundation, West Lafayette, Indiana
+ * 47907.  All rights reserved.
+ *
+ * Written by Victor A. Abell
+ *
+ * This software is not subject to any license of the American Telephone
+ * and Telegraph Company or the Regents of the University of California.
+ *
+ * Permission is granted to anyone to use this software for any purpose on
+ * any computer system, and to alter it and redistribute it freely, subject
+ * to the following restrictions:
+ *
+ * 1. Neither the authors nor Purdue University are responsible for any
+ *    consequences of the use of this software.
+ *
+ * 2. The origin of this software must not be misrepresented, either by
+ *    explicit claim or by omission.  Credit to the authors and Purdue
+ *    University must appear in documentation and sources.
+ *
+ * 3. Altered versions must be plainly marked as such, and must not be
+ *    misrepresented as being the original software.
+ *
+ * 4. This notice may not be removed or altered.
+ */
+
+#include "common.h"
+#include "lsof.h"
+
+/*
+ * Local definitions, structures and function prototypes
+ */
+
+/*
+ * print_access() - print enum lsof_file_access_mode
+ */
+char print_access(enum lsof_file_access_mode access) {
+    switch (access) {
+    default:
+    case LSOF_FILE_ACCESS_NONE:
+        return ' ';
+    case LSOF_FILE_ACCESS_READ:
+        return 'r';
+    case LSOF_FILE_ACCESS_WRITE:
+        return 'w';
+    case LSOF_FILE_ACCESS_READ_WRITE:
+        return 'u';
+    }
+}

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -29,6 +29,7 @@
  */
 
 #include "common.h"
+#include "lsof.h"
 
 #if defined(HASEPTOPTS)
 _PROTOTYPE(static void prt_pinfo, (pxinfo_t * pp, int ps));
@@ -140,7 +141,8 @@ int num;                            /* file descriptor number -- -1 if
     /*
      * Initialize the structure.
      */
-    Lf->access = Lf->lock = ' ';
+    Lf->access = LSOF_FILE_ACCESS_NONE;
+    Lf->lock = ' ';
     Lf->dev_def = Lf->inp_ty = Lf->is_com = Lf->is_nfs = Lf->is_stream =
         Lf->lmi_srch = Lf->nlink_def = Lf->off_def = Lf->sz_def = Lf->rdev_def =
             (unsigned char)0;
@@ -1044,7 +1046,7 @@ int ps;                                     /* processing status:
             break;
     }
     (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim, ep->cmd,
-               &ef->fd[i], ef->access);
+               &ef->fd[i], print_access(ef->access));
     (void)add_nma(nma, strlen(nma));
     if (ps) {
 
@@ -1143,7 +1145,7 @@ int ps;                                         /* processing status:
             break;
     }
     (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim, ep->cmd,
-               &ef->fd[i], ef->access);
+               &ef->fd[i], print_access(ef->access));
     (void)add_nma(nma, strlen(nma));
     if (ps) {
 
@@ -1242,7 +1244,7 @@ int ps;                                         /* processing status:
             break;
     }
     (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim, ep->cmd,
-               &ef->fd[i], ef->access);
+               &ef->fd[i], print_access(ef->access));
     (void)add_nma(nma, strlen(nma));
     if (ps) {
 
@@ -1446,7 +1448,8 @@ int print_proc() {
          * Print selected fields.
          */
         if (FieldSel[LSOF_FIX_ACCESS].st) {
-            (void)printf("%c%c%c", LSOF_FID_ACCESS, Lf->access, Terminator);
+            (void)printf("%c%c%c", LSOF_FID_ACCESS, print_access(Lf->access),
+                         Terminator);
             lc++;
         }
         if (FieldSel[LSOF_FIX_LOCK].st) {
@@ -1689,10 +1692,10 @@ int ps;       /* processing status:
     if (prt_edev) {
         (void)snpf(nma, sizeof(nma) - 1, "->/dev/pts/%d %d,%.*s,%s%c",
                    Lf->tty_index, ep->pid, CmdLim, ep->cmd, &ef->fd[i],
-                   ef->access);
+                   print_access(ef->access));
     } else {
         (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim,
-                   ep->cmd, &ef->fd[i], ef->access);
+                   ep->cmd, &ef->fd[i], print_access(ef->access));
     }
     (void)add_nma(nma, strlen(nma));
     if (ps) {

--- a/lib/proc.c
+++ b/lib/proc.c
@@ -1046,7 +1046,7 @@ int ps;                                     /* processing status:
             break;
     }
     (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim, ep->cmd,
-               &ef->fd[i], print_access(ef->access));
+               &ef->fd[i], access_to_char(ef->access));
     (void)add_nma(nma, strlen(nma));
     if (ps) {
 
@@ -1145,7 +1145,7 @@ int ps;                                         /* processing status:
             break;
     }
     (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim, ep->cmd,
-               &ef->fd[i], print_access(ef->access));
+               &ef->fd[i], access_to_char(ef->access));
     (void)add_nma(nma, strlen(nma));
     if (ps) {
 
@@ -1244,7 +1244,7 @@ int ps;                                         /* processing status:
             break;
     }
     (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim, ep->cmd,
-               &ef->fd[i], print_access(ef->access));
+               &ef->fd[i], access_to_char(ef->access));
     (void)add_nma(nma, strlen(nma));
     if (ps) {
 
@@ -1448,7 +1448,7 @@ int print_proc() {
          * Print selected fields.
          */
         if (FieldSel[LSOF_FIX_ACCESS].st) {
-            (void)printf("%c%c%c", LSOF_FID_ACCESS, print_access(Lf->access),
+            (void)printf("%c%c%c", LSOF_FID_ACCESS, access_to_char(Lf->access),
                          Terminator);
             lc++;
         }
@@ -1692,10 +1692,10 @@ int ps;       /* processing status:
     if (prt_edev) {
         (void)snpf(nma, sizeof(nma) - 1, "->/dev/pts/%d %d,%.*s,%s%c",
                    Lf->tty_index, ep->pid, CmdLim, ep->cmd, &ef->fd[i],
-                   print_access(ef->access));
+                   access_to_char(ef->access));
     } else {
         (void)snpf(nma, sizeof(nma) - 1, "%d,%.*s,%s%c", ep->pid, CmdLim,
-                   ep->cmd, &ef->fd[i], print_access(ef->access));
+                   ep->cmd, &ef->fd[i], access_to_char(ef->access));
     }
     (void)add_nma(nma, strlen(nma));
     if (ps) {

--- a/lib/proto.h
+++ b/lib/proto.h
@@ -197,6 +197,7 @@ _PROTOTYPE(extern void printrawaddr, (struct sockaddr * sa));
 _PROTOTYPE(extern void print_tcptpi, (int nl));
 _PROTOTYPE(extern char *printuid, (UID_ARG uid, int *ty));
 _PROTOTYPE(extern void printunkaf, (int fam, int ty));
+_PROTOTYPE(extern char print_access, (enum lsof_file_access_mode access));
 _PROTOTYPE(extern char *printsockty, (int ty));
 _PROTOTYPE(extern void process_file, (KA_T fp));
 _PROTOTYPE(extern void process_node, (KA_T f));

--- a/lib/proto.h
+++ b/lib/proto.h
@@ -197,7 +197,7 @@ _PROTOTYPE(extern void printrawaddr, (struct sockaddr * sa));
 _PROTOTYPE(extern void print_tcptpi, (int nl));
 _PROTOTYPE(extern char *printuid, (UID_ARG uid, int *ty));
 _PROTOTYPE(extern void printunkaf, (int fam, int ty));
-_PROTOTYPE(extern char print_access, (enum lsof_file_access_mode access));
+_PROTOTYPE(extern char access_to_char, (enum lsof_file_access_mode access));
 _PROTOTYPE(extern char *printsockty, (int ty));
 _PROTOTYPE(extern void process_file, (KA_T fp));
 _PROTOTYPE(extern void process_node, (KA_T f));

--- a/src/print.c
+++ b/src/print.c
@@ -644,6 +644,7 @@ void print_file() {
     char *cp = (char *)NULL;
     dev_t dev;
     int devs, len;
+    char access;
 
     if (PrPass && !Hdr) {
 
@@ -845,19 +846,20 @@ void print_file() {
     /*
      * Size or print the file descriptor, access mode and lock status.
      */
+    access = print_access(Lf->access);
     if (!PrPass) {
         (void)snpf(buf, sizeof(buf), "%s%c%c", Lf->fd,
-                   (Lf->lock == ' ')     ? Lf->access
-                   : (Lf->access == ' ') ? '-'
-                                         : Lf->access,
+                   (Lf->lock == ' ') ? access
+                   : (access == ' ') ? '-'
+                                     : access,
                    Lf->lock);
         if ((len = strlen(buf)) > FdColW)
             FdColW = len;
     } else
         (void)printf(" %*.*s%c%c", FdColW - 2, FdColW - 2, Lf->fd,
-                     (Lf->lock == ' ')     ? Lf->access
-                     : (Lf->access == ' ') ? '-'
-                                           : Lf->access,
+                     (Lf->lock == ' ') ? access
+                     : (access == ' ') ? '-'
+                                       : access,
                      Lf->lock);
     /*
      * Size or print the type.

--- a/src/print.c
+++ b/src/print.c
@@ -977,14 +977,14 @@ void print_file() {
      * Size or print the size or offset.
      */
     if (!PrPass) {
-        if (Lf->sz_def) {
+        if (!Foffset && Lf->sz_def) {
             if (Fhuman) {
                 len = human_readable_size(Lf->sz, 0, 0);
             } else {
                 (void)snpf(buf, sizeof(buf), SzOffFmt_d, Lf->sz);
                 len = strlen(buf);
             }
-        } else if (Lf->off_def) {
+        } else if (!Fsize && Lf->off_def) {
 
 #if defined(HASPRINTOFF)
             cp = HASPRINTOFF(Lf, 0);
@@ -1011,7 +1011,7 @@ void print_file() {
             SzOffColW = len;
     } else {
         putchar(' ');
-        if (Lf->sz_def) {
+        if (!Foffset && Lf->sz_def) {
             if (Fhuman) {
                 human_readable_size(Lf->sz, 1, SzOffColW);
             } else {
@@ -1019,7 +1019,7 @@ void print_file() {
                 len = strlen(buf);
                 (void)printf(SzOffFmt_dv, SzOffColW, Lf->sz);
             }
-        } else if (Lf->off_def) {
+        } else if (!Fsize && Lf->off_def) {
 
 #if defined(HASPRINTOFF)
             cp = HASPRINTOFF(Lf, 0);

--- a/src/print.c
+++ b/src/print.c
@@ -846,7 +846,7 @@ void print_file() {
     /*
      * Size or print the file descriptor, access mode and lock status.
      */
-    access = print_access(Lf->access);
+    access = access_to_char(Lf->access);
     if (!PrPass) {
         (void)snpf(buf, sizeof(buf), "%s%c%c", Lf->fd,
                    (Lf->lock == ' ') ? access


### PR DESCRIPTION
Part 3 of #279: 

1. do not check command flags in dialect-specific code, always save the information into `Lf`.
2. Convert `Lf->access` to enum