### PR TITLE
Issue 326: Fix AIX dialect to work with context refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ lib/dialects/netbsd/include
 /dmnt.c
 /dnode.c
 /dnode1.c
+/dnode2.c
 /dproc.c
 /dproto.h
 /dsock.c

--- a/lib/common.h
+++ b/lib/common.h
@@ -35,11 +35,11 @@
 #if !defined(COMMON_H)
 #    define COMMON_H 1
 
-#    include "lsof.h"
 #    if defined(AUTOTOOLS)
 #        include "autotools.h"
 #    endif
 #    include "machine.h"
+#    include "lsof.h"
 
 #    if !defined(FSV_DEFAULT)
 #        define FSV_DEFAULT 0

--- a/lib/dialects/aix/ddev.c
+++ b/lib/dialects/aix/ddev.c
@@ -634,7 +634,7 @@ int rw_clone_sect(struct lsof_context *ctx, /* context */
         for (c = Clone, n = 0; c; c = c->next, n++)
             ;
         (void)snpf(buf, sizeof(buf), "clone section: %d\n", n);
-        if (wr2DCfd(buf, &DCcksum))
+        if (wr2DCfd(ctx, buf, &DCcksum))
             return (1);
         /*
          * Write the clone section lines.
@@ -642,7 +642,7 @@ int rw_clone_sect(struct lsof_context *ctx, /* context */
         for (c = Clone; c; c = c->next) {
             (void)snpf(buf, sizeof(buf), "%x %ld %s\n", c->cd.rdev,
                        (long)c->cd.inode, c->cd.name);
-            if (wr2DCfd(buf, &DCcksum))
+            if (wr2DCfd(ctx, buf, &DCcksum))
                 return (1);
         }
         return (0);

--- a/lib/dialects/aix/dlsof.h
+++ b/lib/dialects/aix/dlsof.h
@@ -306,9 +306,6 @@ struct clone {
     struct l_dev cd;    /* device, inode, name, verify status */
     struct clone *next; /* next entry */
 };
-extern struct clone *Clone;
-extern int CloneMaj;
-extern int ClonePtc;
 #    endif /* AIXV>=4140 */
 
 /*
@@ -339,7 +336,6 @@ struct l_vfs {
     int vmt_gfstype;    /* vmount gfs type */
     struct l_vfs *next; /* forward link */
 };
-extern struct l_vfs *Lvfs;
 
 /*
  * Local mount information
@@ -363,7 +359,6 @@ struct mounts {
 
     struct mounts *next; /* forward link */
 };
-extern struct mounts *Mtab;
 
 /*
  * Search file information
@@ -396,12 +391,7 @@ extern struct nlist AFSnl[]; /* AFS kernel symbol name list table */
 extern char *AFSApath; /* alternate AFS name list path (from -a) */
 #        endif         /* defined(HASAOPT) */
 
-extern KA_T AFSVfsp; /* AFS struct vfs kernel pointer */
 #    endif           /* defined(HAS_AFS) */
-
-extern int Kd;
-extern int Km;
-extern struct nlist Nl[];
 
 #    if defined(TCPSTATES) && AIXV <= 3250
 /*
@@ -427,6 +417,37 @@ static char *tcpstates[] = {"CLOSED",     "LISTEN",      "SYN_SENT",
                         * in libc.so */
 #    endif             /* AIXA>1 */
 
-struct lsof_context_dialect {};
+struct lsof_context_dialect {
+    int kd;               /* /dev/kmem file descriptor */
+    int km;               /* /dev/mem file descriptor */
+    struct l_vfs *lvfs;   /* local vfs structure table */
+    struct mounts *mtab;  /* local mount table */
+
+#if AIXV >= 4140
+    struct clone *clone;  /* local clone information */
+    int clone_maj;        /* clone major device number */
+    int clone_ptc;        /* /dev/ptc minor device number */
+#endif /* AIXV>=4140 */
+
+#if defined(HAS_AFS)
+    KA_T afs_vfsp;        /* AFS vfs struct kernel pointer */
+#endif /* defined(HAS_AFS) */
+};
+
+/* Convenience macros to access dialect-specific context */
+#define Kd (ctx->dialect.kd)
+#define Km (ctx->dialect.km)
+#define Lvfs (ctx->dialect.lvfs)
+#define Mtab (ctx->dialect.mtab)
+
+#if AIXV >= 4140
+#define Clone (ctx->dialect.clone)
+#define CloneMaj (ctx->dialect.clone_maj)
+#define ClonePtc (ctx->dialect.clone_ptc)
+#endif /* AIXV>=4140 */
+
+#if defined(HAS_AFS)
+#define AFSVfsp (ctx->dialect.afs_vfsp)
+#endif /* defined(HAS_AFS) */
 
 #endif /* AIX_LSOF_H */

--- a/lib/dialects/aix/dnode.c
+++ b/lib/dialects/aix/dnode.c
@@ -495,7 +495,7 @@ void process_node(struct lsof_context *ctx, /* context */
                                  */
                                 Namech[0] = '\0';
                                 Lf->inp_ty = 0;
-                                (void)process_socket(ka);
+                                (void)process_socket(ctx, ka);
                                 return;
                             }
                             /*

--- a/lib/dialects/aix/dproto.h
+++ b/lib/dialects/aix/dproto.h
@@ -50,7 +50,7 @@ extern int readj2lino(struct lsof_context *ctx, struct gnode *ga, struct l_ino *
 
 extern int getchan(char *p);
 extern int is_file_named(struct lsof_context *ctx, char *p, enum vtype ty, chan_t ch, int ic);
-extern char isglocked(struct lsof_context *ctx, struct gnode *ga);
+extern enum lsof_lock_mode isglocked(struct lsof_context *ctx, struct gnode *ga);
 extern int readlino(struct lsof_context *ctx, struct gnode *ga, struct l_ino *li);
 extern struct l_vfs *readvfs(struct lsof_context *ctx, struct vnode *vn);
 

--- a/lib/dialects/aix/dstore.c
+++ b/lib/dialects/aix/dstore.c
@@ -49,30 +49,7 @@ struct nlist AFSnl[] = {
 char *AFSApath = (char *)NULL; /* alternate AFS name list path
                                 * (from -a) */
 #    endif                     /* defined(HASAOPT) */
-
-KA_T AFSVfsp = (KA_T)NULL; /* AFS vfs struct kernel address */
 #endif                     /* defined(HAS_AFS) */
-
-#if AIXV >= 4140
-struct clone *Clone = (struct clone *)NULL;
-/* local clone information */
-int CloneMaj = -1; /* clone major device number */
-int ClonePtc = -1; /* /dev/ptc minor device number */
-#endif             /* AIXV>=4140 */
-
-int Kd = -1;               /* /dev/kmem file descriptor */
-struct l_vfs *Lvfs = NULL; /* local vfs structure table */
-int Km = -1;               /* /dev/mem file descriptor */
-
-struct nlist Nl[] = {
-
-#if AIXV < 4100
-    {"u", 0, 0, 0, 0, 0},
-#else  /* AIXV>=4100 */
-    {"__ublock", 0, 0, 0, 0, 0},
-#endif /* AIXV<4100 */
-
-};
 
 #if defined(HASFSTRUCT)
 /*

--- a/lib/dialects/aix/machine.h
+++ b/lib/dialects/aix/machine.h
@@ -65,7 +65,19 @@
 #        include <sys/types.h>
 
 #        if AIXA > 0
+/*
+ * Work around conflict between GCC fixed headers and AIX system headers.
+ * The global 'time' variable in sys/time.h conflicts with the time()
+ * function. We rename it during inclusion.
+ */
+#            if defined(__GNUC__)
+#                include <time.h>
+#                define time aix_global_time_variable
+#            endif
 #            include <sys/resource.h>
+#            if defined(__GNUC__)
+#                undef time
+#            endif
 #        endif /* AIXA>0 */
 
 #        if defined(__GNUC__)
@@ -292,10 +304,12 @@ typedef long long aligned_offset_t __attribute__((aligned(8)));
 
 /*
  * HASNLIST is defined for those dialects that use nlist() to access
- * kernel symbols.  (AIX lsof doesn't use nlist, it uses knlist.)
+ * kernel symbols.  AIX uses knlist() which is similar.
  */
 
-/* #define	HASNLIST	1 */
+#define	HASNLIST	1
+#define NLIST_TYPE	nlist
+#define NL_NAME		n_name
 
 /*
  * HASPIPEFN is defined for those dialects that have a special function to


### PR DESCRIPTION
The AIX driver no longer compiled after the major refactor that moved global variables into a context structure passed to functions. This commit updates the AIX dialect to work with the new architecture. Only tested compilation with "aixgcc" configure target. I don't have access to the legacy AIX compilers.

In addition to the context library changes the include ordering needed to be adjusted to ensure the very first time sys/inttypes.h was included it was with _KERNEL and __KERNEL_64 defined. Without this fix ulong32int64_t was 8 bytes when it actually needs to be 4 bytes because the kernel structs still use 32 bit fields even on 64 bit kernels.

This has been tested in AIX 7.2, AIX 7.3, macOS Tahoe 26.0.1, and Ubuntu 24.04.

Changes:
- Add dialect-specific fields to struct lsof_context_dialect in dlsof.h:
  - kd, km: kernel memory file descriptors
  - lvfs: local vfs structure table
  - mtab: local mount table
  - clone, clone_maj, clone_ptc: clone device information (AIX >= 4.1.4)
  - afs_vfsp: AFS vfs kernel pointer (when HAS_AFS is defined)

- Add convenience macros (Kd, Km, Lvfs, Mtab, Clone, CloneMaj, ClonePtc, AFSVfsp) to access dialect context fields, allowing existing code to work with minimal changes

- Remove global variable declarations from dlsof.h and definitions from dstore.c for variables now in context

- Update initialize() in dproc.c to initialize all dialect context fields

- Update kreadx() function signature to take context parameter and update all call sites in dproc.c

- The isglocked() function returns enum lsof_lock_mode, not char. Update the prototype in dproto.h to match the implementation.

- Fix signal handler lowpgsp() to not take context parameter Signal handlers can only take signal number, so use static context pointer

- Fix machine.h include order issue causing incorrect kernel struct sizes

- Add dnode2.c symlink to .gitignore

All other AIX source files (ddev.c, dfile.c, dnode.c, dnode1.c, dnode2.c, dsock.c) should work without changes due to the convenience macros that transparently access ctx->dialect fields.

This allows the AIX driver to compile with the refactored codebase while maintaining compatibility with the existing code structure.