### PR TITLE
Add configuration flag for enabling liblsof (#299)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,13 @@
 # liblsof
-lib_LTLIBRARIES = liblsof.la
-
 liblsof_la_SOURCES = lib/ckkv.c lib/cvfs.c lib/dvch.c lib/fino.c lib/isfn.c lib/lkud.c lib/lsof.c lib/misc.c lib/node.c lib/pdvn.c lib/prfp.c lib/print.c lib/proc.c lib/ptti.c lib/rdev.c lib/rnmt.c lib/rmnt.c lib/rnam.c lib/rnch.c lib/rnmh.c
 liblsof_la_SOURCES += lib/common.h lib/proto.h lib/hash.h
+
+if INSTALL_LIBLSOF
+lib_LTLIBRARIES = liblsof.la
 include_HEADERS = include/lsof.h include/lsof_fields.h
+else
+noinst_LTLIBRARIES = liblsof.la
+endif
 
 # Hide internal functions
 AM_CFLAGS = -fvisibility=hidden

--- a/configure.ac
+++ b/configure.ac
@@ -253,6 +253,11 @@ AC_SUBST([LSOF_DIALECT_DIR])
 AC_DEFINE([API_EXPORT], [__attribute__ ((visibility ("default")))],
 	[Set visibility to default for exported API functions.])
 
+# --enable-liblsof to install liblsof
+AC_ARG_ENABLE(liblsof, AS_HELP_STRING([--enable-liblsof],
+	[build and install liblsof @<:@default=no@:>@]), [], [enable_liblsof=no])
+AM_CONDITIONAL([INSTALL_LIBLSOF], [test "x$enable_liblsof" = xyes])
+
 # --enable-security to define HASSECURITY
 AC_ARG_ENABLE(security, AS_HELP_STRING([--enable-security],
 	[allow only the root user to list all open files @<:@default=no@:>@]), [], [enable_security=no])


### PR DESCRIPTION
Since liblsof is still in alpha stage, therefore I've set the flag to disabled by default..

Fixes #299