### PR TITLE
Update dlsof.h for Solaris NFS rnode4.h issues

### DIFF
--- a/lib/dialects/sun/dlsof.h
+++ b/lib/dialects/sun/dlsof.h
@@ -337,7 +337,9 @@ struct lock_descriptor {
 #    if solaris >= 100000
 #        include <nfs/mount.h>
 #        include <nfs/nfs4.h>
+#        define xvattr_t vattr_t
 #        include <nfs/rnode4.h>
+#        undef xvattr_t
 #    endif /* solaris>=100000 */
 
 #    if solaris >= 100000


### PR DESCRIPTION
Addresses #334 issue on Solaris systems. 

I would normally want a successful repo build before submitting PR. However, following the normal source instructions provided via a repo clone do not give me the ability to make a full build for `lsof` from the `master` branch then. It looks like a `Makefile` issue not including all paths and pre-reqs under Solaris. That is a complete other issue. 

That said, the latest Release builds properly with this fix in place even if the github clone build fails. This alternative is better than providing a "corrected" rnode4.h as outlined in #334 .

I feel I am missing another way to solve this with a more elaborate fix, but due to a lack of time, I am providing this as-is until someone else can evaluate the validity of this "solution." My apologies ahead of time if I did not think further outside of the box and come up with a better solution.

Regards,

-Nic