### PR TITLE
adapt to kernel 6.9 pidfd changes

### DIFF
--- a/lib/dialects/linux/tests/case-20-inet6-ffffffff-handling.bash
+++ b/lib/dialects/linux/tests/case-20-inet6-ffffffff-handling.bash
@@ -30,7 +30,7 @@ expectation="n[${v6addr}]:$port"
 result=1
 if "${lsof}" -p "${pid}" -a -d fd -P -n -F n \
     | tee -a "${report}" \
-    | fgrep -q "$expectation"; then
+    | grep -Fq "$expectation"; then
     result=0
 fi
 

--- a/lib/dialects/linux/tests/case-20-pidfd-pid.bash
+++ b/lib/dialects/linux/tests/case-20-pidfd-pid.bash
@@ -11,7 +11,7 @@ $TARGET | (
         exit 77
     fi
     line=$($lsof -p $pid -a -d $fd -F pfn| tr '\n' ' ')
-    if ! fgrep -q "p${pid} f${fd} n[pidfd:$pid]" <<<"$line"; then
+    if ! grep -Fq "p${pid} f${fd} n[pidfd:$pid]" <<<"$line"; then
 	$lsof -p $pid -a -d $fd -F pfn
 	echo
 	echo $line

--- a/lib/dialects/linux/tests/case-20-pidfd-pid.bash
+++ b/lib/dialects/linux/tests/case-20-pidfd-pid.bash
@@ -11,7 +11,8 @@ $TARGET | (
         exit 77
     fi
     line=$($lsof -p $pid -a -d $fd -F pfn| tr '\n' ' ')
-    if ! grep -Fq "p${pid} f${fd} n[pidfd:$pid]" <<<"$line"; then
+    if ! grep -Fq "p${pid} f${fd} n[pidfd:$pid]" <<<"$line" &&
+       ! grep -Fq "p${pid} f${fd} npidfd" <<<"$line"; then
 	$lsof -p $pid -a -d $fd -F pfn
 	echo
 	echo $line


### PR DESCRIPTION
`lsof -F n` used to output `[pidfd:899]`, now it says simple `pidfd`. Adapt to that in tests.
