### PR TITLE
lib/misc.c: fix build against -std=c23 (`void (*)()`) changed the mea…

### DIFF
--- a/lib/misc.c
+++ b/lib/misc.c
@@ -56,7 +56,7 @@ static void closePipes(void);
 static int dolstat(char *path, char *buf, int len);
 static int dostat(char *path, char *buf, int len);
 static int doreadlink(char *path, char *buf, int len);
-static int doinchild(struct lsof_context *ctx, int (*fn)(), char *fp,
+static int doinchild(struct lsof_context *ctx, int (*fn)(char *path, char *buf, int len), char *fp,
                      char *rbuf, int rbln);
 
 #if defined(HASINTSIGNAL)
@@ -259,7 +259,7 @@ void closefrom_shim(struct lsof_context *ctx, int low) {
  */
 
 static int doinchild(struct lsof_context *ctx,
-                     int (*fn)(), /* function to perform */
+                     int (*fn)(char *path, char *buf, int len), /* function to perform */
                      char *fp,    /* function parameter */
                      char *rbuf,  /* response buffer */
                      int rbln)    /* response buffer length */
@@ -321,7 +321,7 @@ static int doinchild(struct lsof_context *ctx,
                      */
                     struct stat _;
                 } r;
-                int (*r_fn)();
+                int (*r_fn)(char *path, char *buf, int len);
                 /*
                  * Close sufficient open file descriptors except Pipes[0] and
                  * Pipes[3].


### PR DESCRIPTION
…ning)

gcc-15 switched to -std=c23 by default:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=55e3bd376b2214e200fa76d12b67ff259b06c212

As a result `lsof` fails the build as:

     misc.c:390:26: error: too many arguments to function 'r_fn'
       390 |                     rv = r_fn(r_arg, r.r_rbuf, r_rbln);
           |                          ^~~~

Before C23 `int (*)()` meant any function that returns `int`. In `C23` if means only `int (*)(void)`. But `lsof` alwaus uses `int (*)(char *path, char *buf, int len)` in that place. Switched to explicit function type instead.