### PR TITLE
Fix case sensitivity in INSTALL commands

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -6,8 +6,8 @@ Basic Installation
 
    The following shell commands:
 
-     test -f configure || ./bootstrap
-     ./configure
+     test -f Configure || ./bootstrap
+     ./Configure
      make
      make install
 


### PR DESCRIPTION
## fix: correct capitalization of Configure in INSTALL instructions

 Line 9 references `configure`  but the actual script
 is `Configure` (capital C)  Update lines to match the real filename to prevent "No such file or directory" errors.