### PR TITLE
Fix null pointer exception

### DIFF
--- a/lib/dialects/linux/dproc.c
+++ b/lib/dialects/linux/dproc.c
@@ -1184,6 +1184,7 @@ static int process_id(struct lsof_context *ctx, /* context */
             continue;
         (void)make_proc_path(ctx, dpath, i, &path, &pathl, fp->d_name);
         (void)alloc_lfile(ctx, LSOF_FD_NUMERIC, fd);
+        efs = 0;
         if (getlinksrc(path, pbuf, sizeof(pbuf), &rest) < 1) {
             zeromem((char *)&sb, sizeof(sb));
             lnk = ss = 0;


### PR DESCRIPTION
The logic in process_id() requires a reset of
the efs variable on every iteration through the
while ((fp = readdir(fdp)) loop.

Failure to do that can land us in a situation
where efs=1 from a previous iteration and
pn=1 from the current iteration.

This fixes issue 335 ( lsof SIGSEGV )  https://github.com/lsof-org/lsof/issues/335