### PR TITLE
Add AIX platform-specific process_file() with filename capture

### DIFF
--- a/lib/dialects/aix/machine.h
+++ b/lib/dialects/aix/machine.h
@@ -603,7 +603,7 @@ typedef long long aligned_offset_t __attribute__((aligned(8)));
 /* #define	USE_LIB_IS_FILE_NAMED		1	   isfn.c */
 #    define USE_LIB_LKUPDEV 1 /* lkud.c */
 /* #define	USE_LIB_PRINTDEVNAME		1	   pdvn.c */
-#    define USE_LIB_PROCESS_FILE 1 /* prfp.c */
+/* #define	USE_LIB_PROCESS_FILE		1	   prfp.c */
 #    define USE_LIB_PRINT_TCPTPI 1 /* ptti.c */
 /* #define	USE_LIB_READDEV			1	   rdev.c */
 /* #define	USE_LIB_READMNT			1	   rmnt.c */


### PR DESCRIPTION
According to the lsof FAQ it can't obtain path name components from the kernel name caches on AIX. At a minimum I can read the leaf node filename from the file struct so you get more than just the volume mount point and device file.

Changes:
- Added process_file() implementation to lib/dialects/aix/dfile.c
- Disabled USE_LIB_PROCESS_FILE in lib/dialects/aix/machine.h to use
  the dialect-specific implementation
- Filename capture for DTYPE_VNODE files by reading f_fnamep from the
  file structure when the vnode points to a regular file or directory
- Combine leaf filename with filesystem mount point for better context
- Use ellipsis (...) to indicate missing path components
- Add comprehensive documentation explaining AIX's name cache limitation

Example output:
- Before: "/var (/dev/hd9var)"
- After:  "/var/.../error.log" (for /var/logs/app/error.log)

This provides the best possible path information given AIX's kernel
limitations, where no accessible name cache exists for full path
reconstruction.
